### PR TITLE
fix(instance_server): default routed_ip_enabled to nil

### DIFF
--- a/scaleway/resource_instance_server.go
+++ b/scaleway/resource_instance_server.go
@@ -367,7 +367,7 @@ func resourceScalewayInstanceServerCreate(ctx context.Context, d *schema.Resourc
 		SecurityGroup:     expandStringPtr(expandZonedID(d.Get("security_group_id")).ID),
 		DynamicIPRequired: scw.BoolPtr(d.Get("enable_dynamic_ip").(bool)),
 		Tags:              expandStrings(d.Get("tags")),
-		RoutedIPEnabled:   expandBoolPtr(d.Get("routed_ip_enabled")),
+		RoutedIPEnabled:   expandBoolPtr(getBool(d, "routed_ip_enabled")),
 	}
 
 	enableIPv6, ok := d.GetOk("enable_ipv6")

--- a/scaleway/testdata/data-source-ipamip-instance-lb.cassette.yaml
+++ b/scaleway/testdata/data-source-ipamip-instance-lb.cassette.yaml
@@ -2,62 +2,27 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips
-    method: POST
-  response:
-    body: '{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":null,"organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "276"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Oct 2023 16:03:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1f218e8e-a246-4fef-aa35-856f5926e8a2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","label":"ubuntu_jammy","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2d830ab7-b11c-435e-a582-f390ef11b1e2","label":"ubuntu_jammy","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"f0d486ff-f178-4941-ad62-8bbda478b53a","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"9467798a-e554-4658-a008-82a868d42a3b","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1179"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:15 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -65,7 +30,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73e080bd-d1c3-48a4-8dd4-4d349600aaf3
+      - 0ab040e1-9b22-49c7-967b-ad257a714941
     status: 200 OK
     code: 200
     duration: ""
@@ -74,59 +39,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/c8f1c1ef-0350-426f-8e79-51b1d44e04b0
-    method: GET
-  response:
-    body: '{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":null,"organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "276"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Oct 2023 16:03:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 64a2ee0c-2275-461d-9f54-2b72b917f147
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38421"
+      - "38183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:15 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -134,9 +66,44 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d602b6bb-0ba6-49af-8fd8-48ea074650d6
+      - 90e3957d-fa80-403f-a83d-1f3580c7482a
       X-Total-Count:
-      - "56"
+      - "61"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","is_ipv6":false}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips
+    method: POST
+  response:
+    body: '{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "287"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3d85bd67-c862-4eda-bc53-082339e83742
     status: 200 OK
     code: 200
     duration: ""
@@ -145,26 +112,59 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/69bad162-3fb1-4469-8f16-70485430ab8a
+    method: GET
+  response:
+    body: '{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "287"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1e36756d-8e77-4985-91ae-88d4d7423806
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4865"
+      - "8882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:15 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -172,36 +172,36 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2988e5a-96e3-4096-a4c8-b00622910911
+      - a098db7a-1909-41a2-9106-b22bbccb0241
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null}'
+    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
     method: POST
   response:
-    body: '{"created_at":"2023-10-24T16:03:15.801850Z","id":"1805549d-ad0b-4ed0-a193-9496fb565d06","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2023-10-24T16:03:15.801850Z"}'
+    body: '{"created_at":"2024-02-22T07:32:02.379740Z","id":"e67ee4ac-8ce7-4a13-9182-54b6be4c8610","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:32:02.379740Z"}'
     headers:
       Content-Length:
-      - "359"
+      - "368"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:15 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -209,7 +209,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48eed84a-3b8e-4cb3-8350-297341c1c6b0
+      - 0aebc687-fb58-42b1-b643-c444cf21016a
     status: 200 OK
     code: 200
     duration: ""
@@ -218,23 +218,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1805549d-ad0b-4ed0-a193-9496fb565d06
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/e67ee4ac-8ce7-4a13-9182-54b6be4c8610
     method: GET
   response:
-    body: '{"created_at":"2023-10-24T16:03:15.801850Z","id":"1805549d-ad0b-4ed0-a193-9496fb565d06","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2023-10-24T16:03:15.801850Z"}'
+    body: '{"created_at":"2024-02-22T07:32:02.379740Z","id":"e67ee4ac-8ce7-4a13-9182-54b6be4c8610","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:32:02.379740Z"}'
     headers:
       Content-Length:
-      - "359"
+      - "368"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:15 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -242,34 +242,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec417927-a9be-4967-9779-83234cb3194b
+      - 936f3634-7d1e-4963-96fb-fcb8b9570ef4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"tf-lb-cool-payne","description":"","ip_id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","assign_flexible_ip":null,"tags":null,"type":"LB-S","ssl_compatibility_level":"ssl_compatibility_level_intermediate"}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-lb-sad-bassi","description":"","ip_id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_ids":null,"tags":null,"type":"LB-S","ssl_compatibility_level":"ssl_compatibility_level_intermediate"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs
     method: POST
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-24T16:03:15.776627544Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:15.776627544Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394172Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:02.656394172Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "865"
+      - "894"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:15 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -277,7 +277,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3ed479b-0283-4192-a279-13d28b0be17a
+      - c4122fe2-dd04-47ee-8af6-b33e27a2097b
     status: 200 OK
     code: 200
     duration: ""
@@ -286,23 +286,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:15.776628Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:02.656394Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "859"
+      - "888"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:16 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -310,42 +310,110 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6511190f-180f-4c4d-b731-a492e45758dc
+      - 74847ddd-47ad-44a0-b443-f7ef41db607d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-tests-ipam-ip-datasource-instance","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"PLAY2-MICRO","image":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","volumes":{"0":{"boot":false,"volume_type":"b_ssd"}},"boot_type":"local","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":["terraform-test","data_scaleway_instance_servers","basic"]}'
+    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null,"vpc_id":"e67ee4ac-8ce7-4a13-9182-54b6be4c8610"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2024-02-22T07:32:02.726153Z","dhcp_enabled":true,"id":"24ff3f79-71d1-466a-959e-967ffcc2411c","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.726153Z","id":"37e55226-bd93-4392-ac5b-2872a9a7b32f","subnet":"172.16.28.0/22","updated_at":"2024-02-22T07:32:02.726153Z"},{"created_at":"2024-02-22T07:32:02.726153Z","id":"e202ee55-746c-4115-891d-186158c139d9","subnet":"fd5f:519c:6d46:7d5b::/64","updated_at":"2024-02-22T07:32:02.726153Z"}],"tags":[],"updated_at":"2024-02-22T07:32:02.726153Z","vpc_id":"e67ee4ac-8ce7-4a13-9182-54b6be4c8610"}'
+    headers:
+      Content-Length:
+      - "737"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bbe0e823-80d4-450f-bf52-f8a196d28d49
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/24ff3f79-71d1-466a-959e-967ffcc2411c
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-22T07:32:02.726153Z","dhcp_enabled":true,"id":"24ff3f79-71d1-466a-959e-967ffcc2411c","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.726153Z","id":"37e55226-bd93-4392-ac5b-2872a9a7b32f","subnet":"172.16.28.0/22","updated_at":"2024-02-22T07:32:02.726153Z"},{"created_at":"2024-02-22T07:32:02.726153Z","id":"e202ee55-746c-4115-891d-186158c139d9","subnet":"fd5f:519c:6d46:7d5b::/64","updated_at":"2024-02-22T07:32:02.726153Z"}],"tags":[],"updated_at":"2024-02-22T07:32:02.726153Z","vpc_id":"e67ee4ac-8ce7-4a13-9182-54b6be4c8610"}'
+    headers:
+      Content-Length:
+      - "737"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 38e80175-639b-4d30-ba4a-66bcecb269e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-tests-ipam-ip-datasource-instance","dynamic_ip_required":false,"commercial_type":"PLAY2-MICRO","image":"9467798a-e554-4658-a008-82a868d42a3b","volumes":{"0":{"boot":false,"volume_type":"b_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","data_scaleway_instance_servers","basic"]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:03:15.903587+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:03.144335+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2766"
+      - "2788"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:16 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -353,7 +421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66496adf-8a56-419c-b278-6d71ed9bd5d5
+      - 50b1ca6b-b5eb-4e53-8dfa-e2538bc6a32c
     status: 201 Created
     code: 201
     duration: ""
@@ -362,29 +430,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:03:15.903587+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:03.144335+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2766"
+      - "2788"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:16 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -392,7 +460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57633b76-63c5-4fbc-9ec6-63d546f519b4
+      - bf208ba2-9df4-453c-8c0a-abd75ec9eaad
     status: 200 OK
     code: 200
     duration: ""
@@ -401,29 +469,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:03:15.903587+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:03.144335+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2766"
+      - "2788"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:16 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -431,7 +499,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75946c15-dcf4-48c8-aa3b-ed3320942ed6
+      - 81d74ea3-08d1-4716-a382-38e1d6ff96af
     status: 200 OK
     code: 200
     duration: ""
@@ -442,12 +510,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/action","href_result":"/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece","id":"510d47d6-81a7-4308-acc9-be43d916ea3d","started_at":"2023-10-24T16:03:16.623705+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/action","href_result":"/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f","id":"20cf0172-9872-4a31-932f-dffd93aca242","started_at":"2024-02-22T07:32:04.004051+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -456,11 +524,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:16 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/510d47d6-81a7-4308-acc9-be43d916ea3d
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/20cf0172-9872-4a31-932f-dffd93aca242
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -468,106 +536,38 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec5341e5-964d-4361-a437-7f003be3f0fc
+      - 79d5fc3a-e2fd-4f83-81c5-961b07fc7c27
     status: 202 Accepted
     code: 202
     duration: ""
 - request:
-    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null,"vpc_id":"1805549d-ad0b-4ed0-a193-9496fb565d06"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
-    method: POST
-  response:
-    body: '{"created_at":"2023-10-24T16:03:16.019227Z","dhcp_enabled":true,"id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-24T16:03:16.019227Z","id":"d70ceb10-28f1-4b7f-aa3b-6c79bd05e5df","subnet":"172.16.28.0/22","updated_at":"2023-10-24T16:03:16.019227Z"},{"created_at":"2023-10-24T16:03:16.019227Z","id":"ff4b43ba-34e4-4d1d-85ca-61e1f64dea30","subnet":"fd46:78ab:30b8:dd18::/64","updated_at":"2023-10-24T16:03:16.019227Z"}],"tags":[],"updated_at":"2023-10-24T16:03:16.019227Z","vpc_id":"1805549d-ad0b-4ed0-a193-9496fb565d06"}'
-    headers:
-      Content-Length:
-      - "720"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Oct 2023 16:03:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 353812ea-10db-47a5-b655-784e0e723fdb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3d11216d-b1a7-4428-9313-ee3c04e09b8a
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-24T16:03:16.019227Z","dhcp_enabled":true,"id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-24T16:03:16.019227Z","id":"d70ceb10-28f1-4b7f-aa3b-6c79bd05e5df","subnet":"172.16.28.0/22","updated_at":"2023-10-24T16:03:16.019227Z"},{"created_at":"2023-10-24T16:03:16.019227Z","id":"ff4b43ba-34e4-4d1d-85ca-61e1f64dea30","subnet":"fd46:78ab:30b8:dd18::/64","updated_at":"2023-10-24T16:03:16.019227Z"}],"tags":[],"updated_at":"2023-10-24T16:03:16.019227Z","vpc_id":"1805549d-ad0b-4ed0-a193-9496fb565d06"}'
-    headers:
-      Content-Length:
-      - "720"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Oct 2023 16:03:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aadf6564-6f4b-4b14-b1f4-f4096e35fe2b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:03:16.353915+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:03.812103+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2788"
+      - "2810"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:16 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -575,7 +575,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa8d11b8-61df-4365-9d9f-736ba4016922
+      - 6f74b929-a93f-4691-9192-cee7de39ae7a
     status: 200 OK
     code: 200
     duration: ""
@@ -584,29 +584,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"301","node_id":"63","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:03:16.353915+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.76.136.125","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:03.812103+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2898"
+      - "2919"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:21 GMT
+      - Thu, 22 Feb 2024 07:32:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -614,7 +614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3021e620-d87b-4cfd-b3a3-1caa828a83d6
+      - b317bf46-8831-42e9-85e3-593d55bdde89
     status: 200 OK
     code: 200
     duration: ""
@@ -623,29 +623,68 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:03.812103+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2919"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 01a07d15-8c14-43b4-8c3a-a473168226ee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"301","node_id":"63","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:03:24.297499+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.76.136.125","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:15.362228+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2929"
+      - "2950"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:27 GMT
+      - Thu, 22 Feb 2024 07:32:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -653,7 +692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3a2ed51-a0c5-4746-93bd-e8705aca1f65
+      - 49ab05e4-294f-4b5d-8149-feee484810e0
     status: 200 OK
     code: 200
     duration: ""
@@ -662,29 +701,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"301","node_id":"63","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:03:24.297499+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.76.136.125","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:15.362228+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2929"
+      - "2950"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:27 GMT
+      - Thu, 22 Feb 2024 07:32:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -692,7 +731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3d5a1c1-9f45-433f-b29e-08f0be214cca
+      - b49a7a38-d95e-4906-90f4-1798b244dc3c
     status: 200 OK
     code: 200
     duration: ""
@@ -701,9 +740,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -715,9 +754,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:27 GMT
+      - Thu, 22 Feb 2024 07:32:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -725,7 +764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cdea899c-e75c-4a80-923d-fc2104168a0a
+      - 4377cf7e-ccd2-4420-a784-c056cada628f
     status: 200 OK
     code: 200
     duration: ""
@@ -734,9 +773,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -748,12 +787,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:27 GMT
+      - Thu, 22 Feb 2024 07:32:20 GMT
       Link:
-      - </servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics?page=0&per_page=50&>;
+      - </servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -761,7 +800,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3188e6ac-47d3-4555-9da8-e726f0a3e6c9
+      - 9ab587a5-5636-4495-8adf-ec638fa47f05
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -772,29 +811,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"301","node_id":"63","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:03:24.297499+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.76.136.125","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:15.362228+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2929"
+      - "2950"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:27 GMT
+      - Thu, 22 Feb 2024 07:32:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -802,23 +841,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 171f5bc9-0a91-4c64-825b-1d1f589d8c27
+      - 41b2b3a6-dd38-4ba5-8250-f50cfccb055c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a"}'
+    body: '{"private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.553850+00:00","id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","modification_date":"2023-10-24T16:03:27.553850+00:00","private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","server_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:20.300551+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -827,9 +866,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:28 GMT
+      - Thu, 22 Feb 2024 07:32:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -837,7 +876,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44cc7f87-de2f-4918-b169-131b9f58849f
+      - 4a8068bc-abc1-414b-bec0-18079d42e732
     status: 201 Created
     code: 201
     duration: ""
@@ -846,12 +885,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics/98f3fc5b-f516-4c49-86f1-58552b58a00f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.553850+00:00","id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","modification_date":"2023-10-24T16:03:27.553850+00:00","private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","server_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:20.300551+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -860,9 +899,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:28 GMT
+      - Thu, 22 Feb 2024 07:32:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -870,7 +909,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a97cb44-01fa-4170-8131-243b7e6c10f9
+      - 55eb594d-32ec-492c-b5f7-bced3c30a437
     status: 200 OK
     code: 200
     duration: ""
@@ -879,12 +918,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics/98f3fc5b-f516-4c49-86f1-58552b58a00f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.553850+00:00","id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","modification_date":"2023-10-24T16:03:30.014896+00:00","private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","server_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:21.235145+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -893,9 +932,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:33 GMT
+      - Thu, 22 Feb 2024 07:32:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -903,7 +942,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98a7f8d4-481a-4356-b7f7-56c0f6ee60e7
+      - eb9885e0-6468-46ce-b08a-6619f6bec495
     status: 200 OK
     code: 200
     duration: ""
@@ -912,12 +951,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics/98f3fc5b-f516-4c49-86f1-58552b58a00f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.553850+00:00","id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","modification_date":"2023-10-24T16:03:30.014896+00:00","private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","server_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:21.235145+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -926,9 +965,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:38 GMT
+      - Thu, 22 Feb 2024 07:32:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -936,7 +975,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba0cbef3-dc8a-44d5-be6c-c50d773fadc4
+      - 52850186-1e72-4756-bdd4-350600fddc47
     status: 200 OK
     code: 200
     duration: ""
@@ -945,23 +984,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics/98f3fc5b-f516-4c49-86f1-58552b58a00f
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.553850+00:00","id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","modification_date":"2023-10-24T16:03:30.014896+00:00","private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","server_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:08.876569Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "376"
+      - "1090"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:43 GMT
+      - Thu, 22 Feb 2024 07:32:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -969,7 +1008,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67c1a0ff-8331-4dbe-96cc-e5854ac8786a
+      - a0f1fa0a-2550-4eb7-87f8-0c0331396130
     status: 200 OK
     code: 200
     duration: ""
@@ -978,23 +1017,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-24T16:03:20.772442Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:22.247918Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:08.876569Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1055"
+      - "1090"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:46 GMT
+      - Thu, 22 Feb 2024 07:32:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1002,7 +1041,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c3630a9-115e-44e7-813e-9558f50af78c
+      - d8d7f2a7-ff03-4be5-83ba-58c3d8df9511
     status: 200 OK
     code: 200
     duration: ""
@@ -1011,56 +1050,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
-    method: GET
-  response:
-    body: '{"backend_count":0,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-24T16:03:20.772442Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:22.247918Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1055"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Oct 2023 16:03:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dfec631e-bbda-4876-8545-bc4b214d898c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181/private-networks?order_by=created_at_asc
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1/private-networks?order_by=created_at_asc
     method: GET
   response:
     body: '{"private_network":[],"total_count":0}'
     headers:
       Content-Length:
-      - "38"
+      - "39"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:46 GMT
+      - Thu, 22 Feb 2024 07:32:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1068,7 +1074,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d29adab0-3a23-4664-b849-e51e6ee6cf77
+      - 3643e774-6796-4cbf-8e0f-73cf6dc33eb8
     status: 200 OK
     code: 200
     duration: ""
@@ -1077,12 +1083,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics/98f3fc5b-f516-4c49-86f1-58552b58a00f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.553850+00:00","id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","modification_date":"2023-10-24T16:03:30.014896+00:00","private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","server_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:21.235145+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1091,9 +1097,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:48 GMT
+      - Thu, 22 Feb 2024 07:32:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1101,7 +1107,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77a0e2c4-65c1-4a92-b366-cf241fb5cd3a
+      - ae6c3e0c-4008-4106-af1d-5877a584edf0
     status: 200 OK
     code: 200
     duration: ""
@@ -1110,12 +1116,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics/98f3fc5b-f516-4c49-86f1-58552b58a00f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.553850+00:00","id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","modification_date":"2023-10-24T16:03:30.014896+00:00","private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","server_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:21.235145+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1124,9 +1130,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:53 GMT
+      - Thu, 22 Feb 2024 07:32:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1134,7 +1140,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f5db4ac-84a0-4938-b697-4ca29371393b
+      - 55b839c5-f33d-4034-adf5-a0e71d77229b
     status: 200 OK
     code: 200
     duration: ""
@@ -1143,12 +1149,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics/98f3fc5b-f516-4c49-86f1-58552b58a00f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.553850+00:00","id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","modification_date":"2023-10-24T16:03:30.014896+00:00","private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","server_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:21.235145+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1157,9 +1163,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:58 GMT
+      - Thu, 22 Feb 2024 07:32:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1167,7 +1173,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d00f456a-668d-4cab-a0b3-7599376cfbbe
+      - c6557256-9056-481c-bbee-a1f7bcb745bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1176,12 +1182,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics/98f3fc5b-f516-4c49-86f1-58552b58a00f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.553850+00:00","id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","modification_date":"2023-10-24T16:03:59.091574+00:00","private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","server_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:21.235145+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "376"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - adfe6a25-cf5d-4b32-bdce-2abfa448a575
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:51.647676+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1190,9 +1229,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:03 GMT
+      - Thu, 22 Feb 2024 07:32:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1200,7 +1239,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d4cbdf8-835c-4011-903d-8ea9206ac3c6
+      - d2fb33be-cffb-4254-a9dc-f013ca849bc5
     status: 200 OK
     code: 200
     duration: ""
@@ -1209,12 +1248,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics/98f3fc5b-f516-4c49-86f1-58552b58a00f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.553850+00:00","id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","modification_date":"2023-10-24T16:03:59.091574+00:00","private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","server_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:51.647676+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1223,9 +1262,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:03 GMT
+      - Thu, 22 Feb 2024 07:32:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1233,7 +1272,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bec32951-8926-4244-aef5-40a16f165b46
+      - e2495797-463f-4804-a10c-eaedd9423cc9
     status: 200 OK
     code: 200
     duration: ""
@@ -1242,23 +1281,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A14%3A68%3A58&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab1&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2023-10-24T16:03:29.901030Z","id":"705ec798-c857-4faf-ab66-da5198b42540","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"source":{"subnet_id":"d70ceb10-28f1-4b7f-aa3b-6c79bd05e5df"},"tags":[],"updated_at":"2023-10-24T16:03:29.901030Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-22T07:32:21.158150Z","id":"637eb92e-c2f0-4134-b3e1-ff9eb095bb26","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8B:B1","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"37e55226-bd93-4392-ac5b-2872a9a7b32f"},"tags":[],"updated_at":"2024-02-22T07:32:21.158150Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "521"
+      - "550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:03 GMT
+      - Thu, 22 Feb 2024 07:32:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1266,7 +1305,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c92226f-63e1-403f-a9d5-5308556d578e
+      - 17a4f4cd-e441-4b78-97b0-28b7900853a3
     status: 200 OK
     code: 200
     duration: ""
@@ -1275,23 +1314,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-24T16:03:20.772442Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:22.247918Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:08.876569Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1055"
+      - "1090"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:03 GMT
+      - Thu, 22 Feb 2024 07:32:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1299,34 +1338,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8874e22-1df0-4c69-900c-53077ffd3866
+      - f8238807-9605-4143-a232-31f8ec883141
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-lb-bkd-agitated-einstein","forward_protocol":"http","forward_port":80,"forward_port_algorithm":"roundrobin","sticky_sessions":"none","sticky_sessions_cookie_name":"","health_check":{"port":80,"check_max_retries":2,"check_send_proxy":false,"transient_check_delay":"0.500000000s","check_delay":60000,"check_timeout":30000},"server_ip":["172.16.28.2"],"on_marked_down_action":"on_marked_down_action_none","proxy_protocol":"proxy_protocol_none","failover_host":null,"ssl_bridging":false,"ignore_ssl_server_verify":false,"redispatch_attempt_count":null,"max_retries":3,"max_connections":null,"timeout_queue":"0.000000000s","timeout_server":300000,"timeout_connect":5000,"timeout_tunnel":900000}'
+    body: '{"name":"tf-lb-bkd-great-mclaren","forward_protocol":"http","forward_port":80,"forward_port_algorithm":"roundrobin","sticky_sessions":"none","sticky_sessions_cookie_name":"","health_check":{"port":80,"check_max_retries":2,"check_send_proxy":false,"transient_check_delay":"0.500000000s","check_delay":60000,"check_timeout":30000},"server_ip":["172.16.28.2"],"on_marked_down_action":"on_marked_down_action_none","proxy_protocol":"proxy_protocol_none","ssl_bridging":false,"ignore_ssl_server_verify":false,"max_retries":3,"timeout_queue":"0.000000000s","timeout_server":300000,"timeout_connect":5000,"timeout_tunnel":900000}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181/backends
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1/backends
     method: POST
   response:
-    body: '{"created_at":"2023-10-24T16:04:04.051125171Z","failover_host":null,"forward_port":80,"forward_port_algorithm":"roundrobin","forward_protocol":"http","health_check":{"check_delay":60000,"check_max_retries":2,"check_send_proxy":false,"check_timeout":30000,"port":80,"tcp_config":{},"transient_check_delay":"0.500s"},"id":"2ec02254-dbff-4f3f-9412-509e8814aa8b","ignore_ssl_server_verify":false,"lb":{"backend_count":1,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"pending","updated_at":"2023-10-24T16:04:04.089939365Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:22.247918Z","zone":"fr-par-1"},"max_connections":null,"max_retries":3,"name":"tf-lb-bkd-agitated-einstein","on_marked_down_action":"on_marked_down_action_none","pool":["172.16.28.2"],"proxy_protocol":"proxy_protocol_none","redispatch_attempt_count":null,"send_proxy_v2":false,"ssl_bridging":false,"sticky_sessions":"none","sticky_sessions_cookie_name":"","timeout_connect":5000,"timeout_queue":"0s","timeout_server":300000,"timeout_tunnel":900000,"updated_at":"2023-10-24T16:04:04.051125171Z"}'
+    body: '{"created_at":"2024-02-22T07:32:56.840818932Z","failover_host":null,"forward_port":80,"forward_port_algorithm":"roundrobin","forward_protocol":"http","health_check":{"check_delay":60000,"check_max_retries":2,"check_send_proxy":false,"check_timeout":30000,"port":80,"tcp_config":{},"transient_check_delay":"0.500s"},"id":"15b3c4a5-00a6-4631-91ed-667014726de9","ignore_ssl_server_verify":false,"lb":{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"pending","updated_at":"2024-02-22T07:32:56.883864384Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"},"max_connections":null,"max_retries":3,"name":"tf-lb-bkd-great-mclaren","on_marked_down_action":"on_marked_down_action_none","pool":["172.16.28.2"],"proxy_protocol":"proxy_protocol_none","redispatch_attempt_count":null,"send_proxy_v2":false,"ssl_bridging":false,"sticky_sessions":"none","sticky_sessions_cookie_name":"","timeout_connect":5000,"timeout_queue":"0s","timeout_server":300000,"timeout_tunnel":900000,"updated_at":"2024-02-22T07:32:56.840818932Z"}'
     headers:
       Content-Length:
-      - "1920"
+      - "1981"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1334,7 +1373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2334a8d6-8db6-4712-ad67-373e8bcce2e7
+      - 4a38ef4d-08c9-4844-8055-a2523d127298
     status: 200 OK
     code: 200
     duration: ""
@@ -1343,23 +1382,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
     method: GET
   response:
-    body: '{"backend_count":1,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"pending","updated_at":"2023-10-24T16:04:04.089939Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:22.247918Z","zone":"fr-par-1"}'
+    body: '{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"pending","updated_at":"2024-02-22T07:32:56.883864Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1057"
+      - "1092"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1367,7 +1406,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 012ba189-a40e-4e4a-b6be-25bcb6f10a8a
+      - c383ac74-e82a-4013-ad53-051fb9435f9e
     status: 200 OK
     code: 200
     duration: ""
@@ -1376,23 +1415,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/backends/2ec02254-dbff-4f3f-9412-509e8814aa8b
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/backends/15b3c4a5-00a6-4631-91ed-667014726de9
     method: GET
   response:
-    body: '{"created_at":"2023-10-24T16:04:04.051125Z","failover_host":null,"forward_port":80,"forward_port_algorithm":"roundrobin","forward_protocol":"http","health_check":{"check_delay":60000,"check_max_retries":2,"check_send_proxy":false,"check_timeout":30000,"port":80,"tcp_config":{},"transient_check_delay":"0.500s"},"id":"2ec02254-dbff-4f3f-9412-509e8814aa8b","ignore_ssl_server_verify":false,"lb":{"backend_count":1,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"pending","updated_at":"2023-10-24T16:04:04.089939Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:22.247918Z","zone":"fr-par-1"},"max_connections":null,"max_retries":3,"name":"tf-lb-bkd-agitated-einstein","on_marked_down_action":"on_marked_down_action_none","pool":["172.16.28.2"],"proxy_protocol":"proxy_protocol_none","redispatch_attempt_count":null,"send_proxy_v2":false,"ssl_bridging":false,"sticky_sessions":"none","sticky_sessions_cookie_name":"","timeout_connect":5000,"timeout_queue":"0s","timeout_server":300000,"timeout_tunnel":900000,"updated_at":"2023-10-24T16:04:04.051125Z"}'
+    body: '{"created_at":"2024-02-22T07:32:56.840819Z","failover_host":null,"forward_port":80,"forward_port_algorithm":"roundrobin","forward_protocol":"http","health_check":{"check_delay":60000,"check_max_retries":2,"check_send_proxy":false,"check_timeout":30000,"port":80,"tcp_config":{},"transient_check_delay":"0.500s"},"id":"15b3c4a5-00a6-4631-91ed-667014726de9","ignore_ssl_server_verify":false,"lb":{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"pending","updated_at":"2024-02-22T07:32:56.883864Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"},"max_connections":null,"max_retries":3,"name":"tf-lb-bkd-great-mclaren","on_marked_down_action":"on_marked_down_action_none","pool":["172.16.28.2"],"proxy_protocol":"proxy_protocol_none","redispatch_attempt_count":null,"send_proxy_v2":false,"ssl_bridging":false,"sticky_sessions":"none","sticky_sessions_cookie_name":"","timeout_connect":5000,"timeout_queue":"0s","timeout_server":300000,"timeout_tunnel":900000,"updated_at":"2024-02-22T07:32:56.840819Z"}'
     headers:
       Content-Length:
-      - "1911"
+      - "1972"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1400,7 +1439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea599daa-e4b3-4ad1-bb13-a02dfe34f4de
+      - ac5b2178-a1ad-4fe1-9e10-cff3ffed9555
     status: 200 OK
     code: 200
     duration: ""
@@ -1409,23 +1448,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
     method: GET
   response:
-    body: '{"backend_count":1,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"pending","updated_at":"2023-10-24T16:04:04.089939Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:22.247918Z","zone":"fr-par-1"}'
+    body: '{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:57.182574Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1057"
+      - "1090"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1433,7 +1472,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f10a51b5-b4aa-4523-a619-31d3764281c3
+      - b06eca4a-3ad2-4fa9-ab0f-37a1b2b0f029
     status: 200 OK
     code: 200
     duration: ""
@@ -1442,23 +1481,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A14%3A68%3A58&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab1&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2023-10-24T16:03:29.901030Z","id":"705ec798-c857-4faf-ab66-da5198b42540","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"source":{"subnet_id":"d70ceb10-28f1-4b7f-aa3b-6c79bd05e5df"},"tags":[],"updated_at":"2023-10-24T16:03:29.901030Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-22T07:32:21.158150Z","id":"637eb92e-c2f0-4134-b3e1-ff9eb095bb26","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8B:B1","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"37e55226-bd93-4392-ac5b-2872a9a7b32f"},"tags":[],"updated_at":"2024-02-22T07:32:21.158150Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "521"
+      - "550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1466,7 +1505,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b649188-c884-4cf5-9c3d-debc5f2d4211
+      - c55a4474-3901-4f22-a8bc-3e7c5e31676d
     status: 200 OK
     code: 200
     duration: ""
@@ -1475,23 +1514,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/c8f1c1ef-0350-426f-8e79-51b1d44e04b0
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/e67ee4ac-8ce7-4a13-9182-54b6be4c8610
     method: GET
   response:
-    body: '{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:02.379740Z","id":"e67ee4ac-8ce7-4a13-9182-54b6be4c8610","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:32:02.379740Z"}'
     headers:
       Content-Length:
-      - "310"
+      - "368"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1499,7 +1538,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33e27601-6852-400a-b69b-f766a9ff8221
+      - 1df1df9b-905e-418e-8816-8025dd128e0e
     status: 200 OK
     code: 200
     duration: ""
@@ -1508,23 +1547,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1805549d-ad0b-4ed0-a193-9496fb565d06
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/69bad162-3fb1-4469-8f16-70485430ab8a
     method: GET
   response:
-    body: '{"created_at":"2023-10-24T16:03:15.801850Z","id":"1805549d-ad0b-4ed0-a193-9496fb565d06","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2023-10-24T16:03:15.801850Z"}'
+    body: '{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "359"
+      - "321"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1532,7 +1571,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0afbf4d1-3b6a-45fb-8dbb-fc3d3bec4db2
+      - 3f5fec61-3f79-450c-a6af-6ad6ec987852
     status: 200 OK
     code: 200
     duration: ""
@@ -1541,23 +1580,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3d11216d-b1a7-4428-9313-ee3c04e09b8a
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/24ff3f79-71d1-466a-959e-967ffcc2411c
     method: GET
   response:
-    body: '{"created_at":"2023-10-24T16:03:16.019227Z","dhcp_enabled":true,"id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-24T16:03:16.019227Z","id":"d70ceb10-28f1-4b7f-aa3b-6c79bd05e5df","subnet":"172.16.28.0/22","updated_at":"2023-10-24T16:03:16.019227Z"},{"created_at":"2023-10-24T16:03:16.019227Z","id":"ff4b43ba-34e4-4d1d-85ca-61e1f64dea30","subnet":"fd46:78ab:30b8:dd18::/64","updated_at":"2023-10-24T16:03:16.019227Z"}],"tags":[],"updated_at":"2023-10-24T16:03:16.019227Z","vpc_id":"1805549d-ad0b-4ed0-a193-9496fb565d06"}'
+    body: '{"created_at":"2024-02-22T07:32:02.726153Z","dhcp_enabled":true,"id":"24ff3f79-71d1-466a-959e-967ffcc2411c","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.726153Z","id":"37e55226-bd93-4392-ac5b-2872a9a7b32f","subnet":"172.16.28.0/22","updated_at":"2024-02-22T07:32:02.726153Z"},{"created_at":"2024-02-22T07:32:02.726153Z","id":"e202ee55-746c-4115-891d-186158c139d9","subnet":"fd5f:519c:6d46:7d5b::/64","updated_at":"2024-02-22T07:32:02.726153Z"}],"tags":[],"updated_at":"2024-02-22T07:32:02.726153Z","vpc_id":"e67ee4ac-8ce7-4a13-9182-54b6be4c8610"}'
     headers:
       Content-Length:
-      - "720"
+      - "737"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1565,7 +1604,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1516ecdc-3d9d-4557-961f-77a736c181d9
+      - 4d59179e-4aba-42f8-bccf-220760c398a3
     status: 200 OK
     code: 200
     duration: ""
@@ -1574,62 +1613,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
-    method: GET
-  response:
-    body: '{"backend_count":1,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-24T16:04:04.403432Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:22.247918Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1055"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8ddaabd8-839a-4e50-9bf5-f57380a6bec5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"301","node_id":"63","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:03:24.297499+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.76.136.125","private_nics":[{"creation_date":"2023-10-24T16:03:27.553850+00:00","id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","modification_date":"2023-10-24T16:03:59.091574+00:00","private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","server_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:15.362228+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:51.647676+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3282"
+      - "3303"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1637,7 +1643,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2003325d-9e02-430e-b02a-f65f45aa747d
+      - f093fc9a-f523-413c-8326-a6b7053d1eb4
     status: 200 OK
     code: 200
     duration: ""
@@ -1646,9 +1652,42 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/user_data
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    method: GET
+  response:
+    body: '{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:57.182574Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1090"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:58 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cb6ea37d-1f50-45aa-831e-83a7d34e5bab
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1660,9 +1699,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1670,7 +1709,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ead95074-e8a1-4b3a-9aec-31a71461ad96
+      - 4091b98a-5c36-4a3b-a991-8d940ef91777
     status: 200 OK
     code: 200
     duration: ""
@@ -1679,23 +1718,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
     method: GET
   response:
-    body: '{"backend_count":1,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-24T16:04:04.403432Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:22.247918Z","zone":"fr-par-1"}'
+    body: '{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:57.182574Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1055"
+      - "1090"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1703,7 +1742,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da902412-06ad-424f-a5d2-6855aa797a1a
+      - 6a986aa8-d201-474b-a235-f50d3877e282
     status: 200 OK
     code: 200
     duration: ""
@@ -1712,12 +1751,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-24T16:03:27.553850+00:00","id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","modification_date":"2023-10-24T16:03:59.091574+00:00","private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","server_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:51.647676+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1726,12 +1765,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Link:
-      - </servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics?page=1&per_page=50&>;
+      - </servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1739,7 +1778,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84e5ae55-539c-4914-8823-660b985cff4a
+      - 98950720-6440-4f87-bf01-2e71ae9a035f
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1750,23 +1789,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181/private-networks?order_by=created_at_asc
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1/private-networks?order_by=created_at_asc
     method: GET
   response:
     body: '{"private_network":[],"total_count":0}'
     headers:
       Content-Length:
-      - "38"
+      - "39"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1774,7 +1813,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cfeb05d-e0dd-4c76-84e9-a1c467cf2515
+      - 6d2afff1-b3cf-472a-b5a2-a733544e51ab
     status: 200 OK
     code: 200
     duration: ""
@@ -1783,12 +1822,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics/98f3fc5b-f516-4c49-86f1-58552b58a00f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.553850+00:00","id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","modification_date":"2023-10-24T16:03:59.091574+00:00","private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","server_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:51.647676+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1797,9 +1836,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1807,7 +1846,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ff5000d-57b6-4031-977f-2bae32dbc8ea
+      - bf20ee7f-e739-4e44-84cf-fbc4e5709a95
     status: 200 OK
     code: 200
     duration: ""
@@ -1816,23 +1855,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A14%3A68%3A58&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab1&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2023-10-24T16:03:29.901030Z","id":"705ec798-c857-4faf-ab66-da5198b42540","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"source":{"subnet_id":"d70ceb10-28f1-4b7f-aa3b-6c79bd05e5df"},"tags":[],"updated_at":"2023-10-24T16:03:29.901030Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-22T07:32:21.158150Z","id":"637eb92e-c2f0-4134-b3e1-ff9eb095bb26","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8B:B1","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"37e55226-bd93-4392-ac5b-2872a9a7b32f"},"tags":[],"updated_at":"2024-02-22T07:32:21.158150Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "521"
+      - "550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1840,7 +1879,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f1edc62-85a9-410e-b5d9-d7dd1a666ac4
+      - d176a972-bc81-46b6-b963-2f0571852698
     status: 200 OK
     code: 200
     duration: ""
@@ -1849,23 +1888,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/backends/2ec02254-dbff-4f3f-9412-509e8814aa8b
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/backends/15b3c4a5-00a6-4631-91ed-667014726de9
     method: GET
   response:
-    body: '{"created_at":"2023-10-24T16:04:04.051125Z","failover_host":null,"forward_port":80,"forward_port_algorithm":"roundrobin","forward_protocol":"http","health_check":{"check_delay":60000,"check_max_retries":2,"check_send_proxy":false,"check_timeout":30000,"port":80,"tcp_config":{},"transient_check_delay":"0.500s"},"id":"2ec02254-dbff-4f3f-9412-509e8814aa8b","ignore_ssl_server_verify":false,"lb":{"backend_count":1,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-24T16:04:04.403432Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:22.247918Z","zone":"fr-par-1"},"max_connections":null,"max_retries":3,"name":"tf-lb-bkd-agitated-einstein","on_marked_down_action":"on_marked_down_action_none","pool":["172.16.28.2"],"proxy_protocol":"proxy_protocol_none","redispatch_attempt_count":null,"send_proxy_v2":false,"ssl_bridging":false,"sticky_sessions":"none","sticky_sessions_cookie_name":"","timeout_connect":5000,"timeout_queue":"0s","timeout_server":300000,"timeout_tunnel":900000,"updated_at":"2023-10-24T16:04:04.051125Z"}'
+    body: '{"created_at":"2024-02-22T07:32:56.840819Z","failover_host":null,"forward_port":80,"forward_port_algorithm":"roundrobin","forward_protocol":"http","health_check":{"check_delay":60000,"check_max_retries":2,"check_send_proxy":false,"check_timeout":30000,"port":80,"tcp_config":{},"transient_check_delay":"0.500s"},"id":"15b3c4a5-00a6-4631-91ed-667014726de9","ignore_ssl_server_verify":false,"lb":{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:57.182574Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"},"max_connections":null,"max_retries":3,"name":"tf-lb-bkd-great-mclaren","on_marked_down_action":"on_marked_down_action_none","pool":["172.16.28.2"],"proxy_protocol":"proxy_protocol_none","redispatch_attempt_count":null,"send_proxy_v2":false,"ssl_bridging":false,"sticky_sessions":"none","sticky_sessions_cookie_name":"","timeout_connect":5000,"timeout_queue":"0s","timeout_server":300000,"timeout_tunnel":900000,"updated_at":"2024-02-22T07:32:56.840819Z"}'
     headers:
       Content-Length:
-      - "1909"
+      - "1970"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1873,7 +1912,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6feb6c4a-c04e-4ac2-a76e-47d8160e1223
+      - c0993c41-c14d-421a-88aa-fd469145d882
     status: 200 OK
     code: 200
     duration: ""
@@ -1882,23 +1921,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
     method: GET
   response:
-    body: '{"backend_count":1,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-24T16:04:04.403432Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:22.247918Z","zone":"fr-par-1"}'
+    body: '{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:57.182574Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1055"
+      - "1090"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1906,7 +1945,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb3d8750-4ca5-4652-b404-879847a0460b
+      - b41a7918-cb09-4e01-83ae-255af9a04e9a
     status: 200 OK
     code: 200
     duration: ""
@@ -1915,23 +1954,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A14%3A68%3A58&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab1&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2023-10-24T16:03:29.901030Z","id":"705ec798-c857-4faf-ab66-da5198b42540","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"source":{"subnet_id":"d70ceb10-28f1-4b7f-aa3b-6c79bd05e5df"},"tags":[],"updated_at":"2023-10-24T16:03:29.901030Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-22T07:32:21.158150Z","id":"637eb92e-c2f0-4134-b3e1-ff9eb095bb26","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8B:B1","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"37e55226-bd93-4392-ac5b-2872a9a7b32f"},"tags":[],"updated_at":"2024-02-22T07:32:21.158150Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "521"
+      - "550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:32:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1939,7 +1978,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4dd040d-9be0-4c9d-93d8-f29d24dd857c
+      - 242921f2-1521-48af-adea-148f418a18f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1948,23 +1987,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
     method: GET
   response:
-    body: '{"backend_count":1,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-24T16:04:04.403432Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:22.247918Z","zone":"fr-par-1"}'
+    body: '{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:57.182574Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1055"
+      - "1090"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:06 GMT
+      - Thu, 22 Feb 2024 07:32:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1972,7 +2011,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a241a33-ea84-4742-a33d-cf8dc3d39d33
+      - 7e5f6184-9f5b-42b4-9a0b-be803c3c9f71
     status: 200 OK
     code: 200
     duration: ""
@@ -1981,9 +2020,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/backends/2ec02254-dbff-4f3f-9412-509e8814aa8b
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/backends/15b3c4a5-00a6-4631-91ed-667014726de9
     method: DELETE
   response:
     body: ""
@@ -1993,9 +2032,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:06 GMT
+      - Thu, 22 Feb 2024 07:32:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2003,7 +2042,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96f65960-71e8-4c92-a34a-d23df9ea5cdf
+      - 45feaea7-3972-49a9-9b58-f8a86230f7d1
     status: 204 No Content
     code: 204
     duration: ""
@@ -2012,23 +2051,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"pending","updated_at":"2023-10-24T16:04:06.257008Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:22.247918Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"pending","updated_at":"2024-02-22T07:32:59.700879Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1057"
+      - "1092"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:06 GMT
+      - Thu, 22 Feb 2024 07:32:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2036,7 +2075,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bafe8a4e-b838-4c2c-9878-fb031f8c27c7
+      - bd3954b6-2527-4695-aec3-3af01622f728
     status: 200 OK
     code: 200
     duration: ""
@@ -2045,12 +2084,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics/98f3fc5b-f516-4c49-86f1-58552b58a00f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.553850+00:00","id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","mac_address":"02:00:00:14:68:58","modification_date":"2023-10-24T16:03:59.091574+00:00","private_network_id":"3d11216d-b1a7-4428-9313-ee3c04e09b8a","server_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:51.647676+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -2059,9 +2098,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:06 GMT
+      - Thu, 22 Feb 2024 07:33:00 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2069,7 +2108,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1915c1a0-8d72-4a91-b7b6-0c909b497f4e
+      - 7693075e-2e07-42c0-b96f-b5e66e3aa447
     status: 200 OK
     code: 200
     duration: ""
@@ -2078,23 +2117,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-24T16:04:06.544107Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:03:22.247918Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:59.970448Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1055"
+      - "1090"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:06 GMT
+      - Thu, 22 Feb 2024 07:33:00 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2102,7 +2141,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d944f074-9ad2-4649-9338-70bb269068d1
+      - be24d737-51e1-46b6-b198-2e525f93b035
     status: 200 OK
     code: 200
     duration: ""
@@ -2111,9 +2150,38 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181?release_ip=false
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Thu, 22 Feb 2024 07:33:00 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 771203c6-d944-4925-a00b-44d3b00a141c
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1?release_ip=false
     method: DELETE
   response:
     body: ""
@@ -2123,9 +2191,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:06 GMT
+      - Thu, 22 Feb 2024 07:33:00 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2133,7 +2201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e20d73b-4166-4a1c-a860-eb882a5d9902
+      - 886db941-f277-4b06-a924-c16db5848032
     status: 204 No Content
     code: 204
     duration: ""
@@ -2142,74 +2210,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-24T16:03:15.776628Z","description":"","frontend_count":0,"id":"b952606a-4c72-43d4-9097-e66cedabd181","instances":[{"created_at":"2023-10-24T16:02:10.165776Z","id":"4160a2aa-3a6d-4477-9d24-23513448d5d7","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-24T16:04:06.544107Z","zone":"fr-par-1"}],"ip":[{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":"b952606a-4c72-43d4-9097-e66cedabd181","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-cool-payne","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_delete","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-24T16:04:06.684757Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1059"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Oct 2023 16:04:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8788f817-03f0-4920-be07-f34e82b68f93
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics/98f3fc5b-f516-4c49-86f1-58552b58a00f
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Date:
-      - Tue, 24 Oct 2023 16:04:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0b6a9153-f5cc-437e-8a58-26df1842e390
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/private_nics/98f3fc5b-f516-4c49-86f1-58552b58a00f
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"98f3fc5b-f516-4c49-86f1-58552b58a00f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -2218,9 +2224,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:07 GMT
+      - Thu, 22 Feb 2024 07:33:00 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2228,7 +2234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 400e6f0b-e046-4130-b3c7-87baa21cc0b6
+      - 5fd44632-89fb-4fd0-b09f-e4d5ae3213c7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2237,29 +2243,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"301","node_id":"63","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:03:24.297499+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.76.136.125","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:59.970448Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_delete","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:33:00.226342Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2921"
+      - "1094"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:07 GMT
+      - Thu, 22 Feb 2024 07:33:00 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2267,9 +2267,82 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56f2aaff-d884-42af-9bac-ce6cf97a38c2
+      - 5d08a965-3b90-4894-8fef-247256f9fd84
     status: 200 OK
     code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:15.362228+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2942"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:00 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 752a2b7f-7516-42a6-b48a-2b9013917963
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/24ff3f79-71d1-466a-959e-967ffcc2411c
+    method: DELETE
+  response:
+    body: '{"help_message":"Private Network must be empty to be deleted","message":"precondition
+      is not respected","precondition":"resource_still_in_use","type":"precondition_failed"}'
+    headers:
+      Content-Length:
+      - "172"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c4b49b6f-64ee-41e6-93f6-7f9883effe3d
+    status: 412 Precondition Failed
+    code: 412
     duration: ""
 - request:
     body: '{"action":"poweroff"}'
@@ -2278,12 +2351,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece/action","href_result":"/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece","id":"6c5c8c40-1d79-4cae-9053-eac6f8a25f3c","started_at":"2023-10-24T16:04:07.547126+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/action","href_result":"/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f","id":"3e19f59d-af46-4ad9-be0e-8aab8b8cbc2f","started_at":"2024-02-22T07:33:00.955576+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -2292,11 +2365,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:07 GMT
+      - Thu, 22 Feb 2024 07:33:01 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6c5c8c40-1d79-4cae-9053-eac6f8a25f3c
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3e19f59d-af46-4ad9-be0e-8aab8b8cbc2f
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2304,7 +2377,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e8b7f0e-7f6b-455b-b7a4-9c9c9ff561c9
+      - a934fbdb-0da8-473c-9439-14e81b41c383
     status: 202 Accepted
     code: 202
     duration: ""
@@ -2313,9 +2386,48 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/3d11216d-b1a7-4428-9313-ee3c04e09b8a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:33:00.593901+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2910"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:01 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 51e05b9a-eef8-4bdb-b04e-a750bececa37
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/24ff3f79-71d1-466a-959e-967ffcc2411c
     method: DELETE
   response:
     body: ""
@@ -2325,9 +2437,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:07 GMT
+      - Thu, 22 Feb 2024 07:33:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2335,7 +2447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 157abac3-0663-478d-86a0-55fbdfc08c48
+      - 01300d45-36c2-49da-adc1-dbc693d8f0ee
     status: 204 No Content
     code: 204
     duration: ""
@@ -2344,48 +2456,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"301","node_id":"63","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:04:07.250364+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.76.136.125","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2889"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Oct 2023 16:04:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 26576761-c9c0-4adc-9fa7-57bf9a9be85c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/1805549d-ad0b-4ed0-a193-9496fb565d06
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/e67ee4ac-8ce7-4a13-9182-54b6be4c8610
     method: DELETE
   response:
     body: ""
@@ -2395,9 +2468,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:07 GMT
+      - Thu, 22 Feb 2024 07:33:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2405,7 +2478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65b153d6-55a3-431d-8c68-0ff2f3a72246
+      - 9eda2585-cc4c-42b5-bfb4-ef36cb5a10ef
     status: 204 No Content
     code: 204
     duration: ""
@@ -2414,29 +2487,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"301","node_id":"63","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:04:07.250364+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.76.136.125","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:33:00.593901+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2889"
+      - "2910"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:12 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2444,7 +2517,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82d3d2c5-469b-4b92-b604-9dbb37b4758b
+      - d5d40be5-afd9-4534-b6d8-fa4300f129a5
     status: 200 OK
     code: 200
     duration: ""
@@ -2453,29 +2526,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"301","node_id":"63","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:04:07.250364+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.76.136.125","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:33:00.593901+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2889"
+      - "2910"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:18 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2483,7 +2556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9f7e5e8-5af5-4b3b-bfac-117cdf235686
+      - 513998a7-267b-44d9-ae37-04a9efbf2b75
     status: 200 OK
     code: 200
     duration: ""
@@ -2492,29 +2565,68 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:33:00.593901+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2910"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 468c8c28-417b-404b-a3b9-5d552af133a1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:04:22.979126+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:33:19.647374+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2766"
+      - "2788"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:23 GMT
+      - Thu, 22 Feb 2024 07:33:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2522,7 +2634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb2cbcd2-707b-4f4c-8c6c-7152ea7bb014
+      - 6a37a24a-faaf-4ba7-afb0-3be299cebe44
     status: 200 OK
     code: 200
     duration: ""
@@ -2531,29 +2643,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.903587+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:4c:d3","maintenances":[],"modification_date":"2023-10-24T16:04:22.979126+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.903587+00:00","export_uri":null,"id":"b35d0064-0b1a-4028-a96a-89af435409eb","modification_date":"2023-10-24T16:03:15.903587+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:33:19.647374+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2766"
+      - "2788"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:23 GMT
+      - Thu, 22 Feb 2024 07:33:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2561,7 +2673,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f40865d7-ae8e-4b26-a982-0be526fb64db
+      - f5bfb6cc-4488-4eae-a556-40beaa597be8
     status: 200 OK
     code: 200
     duration: ""
@@ -2570,9 +2682,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: DELETE
   response:
     body: ""
@@ -2580,9 +2692,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 24 Oct 2023 16:04:23 GMT
+      - Thu, 22 Feb 2024 07:33:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2590,7 +2702,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3472ddf-fe7b-47d4-a345-2b13e1834ac6
+      - 24229c34-de47-4dbf-8bfc-5720545a382b
     status: 204 No Content
     code: 204
     duration: ""
@@ -2599,12 +2711,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -2613,9 +2725,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:23 GMT
+      - Thu, 22 Feb 2024 07:33:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2623,7 +2735,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfbb5451-8810-4507-88c1-a4630dbd556d
+      - 75aaeaef-8b1b-41f6-a70a-9c40fa3bd2d6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2632,9 +2744,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/b35d0064-0b1a-4028-a96a-89af435409eb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/501a5e3d-0dbd-4162-a38f-32113a5f2487
     method: DELETE
   response:
     body: ""
@@ -2642,9 +2754,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 24 Oct 2023 16:04:23 GMT
+      - Thu, 22 Feb 2024 07:33:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2652,7 +2764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6190b93a-4f6c-486c-88c2-55d8a3d9911d
+      - f681d10e-2125-482e-adbe-1120b05879de
     status: 204 No Content
     code: 204
     duration: ""
@@ -2661,9 +2773,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
     method: GET
   response:
     body: '{"message":"lbs not Found"}'
@@ -2675,9 +2787,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:36 GMT
+      - Thu, 22 Feb 2024 07:33:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2685,7 +2797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17e1bb72-d80f-411c-9137-72fdbd546a7e
+      - 53b272f5-4cbd-4fb7-8727-20aa139a69c3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2694,9 +2806,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/b952606a-4c72-43d4-9097-e66cedabd181
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
     method: GET
   response:
     body: '{"message":"lbs not Found"}'
@@ -2708,9 +2820,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:36 GMT
+      - Thu, 22 Feb 2024 07:33:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2718,7 +2830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fdb28df-3313-4ebb-b9d1-05aff12af774
+      - adc44546-c063-40b8-b0bf-525191e4fef1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2727,23 +2839,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/c8f1c1ef-0350-426f-8e79-51b1d44e04b0
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/69bad162-3fb1-4469-8f16-70485430ab8a
     method: GET
   response:
-    body: '{"id":"c8f1c1ef-0350-426f-8e79-51b1d44e04b0","ip_address":"51.159.74.42","lb_id":null,"organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-159-74-42.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    body: '{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "276"
+      - "287"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:37 GMT
+      - Thu, 22 Feb 2024 07:33:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2751,7 +2863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88e19f39-a1a2-48bd-a394-1d6d631c8ec8
+      - d696ca11-9ed5-4f89-b80e-0aa88b6575e7
     status: 200 OK
     code: 200
     duration: ""
@@ -2760,9 +2872,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/c8f1c1ef-0350-426f-8e79-51b1d44e04b0
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/69bad162-3fb1-4469-8f16-70485430ab8a
     method: DELETE
   response:
     body: ""
@@ -2772,9 +2884,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:37 GMT
+      - Thu, 22 Feb 2024 07:33:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2782,7 +2894,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcb3871e-e3d6-4d89-9244-9a07035b6d6b
+      - 19a02cb3-f5a2-48e7-9663-60130a854a21
     status: 204 No Content
     code: 204
     duration: ""
@@ -2791,12 +2903,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/58a8f734-7250-488b-a6d4-5d6f4b4a7ece
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"58a8f734-7250-488b-a6d4-5d6f4b4a7ece","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -2805,9 +2917,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:37 GMT
+      - Thu, 22 Feb 2024 07:33:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2815,7 +2927,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10d22c82-e586-4c19-b297-46ab06640e57
+      - 7734166c-bd1f-4563-a83a-670b7886f14b
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-ipamip-instance-lb.cassette.yaml
+++ b/scaleway/testdata/data-source-ipamip-instance-lb.cassette.yaml
@@ -20,7 +20,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:44:21 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -30,45 +30,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ab040e1-9b22-49c7-967b-ad257a714941
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
-    method: GET
-  response:
-    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
-    headers:
-      Content-Length:
-      - "38183"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
-      Link:
-      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
-        rel="last"
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 90e3957d-fa80-403f-a83d-1f3580c7482a
-      X-Total-Count:
-      - "61"
+      - 1c17c958-788b-46bb-84a9-7f16acb90435
     status: 200 OK
     code: 200
     duration: ""
@@ -93,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:44:21 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -103,7 +65,80 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d85bd67-c862-4eda-bc53-082339e83742
+      - d1c159ef-ea3b-4274-b2b4-98aefe20dfe6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+    method: GET
+  response:
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
+    headers:
+      Content-Length:
+      - "38183"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:44:21 GMT
+      Link:
+      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8cd0b5bc-7dae-4fe6-b21c-51a27386ac7c
+      X-Total-Count:
+      - "61"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+    method: POST
+  response:
+    body: '{"created_at":"2024-02-22T07:44:21.271793Z","id":"f2816ad2-29c5-47dd-bfbe-65d507d02b00","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:44:21.271793Z"}'
+    headers:
+      Content-Length:
+      - "368"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:44:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c601485c-bd70-43c2-9168-2f5efe18b235
     status: 200 OK
     code: 200
     duration: ""
@@ -126,7 +161,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:44:21 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -136,7 +171,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e36756d-8e77-4985-91ae-88d4d7423806
+      - 70599293-6d2c-4b72-803f-ffb2b698ee21
     status: 200 OK
     code: 200
     duration: ""
@@ -159,7 +194,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:44:21 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
@@ -172,44 +207,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a098db7a-1909-41a2-9106-b22bbccb0241
+      - 91fd6861-1feb-4012-866e-ba411828759e
       X-Total-Count:
       - "61"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
-    method: POST
-  response:
-    body: '{"created_at":"2024-02-22T07:32:02.379740Z","id":"e67ee4ac-8ce7-4a13-9182-54b6be4c8610","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:32:02.379740Z"}'
-    headers:
-      Content-Length:
-      - "368"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0aebc687-fb58-42b1-b643-c444cf21016a
     status: 200 OK
     code: 200
     duration: ""
@@ -220,10 +220,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/e67ee4ac-8ce7-4a13-9182-54b6be4c8610
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/f2816ad2-29c5-47dd-bfbe-65d507d02b00
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:02.379740Z","id":"e67ee4ac-8ce7-4a13-9182-54b6be4c8610","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:32:02.379740Z"}'
+    body: '{"created_at":"2024-02-22T07:44:21.271793Z","id":"f2816ad2-29c5-47dd-bfbe-65d507d02b00","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:44:21.271793Z"}'
     headers:
       Content-Length:
       - "368"
@@ -232,7 +232,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:44:21 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -242,12 +242,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 936f3634-7d1e-4963-96fb-fcb8b9570ef4
+      - f5036cbd-5216-4f87-82b9-9f8579a3a155
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-lb-sad-bassi","description":"","ip_id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_ids":null,"tags":null,"type":"LB-S","ssl_compatibility_level":"ssl_compatibility_level_intermediate"}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-lb-heuristic-feynman","description":"","ip_id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_ids":null,"tags":null,"type":"LB-S","ssl_compatibility_level":"ssl_compatibility_level_intermediate"}'
     form: {}
     headers:
       Content-Type:
@@ -258,16 +258,16 @@ interactions:
     url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs
     method: POST
   response:
-    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394172Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:02.656394172Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:44:21.517853430Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:21.517853430Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "894"
+      - "902"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:44:21 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -277,7 +277,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4122fe2-dd04-47ee-8af6-b33e27a2097b
+      - 7c68c233-e833-4cb7-924d-881973fe6e7d
     status: 200 OK
     code: 200
     duration: ""
@@ -288,19 +288,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:02.656394Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"unknown","updated_at":"2024-02-22T07:44:21.761402Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"creating","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:21.773530Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "888"
+      - "1103"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:44:21 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -310,12 +310,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74847ddd-47ad-44a0-b443-f7ef41db607d
+      - dc14cf25-ef69-47eb-9767-fdd20ad59fac
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null,"vpc_id":"e67ee4ac-8ce7-4a13-9182-54b6be4c8610"}'
+    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null,"vpc_id":"f2816ad2-29c5-47dd-bfbe-65d507d02b00"}'
     form: {}
     headers:
       Content-Type:
@@ -326,7 +326,7 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2024-02-22T07:32:02.726153Z","dhcp_enabled":true,"id":"24ff3f79-71d1-466a-959e-967ffcc2411c","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.726153Z","id":"37e55226-bd93-4392-ac5b-2872a9a7b32f","subnet":"172.16.28.0/22","updated_at":"2024-02-22T07:32:02.726153Z"},{"created_at":"2024-02-22T07:32:02.726153Z","id":"e202ee55-746c-4115-891d-186158c139d9","subnet":"fd5f:519c:6d46:7d5b::/64","updated_at":"2024-02-22T07:32:02.726153Z"}],"tags":[],"updated_at":"2024-02-22T07:32:02.726153Z","vpc_id":"e67ee4ac-8ce7-4a13-9182-54b6be4c8610"}'
+    body: '{"created_at":"2024-02-22T07:44:21.457717Z","dhcp_enabled":true,"id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:44:21.457717Z","id":"8a310995-8480-4aa8-8759-5857848961fd","subnet":"172.16.28.0/22","updated_at":"2024-02-22T07:44:21.457717Z"},{"created_at":"2024-02-22T07:44:21.457717Z","id":"b8efd6b8-c19f-4efd-8cbc-14ffb94f5f0f","subnet":"fd5f:519c:6d46:bf04::/64","updated_at":"2024-02-22T07:44:21.457717Z"}],"tags":[],"updated_at":"2024-02-22T07:44:21.457717Z","vpc_id":"f2816ad2-29c5-47dd-bfbe-65d507d02b00"}'
     headers:
       Content-Length:
       - "737"
@@ -335,7 +335,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:44:21 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -345,7 +345,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbe0e823-80d4-450f-bf52-f8a196d28d49
+      - 41c180af-a3e1-4ed8-9a91-8bca69111718
     status: 200 OK
     code: 200
     duration: ""
@@ -356,10 +356,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/24ff3f79-71d1-466a-959e-967ffcc2411c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fdd36901-de79-4e24-8fe4-6a538b0cb746
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:02.726153Z","dhcp_enabled":true,"id":"24ff3f79-71d1-466a-959e-967ffcc2411c","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.726153Z","id":"37e55226-bd93-4392-ac5b-2872a9a7b32f","subnet":"172.16.28.0/22","updated_at":"2024-02-22T07:32:02.726153Z"},{"created_at":"2024-02-22T07:32:02.726153Z","id":"e202ee55-746c-4115-891d-186158c139d9","subnet":"fd5f:519c:6d46:7d5b::/64","updated_at":"2024-02-22T07:32:02.726153Z"}],"tags":[],"updated_at":"2024-02-22T07:32:02.726153Z","vpc_id":"e67ee4ac-8ce7-4a13-9182-54b6be4c8610"}'
+    body: '{"created_at":"2024-02-22T07:44:21.457717Z","dhcp_enabled":true,"id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:44:21.457717Z","id":"8a310995-8480-4aa8-8759-5857848961fd","subnet":"172.16.28.0/22","updated_at":"2024-02-22T07:44:21.457717Z"},{"created_at":"2024-02-22T07:44:21.457717Z","id":"b8efd6b8-c19f-4efd-8cbc-14ffb94f5f0f","subnet":"fd5f:519c:6d46:bf04::/64","updated_at":"2024-02-22T07:44:21.457717Z"}],"tags":[],"updated_at":"2024-02-22T07:44:21.457717Z","vpc_id":"f2816ad2-29c5-47dd-bfbe-65d507d02b00"}'
     headers:
       Content-Length:
       - "737"
@@ -368,7 +368,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:44:21 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -378,7 +378,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38e80175-639b-4d30-ba4a-66bcecb269e7
+      - 292ad778-f545-45a9-a95d-09d1bc0f34fb
     status: 200 OK
     code: 200
     duration: ""
@@ -396,11 +396,11 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:03.144335+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:44:22.111543+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2788"
@@ -409,9 +409,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:44:22 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -421,7 +421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50b1ca6b-b5eb-4e53-8dfa-e2538bc6a32c
+      - a3888598-f5cd-4cd2-afa0-5c7fa7aac039
     status: 201 Created
     code: 201
     duration: ""
@@ -432,16 +432,16 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:03.144335+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:44:22.111543+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2788"
@@ -450,7 +450,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:44:22 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -460,7 +460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf208ba2-9df4-453c-8c0a-abd75ec9eaad
+      - 36016697-be3f-4f60-9b82-c9a1b5960d85
     status: 200 OK
     code: 200
     duration: ""
@@ -471,16 +471,16 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:03.144335+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:44:22.111543+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2788"
@@ -489,7 +489,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:44:23 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -499,7 +499,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81d74ea3-08d1-4716-a382-38e1d6ff96af
+      - 2d8eac3c-62d6-45e4-8e7c-b89a8cfea644
     status: 200 OK
     code: 200
     duration: ""
@@ -512,10 +512,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/action","href_result":"/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f","id":"20cf0172-9872-4a31-932f-dffd93aca242","started_at":"2024-02-22T07:32:04.004051+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/action","href_result":"/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0","id":"92b412f2-8cbf-420d-9cf9-b9e38ffc41f2","started_at":"2024-02-22T07:44:23.350824+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -524,9 +524,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:04 GMT
+      - Thu, 22 Feb 2024 07:44:23 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/20cf0172-9872-4a31-932f-dffd93aca242
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/92b412f2-8cbf-420d-9cf9-b9e38ffc41f2
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -536,7 +536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79d5fc3a-e2fd-4f83-81c5-961b07fc7c27
+      - 2805930c-826f-422d-bfc9-700175d53c6e
     status: 202 Accepted
     code: 202
     duration: ""
@@ -547,16 +547,16 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:03.812103+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:44:23.147272+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2810"
@@ -565,7 +565,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:04 GMT
+      - Thu, 22 Feb 2024 07:44:23 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -575,7 +575,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f74b929-a93f-4691-9192-cee7de39ae7a
+      - c0871ef7-facd-4f19-ae31-5f27cddff653
     status: 200 OK
     code: 200
     duration: ""
@@ -586,25 +586,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:03.812103+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"101","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:44:23.147272+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.40.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2919"
+      - "2917"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:09 GMT
+      - Thu, 22 Feb 2024 07:44:29 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -614,7 +614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b317bf46-8831-42e9-85e3-593d55bdde89
+      - 81feaf7c-b8f3-4359-a2a9-f7f7f9957542
     status: 200 OK
     code: 200
     duration: ""
@@ -625,64 +625,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:03.812103+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2919"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 01a07d15-8c14-43b4-8c3a-a473168226ee
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:15.362228+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"101","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:44:29.855424+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.40.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2950"
+      - "2948"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:19 GMT
+      - Thu, 22 Feb 2024 07:44:34 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -692,7 +653,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49ab05e4-294f-4b5d-8149-feee484810e0
+      - ae8c6d28-e8df-40c2-824c-2eae71edd75f
     status: 200 OK
     code: 200
     duration: ""
@@ -703,25 +664,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:15.362228+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"101","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:44:29.855424+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.40.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2950"
+      - "2948"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:19 GMT
+      - Thu, 22 Feb 2024 07:44:34 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -731,7 +692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b49a7a38-d95e-4906-90f4-1798b244dc3c
+      - 838de3f5-466c-4e30-aaad-f6e7ca5c37c4
     status: 200 OK
     code: 200
     duration: ""
@@ -742,7 +703,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -754,7 +715,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:20 GMT
+      - Thu, 22 Feb 2024 07:44:34 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -764,7 +725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4377cf7e-ccd2-4420-a784-c056cada628f
+      - 1960c2e8-6a9e-4a35-a0ae-936b266377ac
     status: 200 OK
     code: 200
     duration: ""
@@ -775,7 +736,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -787,9 +748,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:20 GMT
+      - Thu, 22 Feb 2024 07:44:34 GMT
       Link:
-      - </servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics?page=0&per_page=50&>;
+      - </servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
@@ -800,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ab587a5-5636-4495-8adf-ec638fa47f05
+      - cc63c9ae-225d-47d0-8d6f-4c3d0875d1df
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -813,25 +774,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:15.362228+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"101","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:44:29.855424+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.40.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2950"
+      - "2948"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:20 GMT
+      - Thu, 22 Feb 2024 07:44:34 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -841,12 +802,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41b2b3a6-dd38-4ba5-8250-f50cfccb055c
+      - c27ba55d-57cc-4fa2-8b21-b1642cf35e07
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c"}'
+    body: '{"private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746"}'
     form: {}
     headers:
       Content-Type:
@@ -854,10 +815,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:20.300551+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:44:34.925318+00:00","id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8b:c3","modification_date":"2024-02-22T07:44:34.925318+00:00","private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","server_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -866,7 +827,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:20 GMT
+      - Thu, 22 Feb 2024 07:44:35 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -876,7 +837,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a8068bc-abc1-414b-bec0-18079d42e732
+      - 833bbd3d-83ce-47ad-916e-c1e974adab50
     status: 201 Created
     code: 201
     duration: ""
@@ -887,10 +848,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics/7da323ac-12a7-4bb6-bcaa-ad332049d19d
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:20.300551+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:44:34.925318+00:00","id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8b:c3","modification_date":"2024-02-22T07:44:34.925318+00:00","private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","server_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -899,7 +860,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:20 GMT
+      - Thu, 22 Feb 2024 07:44:35 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -909,7 +870,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55eb594d-32ec-492c-b5f7-bced3c30a437
+      - 0a9e8f3f-9161-4951-a3af-a9b44ab99551
     status: 200 OK
     code: 200
     duration: ""
@@ -920,10 +881,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics/7da323ac-12a7-4bb6-bcaa-ad332049d19d
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:21.235145+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:44:34.925318+00:00","id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8b:c3","modification_date":"2024-02-22T07:44:35.637387+00:00","private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","server_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -932,7 +893,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:26 GMT
+      - Thu, 22 Feb 2024 07:44:40 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -942,7 +903,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb9885e0-6468-46ce-b08a-6619f6bec495
+      - 590fab4f-a035-40e3-b434-dad328a7309e
     status: 200 OK
     code: 200
     duration: ""
@@ -953,10 +914,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics/7da323ac-12a7-4bb6-bcaa-ad332049d19d
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:21.235145+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:44:34.925318+00:00","id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8b:c3","modification_date":"2024-02-22T07:44:35.637387+00:00","private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","server_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -965,7 +926,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:31 GMT
+      - Thu, 22 Feb 2024 07:44:45 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -975,7 +936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52850186-1e72-4756-bdd4-350600fddc47
+      - 1d8e7f9f-7af3-4adb-b1d6-7b5bd9f4f06b
     status: 200 OK
     code: 200
     duration: ""
@@ -986,19 +947,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics/7da323ac-12a7-4bb6-bcaa-ad332049d19d
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:08.876569Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:44:34.925318+00:00","id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8b:c3","modification_date":"2024-02-22T07:44:35.637387+00:00","private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","server_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "1090"
+      - "376"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:33 GMT
+      - Thu, 22 Feb 2024 07:44:50 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1008,7 +969,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0f1fa0a-2550-4eb7-87f8-0c0331396130
+      - 4351fbdf-5a19-426b-bb49-24c226c666f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1019,19 +980,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:08.876569Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:44:26.799386Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:28.176885Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1090"
+      - "1098"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:33 GMT
+      - Thu, 22 Feb 2024 07:44:51 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1041,7 +1002,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8d7f2a7-ff03-4be5-83ba-58c3d8df9511
+      - 6ad1c206-440e-42ee-9c2b-157ba221cdd4
     status: 200 OK
     code: 200
     duration: ""
@@ -1052,7 +1013,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1/private-networks?order_by=created_at_asc
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
+    method: GET
+  response:
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:44:26.799386Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:28.176885Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1098"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:44:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5b9f20f0-3241-4902-8c5e-83a79d4e0da0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2/private-networks?order_by=created_at_asc
     method: GET
   response:
     body: '{"private_network":[],"total_count":0}'
@@ -1064,7 +1058,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:33 GMT
+      - Thu, 22 Feb 2024 07:44:52 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1074,7 +1068,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3643e774-6796-4cbf-8e0f-73cf6dc33eb8
+      - 2a79ae82-2138-45f7-ad04-2f66c61019b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1085,10 +1079,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics/7da323ac-12a7-4bb6-bcaa-ad332049d19d
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:21.235145+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:44:34.925318+00:00","id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8b:c3","modification_date":"2024-02-22T07:44:35.637387+00:00","private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","server_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1097,7 +1091,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:36 GMT
+      - Thu, 22 Feb 2024 07:44:55 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1107,7 +1101,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae6c3e0c-4008-4106-af1d-5877a584edf0
+      - 09d63f2f-565f-4600-a73a-800ffe377c6e
     status: 200 OK
     code: 200
     duration: ""
@@ -1118,10 +1112,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics/7da323ac-12a7-4bb6-bcaa-ad332049d19d
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:21.235145+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:44:34.925318+00:00","id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8b:c3","modification_date":"2024-02-22T07:44:35.637387+00:00","private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","server_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1130,7 +1124,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:41 GMT
+      - Thu, 22 Feb 2024 07:45:00 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1140,7 +1134,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55b839c5-f33d-4034-adf5-a0e71d77229b
+      - 5f9e043b-349d-4033-9dfd-bdd64c1ed93f
     status: 200 OK
     code: 200
     duration: ""
@@ -1151,10 +1145,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics/7da323ac-12a7-4bb6-bcaa-ad332049d19d
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:21.235145+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:44:34.925318+00:00","id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8b:c3","modification_date":"2024-02-22T07:44:35.637387+00:00","private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","server_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1163,7 +1157,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:46 GMT
+      - Thu, 22 Feb 2024 07:45:05 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1173,7 +1167,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6557256-9056-481c-bbee-a1f7bcb745bb
+      - 82430afd-7aca-484a-ad69-aac1acba0b65
     status: 200 OK
     code: 200
     duration: ""
@@ -1184,43 +1178,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics/7da323ac-12a7-4bb6-bcaa-ad332049d19d
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:21.235145+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:51 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - adfe6a25-cf5d-4b32-bdce-2abfa448a575
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:51.647676+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:44:34.925318+00:00","id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8b:c3","modification_date":"2024-02-22T07:45:05.992112+00:00","private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","server_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1229,7 +1190,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:56 GMT
+      - Thu, 22 Feb 2024 07:45:11 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1239,7 +1200,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2fb33be-cffb-4254-a9dc-f013ca849bc5
+      - 0b13e2e2-158d-46bc-8a24-afc48ef5c4d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1250,10 +1211,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics/7da323ac-12a7-4bb6-bcaa-ad332049d19d
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:51.647676+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:44:34.925318+00:00","id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8b:c3","modification_date":"2024-02-22T07:45:05.992112+00:00","private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","server_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1262,7 +1223,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:56 GMT
+      - Thu, 22 Feb 2024 07:45:11 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1272,7 +1233,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2495797-463f-4804-a10c-eaedd9423cc9
+      - caf6e9d1-9aa1-49c1-9d1b-848dcd9154d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1283,10 +1244,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab1&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ac3&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-22T07:32:21.158150Z","id":"637eb92e-c2f0-4134-b3e1-ff9eb095bb26","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8B:B1","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"37e55226-bd93-4392-ac5b-2872a9a7b32f"},"tags":[],"updated_at":"2024-02-22T07:32:21.158150Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-22T07:44:35.530272Z","id":"63ffda1e-4743-4a64-831c-be2e239b5b27","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8B:C3","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"8a310995-8480-4aa8-8759-5857848961fd"},"tags":[],"updated_at":"2024-02-22T07:44:35.530272Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
       - "550"
@@ -1295,7 +1256,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:56 GMT
+      - Thu, 22 Feb 2024 07:45:11 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1305,7 +1266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17a4f4cd-e441-4b78-97b0-28b7900853a3
+      - 261cfc71-cd8a-42a3-aba3-6721892077b4
     status: 200 OK
     code: 200
     duration: ""
@@ -1316,19 +1277,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:08.876569Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:44:26.799386Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:28.176885Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1090"
+      - "1098"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:56 GMT
+      - Thu, 22 Feb 2024 07:45:11 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1338,12 +1299,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8238807-9605-4143-a232-31f8ec883141
+      - 2471b051-100d-4893-8417-46f6de3a5012
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-lb-bkd-great-mclaren","forward_protocol":"http","forward_port":80,"forward_port_algorithm":"roundrobin","sticky_sessions":"none","sticky_sessions_cookie_name":"","health_check":{"port":80,"check_max_retries":2,"check_send_proxy":false,"transient_check_delay":"0.500000000s","check_delay":60000,"check_timeout":30000},"server_ip":["172.16.28.2"],"on_marked_down_action":"on_marked_down_action_none","proxy_protocol":"proxy_protocol_none","ssl_bridging":false,"ignore_ssl_server_verify":false,"max_retries":3,"timeout_queue":"0.000000000s","timeout_server":300000,"timeout_connect":5000,"timeout_tunnel":900000}'
+    body: '{"name":"tf-lb-bkd-determined-goldberg","forward_protocol":"http","forward_port":80,"forward_port_algorithm":"roundrobin","sticky_sessions":"none","sticky_sessions_cookie_name":"","health_check":{"port":80,"check_max_retries":2,"check_send_proxy":false,"transient_check_delay":"0.500000000s","check_delay":60000,"check_timeout":30000},"server_ip":["172.16.28.2"],"on_marked_down_action":"on_marked_down_action_none","proxy_protocol":"proxy_protocol_none","ssl_bridging":false,"ignore_ssl_server_verify":false,"max_retries":3,"timeout_queue":"0.000000000s","timeout_server":300000,"timeout_connect":5000,"timeout_tunnel":900000}'
     form: {}
     headers:
       Content-Type:
@@ -1351,19 +1312,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1/backends
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2/backends
     method: POST
   response:
-    body: '{"created_at":"2024-02-22T07:32:56.840818932Z","failover_host":null,"forward_port":80,"forward_port_algorithm":"roundrobin","forward_protocol":"http","health_check":{"check_delay":60000,"check_max_retries":2,"check_send_proxy":false,"check_timeout":30000,"port":80,"tcp_config":{},"transient_check_delay":"0.500s"},"id":"15b3c4a5-00a6-4631-91ed-667014726de9","ignore_ssl_server_verify":false,"lb":{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"pending","updated_at":"2024-02-22T07:32:56.883864384Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"},"max_connections":null,"max_retries":3,"name":"tf-lb-bkd-great-mclaren","on_marked_down_action":"on_marked_down_action_none","pool":["172.16.28.2"],"proxy_protocol":"proxy_protocol_none","redispatch_attempt_count":null,"send_proxy_v2":false,"ssl_bridging":false,"sticky_sessions":"none","sticky_sessions_cookie_name":"","timeout_connect":5000,"timeout_queue":"0s","timeout_server":300000,"timeout_tunnel":900000,"updated_at":"2024-02-22T07:32:56.840818932Z"}'
+    body: '{"created_at":"2024-02-22T07:45:11.367743861Z","failover_host":null,"forward_port":80,"forward_port_algorithm":"roundrobin","forward_protocol":"http","health_check":{"check_delay":60000,"check_max_retries":2,"check_send_proxy":false,"check_timeout":30000,"port":80,"tcp_config":{},"transient_check_delay":"0.500s"},"id":"3cdfcf40-418d-4f7f-ad27-e817fd537dcf","ignore_ssl_server_verify":false,"lb":{"backend_count":1,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"pending","updated_at":"2024-02-22T07:45:11.399024807Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:28.176885Z","zone":"fr-par-1"},"max_connections":null,"max_retries":3,"name":"tf-lb-bkd-determined-goldberg","on_marked_down_action":"on_marked_down_action_none","pool":["172.16.28.2"],"proxy_protocol":"proxy_protocol_none","redispatch_attempt_count":null,"send_proxy_v2":false,"ssl_bridging":false,"sticky_sessions":"none","sticky_sessions_cookie_name":"","timeout_connect":5000,"timeout_queue":"0s","timeout_server":300000,"timeout_tunnel":900000,"updated_at":"2024-02-22T07:45:11.367743861Z"}'
     headers:
       Content-Length:
-      - "1981"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:57 GMT
+      - Thu, 22 Feb 2024 07:45:11 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1373,7 +1334,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a38ef4d-08c9-4844-8055-a2523d127298
+      - 2713e8a6-e759-47c4-adb2-13d6992c23e1
     status: 200 OK
     code: 200
     duration: ""
@@ -1384,19 +1345,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
     method: GET
   response:
-    body: '{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"pending","updated_at":"2024-02-22T07:32:56.883864Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
+    body: '{"backend_count":1,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"pending","updated_at":"2024-02-22T07:45:11.399025Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:28.176885Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1092"
+      - "1100"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:57 GMT
+      - Thu, 22 Feb 2024 07:45:11 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1406,7 +1367,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c383ac74-e82a-4013-ad53-051fb9435f9e
+      - b5ec07c5-218d-4fc7-9a8c-7883aaf4b8e0
     status: 200 OK
     code: 200
     duration: ""
@@ -1417,19 +1378,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/backends/15b3c4a5-00a6-4631-91ed-667014726de9
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/backends/3cdfcf40-418d-4f7f-ad27-e817fd537dcf
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:56.840819Z","failover_host":null,"forward_port":80,"forward_port_algorithm":"roundrobin","forward_protocol":"http","health_check":{"check_delay":60000,"check_max_retries":2,"check_send_proxy":false,"check_timeout":30000,"port":80,"tcp_config":{},"transient_check_delay":"0.500s"},"id":"15b3c4a5-00a6-4631-91ed-667014726de9","ignore_ssl_server_verify":false,"lb":{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"pending","updated_at":"2024-02-22T07:32:56.883864Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"},"max_connections":null,"max_retries":3,"name":"tf-lb-bkd-great-mclaren","on_marked_down_action":"on_marked_down_action_none","pool":["172.16.28.2"],"proxy_protocol":"proxy_protocol_none","redispatch_attempt_count":null,"send_proxy_v2":false,"ssl_bridging":false,"sticky_sessions":"none","sticky_sessions_cookie_name":"","timeout_connect":5000,"timeout_queue":"0s","timeout_server":300000,"timeout_tunnel":900000,"updated_at":"2024-02-22T07:32:56.840819Z"}'
+    body: '{"created_at":"2024-02-22T07:45:11.367744Z","failover_host":null,"forward_port":80,"forward_port_algorithm":"roundrobin","forward_protocol":"http","health_check":{"check_delay":60000,"check_max_retries":2,"check_send_proxy":false,"check_timeout":30000,"port":80,"tcp_config":{},"transient_check_delay":"0.500s"},"id":"3cdfcf40-418d-4f7f-ad27-e817fd537dcf","ignore_ssl_server_verify":false,"lb":{"backend_count":1,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:45:11.668388Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:28.176885Z","zone":"fr-par-1"},"max_connections":null,"max_retries":3,"name":"tf-lb-bkd-determined-goldberg","on_marked_down_action":"on_marked_down_action_none","pool":["172.16.28.2"],"proxy_protocol":"proxy_protocol_none","redispatch_attempt_count":null,"send_proxy_v2":false,"ssl_bridging":false,"sticky_sessions":"none","sticky_sessions_cookie_name":"","timeout_connect":5000,"timeout_queue":"0s","timeout_server":300000,"timeout_tunnel":900000,"updated_at":"2024-02-22T07:45:11.367744Z"}'
     headers:
       Content-Length:
-      - "1972"
+      - "1984"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:57 GMT
+      - Thu, 22 Feb 2024 07:45:11 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1439,7 +1400,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac5b2178-a1ad-4fe1-9e10-cff3ffed9555
+      - 64e063c0-d3ab-4abc-b9ae-a3d725bb859f
     status: 200 OK
     code: 200
     duration: ""
@@ -1450,19 +1411,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
     method: GET
   response:
-    body: '{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:57.182574Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
+    body: '{"backend_count":1,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:45:11.668388Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:28.176885Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1090"
+      - "1098"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:57 GMT
+      - Thu, 22 Feb 2024 07:45:11 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1472,7 +1433,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b06eca4a-3ad2-4fa9-ab0f-37a1b2b0f029
+      - ebd6c71f-fa04-46fd-a6e1-cdd0f2326fcf
     status: 200 OK
     code: 200
     duration: ""
@@ -1483,10 +1444,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab1&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ac3&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-22T07:32:21.158150Z","id":"637eb92e-c2f0-4134-b3e1-ff9eb095bb26","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8B:B1","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"37e55226-bd93-4392-ac5b-2872a9a7b32f"},"tags":[],"updated_at":"2024-02-22T07:32:21.158150Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-22T07:44:35.530272Z","id":"63ffda1e-4743-4a64-831c-be2e239b5b27","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8B:C3","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"8a310995-8480-4aa8-8759-5857848961fd"},"tags":[],"updated_at":"2024-02-22T07:44:35.530272Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
       - "550"
@@ -1495,7 +1456,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:57 GMT
+      - Thu, 22 Feb 2024 07:45:12 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1505,40 +1466,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c55a4474-3901-4f22-a8bc-3e7c5e31676d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/e67ee4ac-8ce7-4a13-9182-54b6be4c8610
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-22T07:32:02.379740Z","id":"e67ee4ac-8ce7-4a13-9182-54b6be4c8610","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:32:02.379740Z"}'
-    headers:
-      Content-Length:
-      - "368"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:58 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1df1df9b-905e-418e-8816-8025dd128e0e
+      - 0075ecef-4aa5-4b87-b1bb-e261c083b935
     status: 200 OK
     code: 200
     duration: ""
@@ -1552,7 +1480,7 @@ interactions:
     url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/69bad162-3fb1-4469-8f16-70485430ab8a
     method: GET
   response:
-    body: '{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    body: '{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "321"
@@ -1561,7 +1489,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:58 GMT
+      - Thu, 22 Feb 2024 07:45:12 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1571,7 +1499,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f5fec61-3f79-450c-a6af-6ad6ec987852
+      - a2cdd862-6643-4ff9-8f17-b73072f9ee1b
     status: 200 OK
     code: 200
     duration: ""
@@ -1582,10 +1510,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/24ff3f79-71d1-466a-959e-967ffcc2411c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/f2816ad2-29c5-47dd-bfbe-65d507d02b00
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:02.726153Z","dhcp_enabled":true,"id":"24ff3f79-71d1-466a-959e-967ffcc2411c","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.726153Z","id":"37e55226-bd93-4392-ac5b-2872a9a7b32f","subnet":"172.16.28.0/22","updated_at":"2024-02-22T07:32:02.726153Z"},{"created_at":"2024-02-22T07:32:02.726153Z","id":"e202ee55-746c-4115-891d-186158c139d9","subnet":"fd5f:519c:6d46:7d5b::/64","updated_at":"2024-02-22T07:32:02.726153Z"}],"tags":[],"updated_at":"2024-02-22T07:32:02.726153Z","vpc_id":"e67ee4ac-8ce7-4a13-9182-54b6be4c8610"}'
+    body: '{"created_at":"2024-02-22T07:44:21.271793Z","id":"f2816ad2-29c5-47dd-bfbe-65d507d02b00","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:44:21.271793Z"}'
+    headers:
+      Content-Length:
+      - "368"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:45:12 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7042de43-f3a9-40a1-9f08-8de865216037
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fdd36901-de79-4e24-8fe4-6a538b0cb746
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-22T07:44:21.457717Z","dhcp_enabled":true,"id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:44:21.457717Z","id":"8a310995-8480-4aa8-8759-5857848961fd","subnet":"172.16.28.0/22","updated_at":"2024-02-22T07:44:21.457717Z"},{"created_at":"2024-02-22T07:44:21.457717Z","id":"b8efd6b8-c19f-4efd-8cbc-14ffb94f5f0f","subnet":"fd5f:519c:6d46:bf04::/64","updated_at":"2024-02-22T07:44:21.457717Z"}],"tags":[],"updated_at":"2024-02-22T07:44:21.457717Z","vpc_id":"f2816ad2-29c5-47dd-bfbe-65d507d02b00"}'
     headers:
       Content-Length:
       - "737"
@@ -1594,7 +1555,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:58 GMT
+      - Thu, 22 Feb 2024 07:45:12 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1604,7 +1565,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d59179e-4aba-42f8-bccf-220760c398a3
+      - 656e9be1-4fe3-405c-a35c-8dc369c7f859
     status: 200 OK
     code: 200
     duration: ""
@@ -1615,25 +1576,58 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
+    method: GET
+  response:
+    body: '{"backend_count":1,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:45:11.668388Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:28.176885Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1098"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:45:12 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c15dc570-a944-4a57-a6c9-6f8093dfc2d8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:15.362228+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:51.647676+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"101","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:44:29.855424+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.40.27","private_nics":[{"creation_date":"2024-02-22T07:44:34.925318+00:00","id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8b:c3","modification_date":"2024-02-22T07:45:05.992112+00:00","private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","server_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3303"
+      - "3301"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:58 GMT
+      - Thu, 22 Feb 2024 07:45:12 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1643,7 +1637,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f093fc9a-f523-413c-8326-a6b7053d1eb4
+      - d9fe93fc-4861-4f3a-9d08-0a3612cd36aa
     status: 200 OK
     code: 200
     duration: ""
@@ -1654,19 +1648,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
     method: GET
   response:
-    body: '{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:57.182574Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
+    body: '{"backend_count":1,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:45:11.668388Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:28.176885Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1090"
+      - "1098"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:58 GMT
+      - Thu, 22 Feb 2024 07:45:12 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1676,7 +1670,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb6ea37d-1f50-45aa-831e-83a7d34e5bab
+      - f31e1e0e-4913-4b76-aa5d-205a1c223cdb
     status: 200 OK
     code: 200
     duration: ""
@@ -1687,7 +1681,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1699,7 +1693,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:58 GMT
+      - Thu, 22 Feb 2024 07:45:12 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1709,7 +1703,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4091b98a-5c36-4a3b-a991-8d940ef91777
+      - 0a25f0d9-5256-4f46-8597-c314f3fcb3f6
     status: 200 OK
     code: 200
     duration: ""
@@ -1720,19 +1714,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2/private-networks?order_by=created_at_asc
     method: GET
   response:
-    body: '{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:57.182574Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
+    body: '{"private_network":[],"total_count":0}'
     headers:
       Content-Length:
-      - "1090"
+      - "39"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:58 GMT
+      - Thu, 22 Feb 2024 07:45:12 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1742,7 +1736,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a986aa8-d201-474b-a235-f50d3877e282
+      - ebe3dbb9-f177-47b8-96b3-be3e300186aa
     status: 200 OK
     code: 200
     duration: ""
@@ -1753,10 +1747,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:51.647676+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:44:34.925318+00:00","id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8b:c3","modification_date":"2024-02-22T07:45:05.992112+00:00","private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","server_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1765,9 +1759,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:58 GMT
+      - Thu, 22 Feb 2024 07:45:12 GMT
       Link:
-      - </servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics?page=1&per_page=50&>;
+      - </servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
@@ -1778,7 +1772,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98950720-6440-4f87-bf01-2e71ae9a035f
+      - 62735ab0-fb5e-47d0-ab2a-6d1ff8257d6c
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1791,43 +1785,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1/private-networks?order_by=created_at_asc
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics/7da323ac-12a7-4bb6-bcaa-ad332049d19d
     method: GET
   response:
-    body: '{"private_network":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "39"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:58 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6d2afff1-b3cf-472a-b5a2-a733544e51ab
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:51.647676+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:44:34.925318+00:00","id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8b:c3","modification_date":"2024-02-22T07:45:05.992112+00:00","private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","server_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1836,7 +1797,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:58 GMT
+      - Thu, 22 Feb 2024 07:45:12 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1846,7 +1807,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf20ee7f-e739-4e44-84cf-fbc4e5709a95
+      - 5259bb23-f1b7-499c-ad36-f7dce925c1e1
     status: 200 OK
     code: 200
     duration: ""
@@ -1857,10 +1818,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab1&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ac3&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-22T07:32:21.158150Z","id":"637eb92e-c2f0-4134-b3e1-ff9eb095bb26","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8B:B1","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"37e55226-bd93-4392-ac5b-2872a9a7b32f"},"tags":[],"updated_at":"2024-02-22T07:32:21.158150Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-22T07:44:35.530272Z","id":"63ffda1e-4743-4a64-831c-be2e239b5b27","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8B:C3","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"8a310995-8480-4aa8-8759-5857848961fd"},"tags":[],"updated_at":"2024-02-22T07:44:35.530272Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
       - "550"
@@ -1869,7 +1830,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:58 GMT
+      - Thu, 22 Feb 2024 07:45:12 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1879,7 +1840,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d176a972-bc81-46b6-b963-2f0571852698
+      - af64d6ce-e0a3-4596-9742-dc855a785890
     status: 200 OK
     code: 200
     duration: ""
@@ -1890,19 +1851,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/backends/15b3c4a5-00a6-4631-91ed-667014726de9
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/backends/3cdfcf40-418d-4f7f-ad27-e817fd537dcf
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:56.840819Z","failover_host":null,"forward_port":80,"forward_port_algorithm":"roundrobin","forward_protocol":"http","health_check":{"check_delay":60000,"check_max_retries":2,"check_send_proxy":false,"check_timeout":30000,"port":80,"tcp_config":{},"transient_check_delay":"0.500s"},"id":"15b3c4a5-00a6-4631-91ed-667014726de9","ignore_ssl_server_verify":false,"lb":{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:57.182574Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"},"max_connections":null,"max_retries":3,"name":"tf-lb-bkd-great-mclaren","on_marked_down_action":"on_marked_down_action_none","pool":["172.16.28.2"],"proxy_protocol":"proxy_protocol_none","redispatch_attempt_count":null,"send_proxy_v2":false,"ssl_bridging":false,"sticky_sessions":"none","sticky_sessions_cookie_name":"","timeout_connect":5000,"timeout_queue":"0s","timeout_server":300000,"timeout_tunnel":900000,"updated_at":"2024-02-22T07:32:56.840819Z"}'
+    body: '{"created_at":"2024-02-22T07:45:11.367744Z","failover_host":null,"forward_port":80,"forward_port_algorithm":"roundrobin","forward_protocol":"http","health_check":{"check_delay":60000,"check_max_retries":2,"check_send_proxy":false,"check_timeout":30000,"port":80,"tcp_config":{},"transient_check_delay":"0.500s"},"id":"3cdfcf40-418d-4f7f-ad27-e817fd537dcf","ignore_ssl_server_verify":false,"lb":{"backend_count":1,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:45:11.668388Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:28.176885Z","zone":"fr-par-1"},"max_connections":null,"max_retries":3,"name":"tf-lb-bkd-determined-goldberg","on_marked_down_action":"on_marked_down_action_none","pool":["172.16.28.2"],"proxy_protocol":"proxy_protocol_none","redispatch_attempt_count":null,"send_proxy_v2":false,"ssl_bridging":false,"sticky_sessions":"none","sticky_sessions_cookie_name":"","timeout_connect":5000,"timeout_queue":"0s","timeout_server":300000,"timeout_tunnel":900000,"updated_at":"2024-02-22T07:45:11.367744Z"}'
     headers:
       Content-Length:
-      - "1970"
+      - "1984"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:58 GMT
+      - Thu, 22 Feb 2024 07:45:13 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1912,7 +1873,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0993c41-c14d-421a-88aa-fd469145d882
+      - 5b9acaa0-9d21-4d62-9699-f0f154c6e036
     status: 200 OK
     code: 200
     duration: ""
@@ -1923,19 +1884,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
     method: GET
   response:
-    body: '{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:57.182574Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
+    body: '{"backend_count":1,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:45:11.668388Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:28.176885Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1090"
+      - "1098"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:58 GMT
+      - Thu, 22 Feb 2024 07:45:13 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1945,7 +1906,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b41a7918-cb09-4e01-83ae-255af9a04e9a
+      - f25e4be6-504d-4270-bda3-182a2e94bb38
     status: 200 OK
     code: 200
     duration: ""
@@ -1956,10 +1917,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab1&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ac3&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-22T07:32:21.158150Z","id":"637eb92e-c2f0-4134-b3e1-ff9eb095bb26","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8B:B1","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"37e55226-bd93-4392-ac5b-2872a9a7b32f"},"tags":[],"updated_at":"2024-02-22T07:32:21.158150Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.28.2/22","created_at":"2024-02-22T07:44:35.530272Z","id":"63ffda1e-4743-4a64-831c-be2e239b5b27","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8B:C3","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"8a310995-8480-4aa8-8759-5857848961fd"},"tags":[],"updated_at":"2024-02-22T07:44:35.530272Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
       - "550"
@@ -1968,7 +1929,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:59 GMT
+      - Thu, 22 Feb 2024 07:45:13 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1978,7 +1939,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 242921f2-1521-48af-adea-148f418a18f2
+      - 555a61e3-83e8-4adb-8617-033c470650cd
     status: 200 OK
     code: 200
     duration: ""
@@ -1989,19 +1950,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
     method: GET
   response:
-    body: '{"backend_count":1,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:57.182574Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
+    body: '{"backend_count":1,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:45:11.668388Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:28.176885Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1090"
+      - "1098"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:59 GMT
+      - Thu, 22 Feb 2024 07:45:14 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2011,7 +1972,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e5f6184-9f5b-42b4-9a0b-be803c3c9f71
+      - e0aacd20-0d41-4315-8a8d-ad96067684fd
     status: 200 OK
     code: 200
     duration: ""
@@ -2022,7 +1983,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/backends/15b3c4a5-00a6-4631-91ed-667014726de9
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/backends/3cdfcf40-418d-4f7f-ad27-e817fd537dcf
     method: DELETE
   response:
     body: ""
@@ -2032,7 +1993,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:59 GMT
+      - Thu, 22 Feb 2024 07:45:14 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2042,7 +2003,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45feaea7-3972-49a9-9b58-f8a86230f7d1
+      - b1efd5c5-4733-4fc7-a190-85f3f0f637c1
     status: 204 No Content
     code: 204
     duration: ""
@@ -2053,19 +2014,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"pending","updated_at":"2024-02-22T07:32:59.700879Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"pending","updated_at":"2024-02-22T07:45:14.343994Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:28.176885Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1092"
+      - "1100"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:59 GMT
+      - Thu, 22 Feb 2024 07:45:14 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2075,7 +2036,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd3954b6-2527-4695-aec3-3af01622f728
+      - cf5300b8-21af-4401-9751-2dcf33f07219
     status: 200 OK
     code: 200
     duration: ""
@@ -2086,10 +2047,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics/7da323ac-12a7-4bb6-bcaa-ad332049d19d
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:20.300551+00:00","id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","mac_address":"02:00:00:18:8b:b1","modification_date":"2024-02-22T07:32:51.647676+00:00","private_network_id":"24ff3f79-71d1-466a-959e-967ffcc2411c","server_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:44:34.925318+00:00","id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","mac_address":"02:00:00:18:8b:c3","modification_date":"2024-02-22T07:45:05.992112+00:00","private_network_id":"fdd36901-de79-4e24-8fe4-6a538b0cb746","server_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -2098,7 +2059,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:00 GMT
+      - Thu, 22 Feb 2024 07:45:14 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2108,7 +2069,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7693075e-2e07-42c0-b96f-b5e66e3aa447
+      - 2c9f5c6d-6988-4050-9c6a-62027757648b
     status: 200 OK
     code: 200
     duration: ""
@@ -2119,19 +2080,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:59.970448Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:10.609736Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:45:14.669685Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:44:28.176885Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1090"
+      - "1098"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:00 GMT
+      - Thu, 22 Feb 2024 07:45:14 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2141,7 +2102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - be24d737-51e1-46b6-b198-2e525f93b035
+      - 84199f98-917d-4998-9205-0ebb36914b69
     status: 200 OK
     code: 200
     duration: ""
@@ -2152,7 +2113,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics/7da323ac-12a7-4bb6-bcaa-ad332049d19d
     method: DELETE
   response:
     body: ""
@@ -2160,7 +2121,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 22 Feb 2024 07:33:00 GMT
+      - Thu, 22 Feb 2024 07:45:15 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2170,7 +2131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 771203c6-d944-4925-a00b-44d3b00a141c
+      - e1c99059-cedd-48a5-bf8b-1b8cfa73aec2
     status: 204 No Content
     code: 204
     duration: ""
@@ -2181,7 +2142,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1?release_ip=false
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2?release_ip=false
     method: DELETE
   response:
     body: ""
@@ -2191,7 +2152,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:00 GMT
+      - Thu, 22 Feb 2024 07:45:15 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2201,7 +2162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 886db941-f277-4b06-a924-c16db5848032
+      - 26f9bfa2-022a-40bb-9c5f-4042b692fe58
     status: 204 No Content
     code: 204
     duration: ""
@@ -2212,10 +2173,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/private_nics/2635c3d2-65c3-4b09-aefd-eeafe9677697
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/private_nics/7da323ac-12a7-4bb6-bcaa-ad332049d19d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"2635c3d2-65c3-4b09-aefd-eeafe9677697","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"7da323ac-12a7-4bb6-bcaa-ad332049d19d","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -2224,7 +2185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:00 GMT
+      - Thu, 22 Feb 2024 07:45:15 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2234,7 +2195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5fd44632-89fb-4fd0-b09f-e4d5ae3213c7
+      - 0f3015b2-4a72-47c7-a4bb-2f6a4c7075a4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2245,19 +2206,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:02.656394Z","description":"","frontend_count":0,"id":"3773f9f5-303c-48a8-ba61-424af4df95f1","instances":[{"created_at":"2024-02-22T07:24:47.237532Z","id":"d6ef1d6f-7034-4aed-adc7-d20090ebf56b","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:59.970448Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"3773f9f5-303c-48a8-ba61-424af4df95f1","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-sad-bassi","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_delete","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:33:00.226342Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:44:21.517853Z","description":"","frontend_count":0,"id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","instances":[{"created_at":"2024-02-22T07:39:17.034329Z","id":"f6c63f38-fa9c-459b-a059-2600c4ddaae2","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:45:14.669685Z","zone":"fr-par-1"}],"ip":[{"id":"69bad162-3fb1-4469-8f16-70485430ab8a","ip_address":"51.159.113.152","lb_id":"a53a5428-8729-4f00-86b0-00d16f6f1ba2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-113-152.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"tf-lb-heuristic-feynman","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_delete","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:45:14.980886Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1094"
+      - "1102"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:00 GMT
+      - Thu, 22 Feb 2024 07:45:15 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2267,7 +2228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d08a965-3b90-4894-8fef-247256f9fd84
+      - f6cb21ad-1aa9-4c89-a4cd-ca80d24bce46
     status: 200 OK
     code: 200
     duration: ""
@@ -2278,25 +2239,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:32:15.362228+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"101","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:44:29.855424+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.40.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2942"
+      - "2940"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:00 GMT
+      - Thu, 22 Feb 2024 07:45:15 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2306,43 +2267,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 752a2b7f-7516-42a6-b48a-2b9013917963
+      - 2371aa91-50ff-456f-8f67-b77e371f2a4b
     status: 200 OK
     code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/24ff3f79-71d1-466a-959e-967ffcc2411c
-    method: DELETE
-  response:
-    body: '{"help_message":"Private Network must be empty to be deleted","message":"precondition
-      is not respected","precondition":"resource_still_in_use","type":"precondition_failed"}'
-    headers:
-      Content-Length:
-      - "172"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:33:01 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c4b49b6f-64ee-41e6-93f6-7f9883effe3d
-    status: 412 Precondition Failed
-    code: 412
     duration: ""
 - request:
     body: '{"action":"poweroff"}'
@@ -2353,10 +2280,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f/action","href_result":"/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f","id":"3e19f59d-af46-4ad9-be0e-8aab8b8cbc2f","started_at":"2024-02-22T07:33:00.955576+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0/action","href_result":"/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0","id":"3127aaf0-e4c0-4449-bff9-835455b3ec68","started_at":"2024-02-22T07:45:15.895437+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -2365,9 +2292,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:01 GMT
+      - Thu, 22 Feb 2024 07:45:16 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3e19f59d-af46-4ad9-be0e-8aab8b8cbc2f
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3127aaf0-e4c0-4449-bff9-835455b3ec68
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2377,7 +2304,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a934fbdb-0da8-473c-9439-14e81b41c383
+      - 0c774326-ca3a-48b0-9358-cd45e601fd2b
     status: 202 Accepted
     code: 202
     duration: ""
@@ -2388,25 +2315,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:33:00.593901+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"101","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:45:15.447710+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.40.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2910"
+      - "2908"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:01 GMT
+      - Thu, 22 Feb 2024 07:45:16 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2416,7 +2343,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51e05b9a-eef8-4bdb-b04e-a750bececa37
+      - 57b8f3fb-a885-4e54-aaa2-9dd9b769279d
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,7 +2354,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/24ff3f79-71d1-466a-959e-967ffcc2411c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/fdd36901-de79-4e24-8fe4-6a538b0cb746
     method: DELETE
   response:
     body: ""
@@ -2437,7 +2364,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:02 GMT
+      - Thu, 22 Feb 2024 07:45:16 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2447,7 +2374,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01300d45-36c2-49da-adc1-dbc693d8f0ee
+      - af2627b6-bb35-419b-a381-d41b7c217156
     status: 204 No Content
     code: 204
     duration: ""
@@ -2458,7 +2385,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/e67ee4ac-8ce7-4a13-9182-54b6be4c8610
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/f2816ad2-29c5-47dd-bfbe-65d507d02b00
     method: DELETE
   response:
     body: ""
@@ -2468,7 +2395,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:02 GMT
+      - Thu, 22 Feb 2024 07:45:16 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2478,7 +2405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9eda2585-cc4c-42b5-bfb4-ef36cb5a10ef
+      - b4f556d1-cc94-427e-8c3f-285b032ef9e3
     status: 204 No Content
     code: 204
     duration: ""
@@ -2489,25 +2416,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:33:00.593901+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"101","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:45:15.447710+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.40.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2910"
+      - "2908"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:06 GMT
+      - Thu, 22 Feb 2024 07:45:21 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2517,7 +2444,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5d40be5-afd9-4534-b6d8-fa4300f129a5
+      - 5755f2cc-bd8c-4328-adfc-db5cfacf81f4
     status: 200 OK
     code: 200
     duration: ""
@@ -2528,25 +2455,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:33:00.593901+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"101","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:45:15.447710+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.40.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2910"
+      - "2908"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:11 GMT
+      - Thu, 22 Feb 2024 07:45:26 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2556,7 +2483,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 513998a7-267b-44d9-ae37-04a9efbf2b75
+      - 4c075e59-bd09-42f4-874c-f2db14bf4199
     status: 200 OK
     code: 200
     duration: ""
@@ -2567,55 +2494,16 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"101","node_id":"13","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:33:00.593901+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.128.25","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2910"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:33:16 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 468c8c28-417b-404b-a3b9-5d552af133a1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:33:19.647374+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:45:30.651166+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2788"
@@ -2624,7 +2512,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:21 GMT
+      - Thu, 22 Feb 2024 07:45:32 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2634,7 +2522,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a37a24a-faaf-4ba7-afb0-3be299cebe44
+      - 50e467bc-9edc-4bc4-bc9b-f7766b92d4d8
     status: 200 OK
     code: 200
     duration: ""
@@ -2645,16 +2533,16 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:03.144335+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:44:22.111543+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a7","maintenances":[],"modification_date":"2024-02-22T07:33:19.647374+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.144335+00:00","export_uri":null,"id":"501a5e3d-0dbd-4162-a38f-32113a5f2487","modification_date":"2024-02-22T07:32:03.144335+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:fd","maintenances":[],"modification_date":"2024-02-22T07:45:30.651166+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:44:22.111543+00:00","export_uri":null,"id":"03e6c925-9500-4328-bcf6-9bab66e1b86d","modification_date":"2024-02-22T07:44:22.111543+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2788"
@@ -2663,7 +2551,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:22 GMT
+      - Thu, 22 Feb 2024 07:45:32 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2673,7 +2561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5bfb6cc-4488-4eae-a556-40beaa597be8
+      - 67d93033-eb7e-4bc5-a4a6-212f5803e943
     status: 200 OK
     code: 200
     duration: ""
@@ -2684,7 +2572,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: DELETE
   response:
     body: ""
@@ -2692,7 +2580,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 22 Feb 2024 07:33:22 GMT
+      - Thu, 22 Feb 2024 07:45:32 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2702,7 +2590,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24229c34-de47-4dbf-8bfc-5720545a382b
+      - 1bc282d9-9616-47eb-b972-70b16cc1869d
     status: 204 No Content
     code: 204
     duration: ""
@@ -2713,10 +2601,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -2725,7 +2613,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:22 GMT
+      - Thu, 22 Feb 2024 07:45:32 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2735,7 +2623,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75aaeaef-8b1b-41f6-a70a-9c40fa3bd2d6
+      - 2cf5fed1-89c7-4413-a5f2-0a48538c4fbd
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2746,7 +2634,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/501a5e3d-0dbd-4162-a38f-32113a5f2487
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/03e6c925-9500-4328-bcf6-9bab66e1b86d
     method: DELETE
   response:
     body: ""
@@ -2754,7 +2642,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 22 Feb 2024 07:33:22 GMT
+      - Thu, 22 Feb 2024 07:45:32 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2764,7 +2652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f681d10e-2125-482e-adbe-1120b05879de
+      - 3e013d29-211c-4e71-a86d-3d5966e46828
     status: 204 No Content
     code: 204
     duration: ""
@@ -2775,7 +2663,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
     method: GET
   response:
     body: '{"message":"lbs not Found"}'
@@ -2787,7 +2675,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:30 GMT
+      - Thu, 22 Feb 2024 07:45:45 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2797,7 +2685,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53b272f5-4cbd-4fb7-8727-20aa139a69c3
+      - 38d86222-be13-4b77-9e9d-bdea7f2de3bd
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2808,7 +2696,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/3773f9f5-303c-48a8-ba61-424af4df95f1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/a53a5428-8729-4f00-86b0-00d16f6f1ba2
     method: GET
   response:
     body: '{"message":"lbs not Found"}'
@@ -2820,7 +2708,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:30 GMT
+      - Thu, 22 Feb 2024 07:45:45 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2830,7 +2718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adc44546-c063-40b8-b0bf-525191e4fef1
+      - 0505d18a-8c15-4e16-a928-0ff1c37692bd
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2853,7 +2741,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:30 GMT
+      - Thu, 22 Feb 2024 07:45:45 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2863,7 +2751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d696ca11-9ed5-4f89-b80e-0aa88b6575e7
+      - 40698256-1d6e-4884-9dee-f091092115fb
     status: 200 OK
     code: 200
     duration: ""
@@ -2884,7 +2772,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:30 GMT
+      - Thu, 22 Feb 2024 07:45:45 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2894,7 +2782,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19a02cb3-f5a2-48e7-9663-60130a854a21
+      - f344f713-31e8-4962-8755-5d9a01db62a4
     status: 204 No Content
     code: 204
     duration: ""
@@ -2905,10 +2793,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/bf29d259-1456-4816-8597-4c68f8f7ae6f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5e290682-8f77-4a7b-8d87-4fb299d1def0
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"bf29d259-1456-4816-8597-4c68f8f7ae6f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"5e290682-8f77-4a7b-8d87-4fb299d1def0","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -2917,7 +2805,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:31 GMT
+      - Thu, 22 Feb 2024 07:45:45 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2927,7 +2815,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7734166c-bd1f-4563-a83a-670b7886f14b
+      - cb414108-18c4-47b9-9ef7-c95c5a0a1295
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-ipamip-instance.cassette.yaml
+++ b/scaleway/testdata/data-source-ipamip-instance.cassette.yaml
@@ -6,23 +6,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","label":"ubuntu_jammy","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2d830ab7-b11c-435e-a582-f390ef11b1e2","label":"ubuntu_jammy","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"f0d486ff-f178-4941-ad62-8bbda478b53a","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"9467798a-e554-4658-a008-82a868d42a3b","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1179"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:15 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -30,7 +30,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1edb76c8-7f77-43bd-b885-74db779189f1
+      - 4fd8bbd5-ea69-4668-affe-de933a4d77d9
     status: 200 OK
     code: 200
     duration: ""
@@ -39,26 +39,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38421"
+      - "38183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:15 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -66,44 +66,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b24628e3-7f35-41a9-8b46-11362e1cdf06
+      - 687e4f5d-bd60-4968-a202-2c3dcbe1255d
       X-Total-Count:
-      - "56"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
-    method: POST
-  response:
-    body: '{"created_at":"2023-10-24T16:03:15.579911Z","id":"747a6735-94ae-4b6f-90d5-e97c83c39543","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2023-10-24T16:03:15.579911Z"}'
-    headers:
-      Content-Length:
-      - "359"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Oct 2023 16:03:15 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bd4a622b-a42c-41e8-b7d1-8987bd36fb45
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
@@ -112,26 +77,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4865"
+      - "8882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:15 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -139,9 +104,44 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2474f06e-0876-4cb9-b6dd-28ee9159108f
+      - 8c6b641a-5a70-4aba-9723-4ad10765c9e0
       X-Total-Count:
-      - "56"
+      - "61"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+    method: POST
+  response:
+    body: '{"created_at":"2024-02-22T07:32:02.612055Z","id":"069d0ca3-f4ff-4131-a027-a6dc8771da2e","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:32:02.612055Z"}'
+    headers:
+      Content-Length:
+      - "368"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2483f8a2-9c8f-4ffc-a6ac-01264835d277
     status: 200 OK
     code: 200
     duration: ""
@@ -150,23 +150,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/747a6735-94ae-4b6f-90d5-e97c83c39543
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/069d0ca3-f4ff-4131-a027-a6dc8771da2e
     method: GET
   response:
-    body: '{"created_at":"2023-10-24T16:03:15.579911Z","id":"747a6735-94ae-4b6f-90d5-e97c83c39543","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2023-10-24T16:03:15.579911Z"}'
+    body: '{"created_at":"2024-02-22T07:32:02.612055Z","id":"069d0ca3-f4ff-4131-a027-a6dc8771da2e","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:32:02.612055Z"}'
     headers:
       Content-Length:
-      - "359"
+      - "368"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:15 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -174,42 +174,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f32ed126-7f55-4cbe-8dc0-410c18e28d17
+      - a1cf751e-3a37-4776-baf8-1559a0329ea5
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-tests-ipam-ip-datasource-instance","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"PLAY2-MICRO","image":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","volumes":{"0":{"boot":false,"volume_type":"b_ssd"}},"boot_type":"local","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":["terraform-test","data_scaleway_instance_servers","basic"]}'
+    body: '{"name":"tf-tests-ipam-ip-datasource-instance","dynamic_ip_required":false,"commercial_type":"PLAY2-MICRO","image":"9467798a-e554-4658-a008-82a868d42a3b","volumes":{"0":{"boot":false,"volume_type":"b_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","data_scaleway_instance_servers","basic"]}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:03:15.901304+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:02.743092+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2766"
+      - "2788"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:16 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -217,7 +217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20244317-1421-46c6-a24f-4734a0534101
+      - 6599830f-69b2-4dd3-91fc-54cc5e9c5fe3
     status: 201 Created
     code: 201
     duration: ""
@@ -226,29 +226,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:03:15.901304+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:02.743092+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2766"
+      - "2788"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:16 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -256,7 +256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f80551c-e902-4f4b-a39e-6704e8e8542a
+      - e4edd47b-dbb5-4b4f-893e-7e3b10a16a1f
     status: 200 OK
     code: 200
     duration: ""
@@ -265,29 +265,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:03:15.901304+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:02.743092+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2766"
+      - "2788"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:16 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -295,34 +295,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4abf9390-082c-4887-8eb6-ae5535284ab7
+      - 2e66f6be-602e-4f58-9102-8570b4d538e6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null,"vpc_id":"747a6735-94ae-4b6f-90d5-e97c83c39543"}'
+    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null,"vpc_id":"069d0ca3-f4ff-4131-a027-a6dc8771da2e"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-24T16:03:15.798725Z","dhcp_enabled":true,"id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-24T16:03:15.798725Z","id":"324d768f-7ade-46d8-be48-2ceb38f65adf","subnet":"172.16.40.0/22","updated_at":"2023-10-24T16:03:15.798725Z"},{"created_at":"2023-10-24T16:03:15.798725Z","id":"e83dd253-d5f2-4290-9340-7a02081a40e4","subnet":"fd46:78ab:30b8:6973::/64","updated_at":"2023-10-24T16:03:15.798725Z"}],"tags":[],"updated_at":"2023-10-24T16:03:15.798725Z","vpc_id":"747a6735-94ae-4b6f-90d5-e97c83c39543"}'
+    body: '{"created_at":"2024-02-22T07:32:03.021725Z","dhcp_enabled":true,"id":"b72772e8-da19-4421-b779-2f92b04efe75","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:03.021725Z","id":"a83e6d5c-0d56-465d-96fc-89e5079e7121","subnet":"172.16.76.0/22","updated_at":"2024-02-22T07:32:03.021725Z"},{"created_at":"2024-02-22T07:32:03.021725Z","id":"a5b8ee11-4239-4644-bf0e-9ca2e800b43b","subnet":"fd5f:519c:6d46:b555::/64","updated_at":"2024-02-22T07:32:03.021725Z"}],"tags":[],"updated_at":"2024-02-22T07:32:03.021725Z","vpc_id":"069d0ca3-f4ff-4131-a027-a6dc8771da2e"}'
     headers:
       Content-Length:
-      - "720"
+      - "737"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:16 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -330,7 +330,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37c4a9e2-d476-4e38-99d7-f06a6a066724
+      - d9cd3306-2cbf-45e0-80d9-619c96d880cd
     status: 200 OK
     code: 200
     duration: ""
@@ -339,23 +339,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/0c73d85b-af61-4ee8-9575-bcef60cdb520
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b72772e8-da19-4421-b779-2f92b04efe75
     method: GET
   response:
-    body: '{"created_at":"2023-10-24T16:03:15.798725Z","dhcp_enabled":true,"id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-24T16:03:15.798725Z","id":"324d768f-7ade-46d8-be48-2ceb38f65adf","subnet":"172.16.40.0/22","updated_at":"2023-10-24T16:03:15.798725Z"},{"created_at":"2023-10-24T16:03:15.798725Z","id":"e83dd253-d5f2-4290-9340-7a02081a40e4","subnet":"fd46:78ab:30b8:6973::/64","updated_at":"2023-10-24T16:03:15.798725Z"}],"tags":[],"updated_at":"2023-10-24T16:03:15.798725Z","vpc_id":"747a6735-94ae-4b6f-90d5-e97c83c39543"}'
+    body: '{"created_at":"2024-02-22T07:32:03.021725Z","dhcp_enabled":true,"id":"b72772e8-da19-4421-b779-2f92b04efe75","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:03.021725Z","id":"a83e6d5c-0d56-465d-96fc-89e5079e7121","subnet":"172.16.76.0/22","updated_at":"2024-02-22T07:32:03.021725Z"},{"created_at":"2024-02-22T07:32:03.021725Z","id":"a5b8ee11-4239-4644-bf0e-9ca2e800b43b","subnet":"fd5f:519c:6d46:b555::/64","updated_at":"2024-02-22T07:32:03.021725Z"}],"tags":[],"updated_at":"2024-02-22T07:32:03.021725Z","vpc_id":"069d0ca3-f4ff-4131-a027-a6dc8771da2e"}'
     headers:
       Content-Length:
-      - "720"
+      - "737"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:16 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3fab7b43-d157-4b1f-928d-104bf7bd68bf
+      - cee81b92-787d-46f9-b5f8-4f25938c8d9c
     status: 200 OK
     code: 200
     duration: ""
@@ -374,12 +374,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/action","href_result":"/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f","id":"0b8ccec0-27bf-4e25-89f1-cb8a5cb6a86f","started_at":"2023-10-24T16:03:16.880634+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/action","href_result":"/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c","id":"c029d1d0-abb8-4ada-bf92-1681899617d6","started_at":"2024-02-22T07:32:03.616748+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -388,11 +388,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:16 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/0b8ccec0-27bf-4e25-89f1-cb8a5cb6a86f
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/c029d1d0-abb8-4ada-bf92-1681899617d6
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -400,7 +400,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4587e01-9278-4ec8-a3d1-3c2368a42191
+      - ac84b2d9-69f7-485a-83da-a8293e96f8b8
     status: 202 Accepted
     code: 202
     duration: ""
@@ -409,29 +409,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:03:16.459950+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:03.437990+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2788"
+      - "2810"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:17 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -439,7 +439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9153ee15-d6d3-4869-8412-f8b0de315ccb
+      - d9e7b86f-68d2-41b7-a7f5-028d78b90fd2
     status: 200 OK
     code: 200
     duration: ""
@@ -448,29 +448,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"1001","node_id":"103","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:03:16.459950+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.75.76.205","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:03.437990+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2898"
+      - "2810"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:22 GMT
+      - Thu, 22 Feb 2024 07:32:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -478,7 +478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd175808-f6c6-4bd7-b419-57c0650e0010
+      - d89d54ce-827d-460d-abaf-ade5b9fbf584
     status: 200 OK
     code: 200
     duration: ""
@@ -487,29 +487,224 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:03.437990+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2810"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4175f53a-57ee-4a80-8d37-b8478b6c237c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:03.437990+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2810"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8878e0f6-4d05-4a62-a7f5-983b56898b9b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:03.437990+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2810"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:25 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - beb19388-48e4-4233-a7fc-efdaf6916b88
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:03.437990+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2810"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fd4143ca-0937-4eb1-b161-94bc73c9097c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:03.437990+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2918"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 92d4557f-d209-4d47-be4c-e79dca8f5475
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"1001","node_id":"103","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:03:25.922200+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.75.76.205","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:37.645264+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2929"
+      - "2949"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:27 GMT
+      - Thu, 22 Feb 2024 07:32:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -517,7 +712,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1882b29-382f-40fd-b4f7-6ad11ecab395
+      - 3cb2b9a4-b360-41b4-8b82-1edbb639db5d
     status: 200 OK
     code: 200
     duration: ""
@@ -526,29 +721,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"1001","node_id":"103","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:03:25.922200+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.75.76.205","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:37.645264+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2929"
+      - "2949"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:27 GMT
+      - Thu, 22 Feb 2024 07:32:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -556,7 +751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88c17598-444d-4109-8a86-bcfb076250ab
+      - 97484453-469f-4639-8f59-cd46da058b55
     status: 200 OK
     code: 200
     duration: ""
@@ -565,9 +760,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -579,9 +774,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:27 GMT
+      - Thu, 22 Feb 2024 07:32:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -589,7 +784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93b58236-ece0-444f-830d-2fe095e1a0c0
+      - a07015ed-f49a-4c3e-8b5c-bafa8474f13b
     status: 200 OK
     code: 200
     duration: ""
@@ -598,9 +793,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -612,12 +807,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:27 GMT
+      - Thu, 22 Feb 2024 07:32:41 GMT
       Link:
-      - </servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics?page=0&per_page=50&>;
+      - </servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -625,7 +820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b3da16e-0f95-4d20-92d6-003ed825f6df
+      - cfd2500d-e9e7-4be5-a1ba-a9b26fd791e3
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -636,29 +831,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"1001","node_id":"103","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:03:25.922200+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.75.76.205","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:37.645264+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2929"
+      - "2949"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:27 GMT
+      - Thu, 22 Feb 2024 07:32:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -666,23 +861,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 579df944-bf5b-4b82-a185-d4c5db79918d
+      - 7659c28d-cfdf-4583-9816-787bac8c95ab
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520"}'
+    body: '{"private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.788045+00:00","id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","modification_date":"2023-10-24T16:03:27.788045+00:00","private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","server_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:41.298204+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -691,9 +886,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:28 GMT
+      - Thu, 22 Feb 2024 07:32:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -701,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e56dc324-787f-41d6-a88a-668bb7b8aa24
+      - 0e9d0c5d-cc90-4a6a-9b51-d43bc947a1bb
     status: 201 Created
     code: 201
     duration: ""
@@ -710,12 +905,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics/d2820bf2-4770-4a07-a19f-9318897e6c5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.788045+00:00","id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","modification_date":"2023-10-24T16:03:27.788045+00:00","private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","server_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:41.298204+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -724,9 +919,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:28 GMT
+      - Thu, 22 Feb 2024 07:32:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -734,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0ebb316-d1c1-4943-940b-f358de34c15b
+      - 50732c0e-e481-4e01-a0cc-18b7676c3fa9
     status: 200 OK
     code: 200
     duration: ""
@@ -743,12 +938,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics/d2820bf2-4770-4a07-a19f-9318897e6c5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.788045+00:00","id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","modification_date":"2023-10-24T16:03:30.013605+00:00","private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","server_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:42.155663+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -757,9 +952,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:33 GMT
+      - Thu, 22 Feb 2024 07:32:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -767,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 230f40a8-baff-42c7-a9bb-82e9c62e662e
+      - 7b0cfe3f-67c5-4def-aa1b-7a705c50bddd
     status: 200 OK
     code: 200
     duration: ""
@@ -776,12 +971,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics/d2820bf2-4770-4a07-a19f-9318897e6c5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.788045+00:00","id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","modification_date":"2023-10-24T16:03:30.013605+00:00","private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","server_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:42.155663+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -790,9 +985,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:38 GMT
+      - Thu, 22 Feb 2024 07:32:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -800,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31bf4d9f-db8a-446c-b169-767702314210
+      - 5097b8bc-dea8-407e-ad01-2a4fd09c4994
     status: 200 OK
     code: 200
     duration: ""
@@ -809,12 +1004,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics/d2820bf2-4770-4a07-a19f-9318897e6c5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.788045+00:00","id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","modification_date":"2023-10-24T16:03:30.013605+00:00","private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","server_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:42.155663+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -823,9 +1018,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:43 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -833,7 +1028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 495377ed-a389-4327-949b-a7716fd6e3bb
+      - a11fb9e0-2b92-4b67-af15-f1e052d6838e
     status: 200 OK
     code: 200
     duration: ""
@@ -842,12 +1037,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics/d2820bf2-4770-4a07-a19f-9318897e6c5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.788045+00:00","id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","modification_date":"2023-10-24T16:03:30.013605+00:00","private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","server_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:42.155663+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -856,9 +1051,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:48 GMT
+      - Thu, 22 Feb 2024 07:33:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -866,7 +1061,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bda5250c-9163-466a-9fce-d97e5691c5bb
+      - 1cf79ef7-3030-4b3a-be60-1f5eaa6898b1
     status: 200 OK
     code: 200
     duration: ""
@@ -875,12 +1070,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics/d2820bf2-4770-4a07-a19f-9318897e6c5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.788045+00:00","id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","modification_date":"2023-10-24T16:03:30.013605+00:00","private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","server_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:42.155663+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -889,9 +1084,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:53 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -899,7 +1094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f87316a5-f61e-487d-80f0-1db53ea54759
+      - b3ccce43-c746-4e72-977d-e5fd9f83473a
     status: 200 OK
     code: 200
     duration: ""
@@ -908,12 +1103,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics/d2820bf2-4770-4a07-a19f-9318897e6c5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.788045+00:00","id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","modification_date":"2023-10-24T16:03:30.013605+00:00","private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","server_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:42.155663+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -922,9 +1117,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:03:58 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -932,7 +1127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a002115d-d7f9-4f96-b236-5c704aaf64c4
+      - 6c34f122-42a3-48a4-90f3-41ee07be9018
     status: 200 OK
     code: 200
     duration: ""
@@ -941,12 +1136,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics/d2820bf2-4770-4a07-a19f-9318897e6c5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.788045+00:00","id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","modification_date":"2023-10-24T16:03:59.300820+00:00","private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","server_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:33:12.540465+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -955,9 +1150,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:03 GMT
+      - Thu, 22 Feb 2024 07:33:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -965,7 +1160,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91113dd6-7522-4bc0-9ac2-329c6d879ada
+      - 9e9d7ac5-f17a-4a2a-b0e3-e0408bfc3d57
     status: 200 OK
     code: 200
     duration: ""
@@ -974,12 +1169,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics/d2820bf2-4770-4a07-a19f-9318897e6c5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.788045+00:00","id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","modification_date":"2023-10-24T16:03:59.300820+00:00","private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","server_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:33:12.540465+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -988,9 +1183,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:03 GMT
+      - Thu, 22 Feb 2024 07:33:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -998,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c67138b5-ab3b-4761-865d-baa32e2a0a03
+      - cb9ff94b-a585-4654-ab2b-9b53c377c6a4
     status: 200 OK
     code: 200
     duration: ""
@@ -1007,23 +1202,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A14%3A68%3A59&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab8&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.40.2/22","created_at":"2023-10-24T16:03:29.911391Z","id":"1e0a96eb-833b-4e87-988b-3d291e288909","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"source":{"subnet_id":"324d768f-7ade-46d8-be48-2ceb38f65adf"},"tags":[],"updated_at":"2023-10-24T16:03:29.911391Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "521"
+      - "550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:03 GMT
+      - Thu, 22 Feb 2024 07:33:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1031,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f9d6d9b-1f30-4136-8b94-5b366eace2ca
+      - f68e2a75-6eb7-4865-ac4f-fb40a330521a
     status: 200 OK
     code: 200
     duration: ""
@@ -1040,23 +1235,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d2820bf2-4770-4a07-a19f-9318897e6c5c&resource_type=instance_private_nic
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=04d0831f-b7c0-4d99-9013-1a66402565a0&resource_type=instance_private_nic
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.40.2/22","created_at":"2023-10-24T16:03:29.911391Z","id":"1e0a96eb-833b-4e87-988b-3d291e288909","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"source":{"subnet_id":"324d768f-7ade-46d8-be48-2ceb38f65adf"},"tags":[],"updated_at":"2023-10-24T16:03:29.911391Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "521"
+      - "550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:03 GMT
+      - Thu, 22 Feb 2024 07:33:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1064,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0237300e-656a-4b14-bc42-a091a3d27f68
+      - 4d82034d-0de2-4401-ae69-093fca929cf7
     status: 200 OK
     code: 200
     duration: ""
@@ -1073,23 +1268,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d2820bf2-4770-4a07-a19f-9318897e6c5c&resource_type=instance_private_nic
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=04d0831f-b7c0-4d99-9013-1a66402565a0&resource_type=instance_private_nic
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.40.2/22","created_at":"2023-10-24T16:03:29.911391Z","id":"1e0a96eb-833b-4e87-988b-3d291e288909","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"source":{"subnet_id":"324d768f-7ade-46d8-be48-2ceb38f65adf"},"tags":[],"updated_at":"2023-10-24T16:03:29.911391Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "521"
+      - "550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
+      - Thu, 22 Feb 2024 07:33:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1097,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea7b59f1-1ac2-446f-a1fe-bf41aaf4cf43
+      - cf12c8d9-92f3-4bc5-a308-24c4c234b671
     status: 200 OK
     code: 200
     duration: ""
@@ -1106,23 +1301,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A14%3A68%3A59&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab8&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.40.2/22","created_at":"2023-10-24T16:03:29.911391Z","id":"1e0a96eb-833b-4e87-988b-3d291e288909","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"source":{"subnet_id":"324d768f-7ade-46d8-be48-2ceb38f65adf"},"tags":[],"updated_at":"2023-10-24T16:03:29.911391Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "521"
+      - "550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
+      - Thu, 22 Feb 2024 07:33:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1130,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 58212889-6e32-4b14-8305-44e374ff0f3c
+      - e0047514-dc91-4fd6-a2e4-d54ab680c753
     status: 200 OK
     code: 200
     duration: ""
@@ -1139,23 +1334,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/747a6735-94ae-4b6f-90d5-e97c83c39543
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/069d0ca3-f4ff-4131-a027-a6dc8771da2e
     method: GET
   response:
-    body: '{"created_at":"2023-10-24T16:03:15.579911Z","id":"747a6735-94ae-4b6f-90d5-e97c83c39543","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","tags":[],"updated_at":"2023-10-24T16:03:15.579911Z"}'
+    body: '{"created_at":"2024-02-22T07:32:02.612055Z","id":"069d0ca3-f4ff-4131-a027-a6dc8771da2e","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:32:02.612055Z"}'
     headers:
       Content-Length:
-      - "359"
+      - "368"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1163,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61f8377a-b72c-4fdc-9c30-a751bc51d2cd
+      - d1395fdc-38a1-4bb6-adce-cfaa84e246bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1172,29 +1367,62 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b72772e8-da19-4421-b779-2f92b04efe75
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-22T07:32:03.021725Z","dhcp_enabled":true,"id":"b72772e8-da19-4421-b779-2f92b04efe75","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:03.021725Z","id":"a83e6d5c-0d56-465d-96fc-89e5079e7121","subnet":"172.16.76.0/22","updated_at":"2024-02-22T07:32:03.021725Z"},{"created_at":"2024-02-22T07:32:03.021725Z","id":"a5b8ee11-4239-4644-bf0e-9ca2e800b43b","subnet":"fd5f:519c:6d46:b555::/64","updated_at":"2024-02-22T07:32:03.021725Z"}],"tags":[],"updated_at":"2024-02-22T07:32:03.021725Z","vpc_id":"069d0ca3-f4ff-4131-a027-a6dc8771da2e"}'
+    headers:
+      Content-Length:
+      - "737"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:18 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1350ccfd-3a5a-484e-bf94-57b64b7cf668
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"1001","node_id":"103","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:03:25.922200+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.75.76.205","private_nics":[{"creation_date":"2023-10-24T16:03:27.788045+00:00","id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","modification_date":"2023-10-24T16:03:59.300820+00:00","private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","server_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:37.645264+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:33:12.540465+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3282"
+      - "3302"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1202,7 +1430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 060b046a-7031-419f-80c9-7159cd4db0c0
+      - e5c0c8e8-1182-447f-b09f-e61a88d8e6c2
     status: 200 OK
     code: 200
     duration: ""
@@ -1211,42 +1439,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/0c73d85b-af61-4ee8-9575-bcef60cdb520
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-24T16:03:15.798725Z","dhcp_enabled":true,"id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-24T16:03:15.798725Z","id":"324d768f-7ade-46d8-be48-2ceb38f65adf","subnet":"172.16.40.0/22","updated_at":"2023-10-24T16:03:15.798725Z"},{"created_at":"2023-10-24T16:03:15.798725Z","id":"e83dd253-d5f2-4290-9340-7a02081a40e4","subnet":"fd46:78ab:30b8:6973::/64","updated_at":"2023-10-24T16:03:15.798725Z"}],"tags":[],"updated_at":"2023-10-24T16:03:15.798725Z","vpc_id":"747a6735-94ae-4b6f-90d5-e97c83c39543"}'
-    headers:
-      Content-Length:
-      - "720"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6dc814d0-64dd-45a2-b867-1103787bb166
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1258,9 +1453,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1268,7 +1463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9563c6c-0535-418a-b492-3d9ad1a524f8
+      - a7be3e0b-3caa-4172-962c-538333332948
     status: 200 OK
     code: 200
     duration: ""
@@ -1277,12 +1472,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-24T16:03:27.788045+00:00","id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","modification_date":"2023-10-24T16:03:59.300820+00:00","private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","server_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:33:12.540465+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1291,12 +1486,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Link:
-      - </servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics?page=1&per_page=50&>;
+      - </servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1304,7 +1499,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a19afaa-9be9-485d-8b68-83826c0879c6
+      - 9d144054-c5d5-4d2d-951d-e33b565eae5b
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1315,12 +1510,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics/d2820bf2-4770-4a07-a19f-9318897e6c5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.788045+00:00","id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","modification_date":"2023-10-24T16:03:59.300820+00:00","private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","server_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:33:12.540465+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1329,9 +1524,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1339,7 +1534,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78826b8e-3435-4719-b8d3-dcfe81bd0b23
+      - 6573ee3c-1284-42d6-9738-78eaf951ea02
     status: 200 OK
     code: 200
     duration: ""
@@ -1348,23 +1543,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A14%3A68%3A59&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab8&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.40.2/22","created_at":"2023-10-24T16:03:29.911391Z","id":"1e0a96eb-833b-4e87-988b-3d291e288909","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"source":{"subnet_id":"324d768f-7ade-46d8-be48-2ceb38f65adf"},"tags":[],"updated_at":"2023-10-24T16:03:29.911391Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "521"
+      - "550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1372,7 +1567,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16de143c-fc6e-4de7-8db1-ac9c27eb5ab4
+      - acec32e8-5732-43ba-b642-e3246128c9f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1381,23 +1576,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d2820bf2-4770-4a07-a19f-9318897e6c5c&resource_type=instance_private_nic
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=04d0831f-b7c0-4d99-9013-1a66402565a0&resource_type=instance_private_nic
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.40.2/22","created_at":"2023-10-24T16:03:29.911391Z","id":"1e0a96eb-833b-4e87-988b-3d291e288909","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"source":{"subnet_id":"324d768f-7ade-46d8-be48-2ceb38f65adf"},"tags":[],"updated_at":"2023-10-24T16:03:29.911391Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "521"
+      - "550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:04 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1405,7 +1600,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91efe837-91b3-4a14-bd6f-b28d876bc045
+      - 7cef2e2e-8290-4e45-93de-5d77fc9e121f
     status: 200 OK
     code: 200
     duration: ""
@@ -1414,23 +1609,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=d2820bf2-4770-4a07-a19f-9318897e6c5c&resource_type=instance_private_nic
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=04d0831f-b7c0-4d99-9013-1a66402565a0&resource_type=instance_private_nic
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.40.2/22","created_at":"2023-10-24T16:03:29.911391Z","id":"1e0a96eb-833b-4e87-988b-3d291e288909","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"source":{"subnet_id":"324d768f-7ade-46d8-be48-2ceb38f65adf"},"tags":[],"updated_at":"2023-10-24T16:03:29.911391Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "521"
+      - "550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1438,7 +1633,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8b3b8bd-e3b2-43f3-88de-127979e0d29e
+      - f16d6ebb-c94a-4f97-9235-1097babf386d
     status: 200 OK
     code: 200
     duration: ""
@@ -1447,23 +1642,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A14%3A68%3A59&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab8&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.40.2/22","created_at":"2023-10-24T16:03:29.911391Z","id":"1e0a96eb-833b-4e87-988b-3d291e288909","is_ipv6":false,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","resource":{"id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"source":{"subnet_id":"324d768f-7ade-46d8-be48-2ceb38f65adf"},"tags":[],"updated_at":"2023-10-24T16:03:29.911391Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "521"
+      - "550"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1471,7 +1666,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09bc655c-b141-4179-b17d-3ebf4b3a0573
+      - 7f6bbbec-2bb9-4e15-ad29-0ca9cf723e53
     status: 200 OK
     code: 200
     duration: ""
@@ -1480,12 +1675,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics/d2820bf2-4770-4a07-a19f-9318897e6c5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-24T16:03:27.788045+00:00","id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","mac_address":"02:00:00:14:68:59","modification_date":"2023-10-24T16:03:59.300820+00:00","private_network_id":"0c73d85b-af61-4ee8-9575-bcef60cdb520","server_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:33:12.540465+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1494,9 +1689,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:05 GMT
+      - Thu, 22 Feb 2024 07:33:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1504,7 +1699,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 666e7f1a-f314-46a7-8814-9bc689d638fd
+      - 2b6825df-3e84-46ad-9911-4ecdda53b418
     status: 200 OK
     code: 200
     duration: ""
@@ -1513,9 +1708,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics/d2820bf2-4770-4a07-a19f-9318897e6c5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
     method: DELETE
   response:
     body: ""
@@ -1523,9 +1718,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 24 Oct 2023 16:04:06 GMT
+      - Thu, 22 Feb 2024 07:33:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1533,7 +1728,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7d4364e-2fe2-4631-846a-ea9b1db42861
+      - a27a145e-e285-4725-b61d-867d4329a30c
     status: 204 No Content
     code: 204
     duration: ""
@@ -1542,12 +1737,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/private_nics/d2820bf2-4770-4a07-a19f-9318897e6c5c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"d2820bf2-4770-4a07-a19f-9318897e6c5c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"04d0831f-b7c0-4d99-9013-1a66402565a0","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -1556,9 +1751,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:06 GMT
+      - Thu, 22 Feb 2024 07:33:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1566,7 +1761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c452221f-a880-42bb-a596-19529c349391
+      - 5277b3bb-4781-4188-9da1-279ba60a54c7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1575,29 +1770,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"1001","node_id":"103","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:03:25.922200+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.75.76.205","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:37.645264+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2921"
+      - "2941"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:06 GMT
+      - Thu, 22 Feb 2024 07:33:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1605,40 +1800,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0be5b77-7145-49b1-81b8-f6ea61e02f0b
+      - 3837422c-3384-4c7c-9c66-eda1ec48449b
     status: 200 OK
     code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/0c73d85b-af61-4ee8-9575-bcef60cdb520
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Oct 2023 16:04:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8a5c855b-96e9-4bf6-8a63-11d88be4f4c7
-    status: 204 No Content
-    code: 204
     duration: ""
 - request:
     body: '{"action":"poweroff"}'
@@ -1647,12 +1811,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f/action","href_result":"/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f","id":"3f5500dc-c2ce-4879-9805-6e092cc3db2e","started_at":"2023-10-24T16:04:07.109221+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/action","href_result":"/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c","id":"84c98fe4-cdf4-4b0d-a0d0-807861d62df5","started_at":"2024-02-22T07:33:20.021297+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -1661,11 +1825,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:07 GMT
+      - Thu, 22 Feb 2024 07:33:20 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3f5500dc-c2ce-4879-9805-6e092cc3db2e
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/84c98fe4-cdf4-4b0d-a0d0-807861d62df5
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1673,7 +1837,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bf5e625-3224-489e-a271-48c268e20b5e
+      - c5cbcec5-4809-41b6-a46c-898f0cea9b77
     status: 202 Accepted
     code: 202
     duration: ""
@@ -1682,9 +1846,82 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/747a6735-94ae-4b6f-90d5-e97c83c39543
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b72772e8-da19-4421-b779-2f92b04efe75
+    method: DELETE
+  response:
+    body: '{"help_message":"Private Network must be empty to be deleted","message":"precondition
+      is not respected","precondition":"resource_still_in_use","type":"precondition_failed"}'
+    headers:
+      Content-Length:
+      - "172"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fd2a9533-3d43-4a6a-a05b-5d83c2a049df
+    status: 412 Precondition Failed
+    code: 412
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:33:19.860342+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2909"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3d9a848d-d0a2-447e-b106-24b9b8d640f9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b72772e8-da19-4421-b779-2f92b04efe75
     method: DELETE
   response:
     body: ""
@@ -1694,9 +1931,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:07 GMT
+      - Thu, 22 Feb 2024 07:33:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1704,7 +1941,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6f4c776-2645-4d7d-95eb-e91782c792aa
+      - deeae898-e967-454a-8824-ef68b50d576b
     status: 204 No Content
     code: 204
     duration: ""
@@ -1713,29 +1950,21 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
-    method: GET
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/069d0ca3-f4ff-4131-a027-a6dc8771da2e
+    method: DELETE
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"1001","node_id":"103","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:04:06.442488+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.75.76.205","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: ""
     headers:
-      Content-Length:
-      - "2889"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:07 GMT
+      - Thu, 22 Feb 2024 07:33:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1743,7 +1972,46 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a7c3c32-43fa-4e24-9ee6-120603e9ad43
+      - b32cdeca-9df5-4118-b9c7-6f94845c974b
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:33:19.860342+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2909"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:25 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9656fec7-2cc8-4558-a640-1814f064bbd8
     status: 200 OK
     code: 200
     duration: ""
@@ -1752,29 +2020,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"1001","node_id":"103","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:04:06.442488+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.75.76.205","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:33:19.860342+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2889"
+      - "2909"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:12 GMT
+      - Thu, 22 Feb 2024 07:33:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1782,7 +2050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7518d31-e774-425a-a753-c619f6aed1a5
+      - af38dfa9-b534-44d5-adea-e9f83b8edf43
     status: 200 OK
     code: 200
     duration: ""
@@ -1791,29 +2059,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"1001","node_id":"103","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:04:06.442488+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.75.76.205","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:33:19.860342+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2889"
+      - "2909"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:17 GMT
+      - Thu, 22 Feb 2024 07:33:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1821,7 +2089,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bba8e626-ca24-4a73-864f-4a4c9d368608
+      - e2e29f2e-db65-433c-abea-69d68d637d14
     status: 200 OK
     code: 200
     duration: ""
@@ -1830,68 +2098,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"1001","node_id":"103","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:04:06.442488+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.75.76.205","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2889"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 24 Oct 2023 16:04:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cbede31b-4c28-4002-88ec-96bf534aa6de
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:04:24.290346+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:33:38.943568+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2766"
+      - "2788"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:27 GMT
+      - Thu, 22 Feb 2024 07:33:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1899,7 +2128,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c3e17f5-1de7-4ac8-a24c-02701da8ae64
+      - 4517ef72-c539-42a4-bc5a-022487138ac2
     status: 200 OK
     code: 200
     duration: ""
@@ -1908,29 +2137,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2023-10-24T16:03:15.901304+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:4c:d5","maintenances":[],"modification_date":"2023-10-24T16:04:24.290346+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-24T16:03:15.901304+00:00","export_uri":null,"id":"419c5fc5-a524-4488-bcc8-df69ae62aea7","modification_date":"2023-10-24T16:03:15.901304+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:33:38.943568+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2766"
+      - "2788"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:27 GMT
+      - Thu, 22 Feb 2024 07:33:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1938,7 +2167,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 497bc266-7de3-4991-af72-d00502ae741e
+      - d013d055-4d5b-4530-ab1a-8c34ca42a194
     status: 200 OK
     code: 200
     duration: ""
@@ -1947,9 +2176,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: DELETE
   response:
     body: ""
@@ -1957,9 +2186,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 24 Oct 2023 16:04:28 GMT
+      - Thu, 22 Feb 2024 07:33:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1967,7 +2196,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c734d5b-79ed-43f6-9b1f-ac7ae391a0af
+      - ffe7e702-355e-4313-b55e-02a5d7e321fd
     status: 204 No Content
     code: 204
     duration: ""
@@ -1976,12 +2205,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -1990,9 +2219,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:28 GMT
+      - Thu, 22 Feb 2024 07:33:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2000,7 +2229,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5164431-3d70-4a19-b2e8-b77a50c0cd08
+      - 22725152-9949-48d0-810d-c875f451e449
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2009,9 +2238,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/419c5fc5-a524-4488-bcc8-df69ae62aea7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4af93a15-8dcd-4071-82f5-25822f6944fc
     method: DELETE
   response:
     body: ""
@@ -2019,9 +2248,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 24 Oct 2023 16:04:28 GMT
+      - Thu, 22 Feb 2024 07:33:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2029,7 +2258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6b35d94-664b-42d3-8f4c-6580fa67f498
+      - f7c477be-a553-429c-a507-a8478a5c68df
     status: 204 No Content
     code: 204
     duration: ""
@@ -2038,12 +2267,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.0; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/29186a8e-76db-49c9-9a1d-ab67f5fa216f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"29186a8e-76db-49c9-9a1d-ab67f5fa216f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -2052,9 +2281,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 24 Oct 2023 16:04:28 GMT
+      - Thu, 22 Feb 2024 07:33:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2062,7 +2291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b5a1d77-0e65-44a8-be16-aa7a19e91268
+      - 526e90ec-ccc3-47e0-9317-f390c79bc7c5
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-ipamip-instance.cassette.yaml
+++ b/scaleway/testdata/data-source-ipamip-instance.cassette.yaml
@@ -20,7 +20,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:42:15 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -30,7 +30,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fd8bbd5-ea69-4668-affe-de933a4d77d9
+      - d41c219b-a001-4880-aa35-4ed463af7c9b
     status: 200 OK
     code: 200
     duration: ""
@@ -53,7 +53,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:42:15 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
@@ -66,9 +66,44 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 687e4f5d-bd60-4968-a202-2c3dcbe1255d
+      - aa84bd4e-833b-4e7a-a751-483ee9da12d1
       X-Total-Count:
       - "61"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
+    method: POST
+  response:
+    body: '{"created_at":"2024-02-22T07:42:15.267913Z","id":"b4e0fca7-b596-4d82-9b0b-d6c2c49af7e4","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:42:15.267913Z"}'
+    headers:
+      Content-Length:
+      - "368"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:42:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1795b08e-ed0c-4b4f-b117-ff2aaef60d5e
     status: 200 OK
     code: 200
     duration: ""
@@ -91,7 +126,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:42:15 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
@@ -104,44 +139,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c6b641a-5a70-4aba-9723-4ad10765c9e0
+      - 2cfbd8a7-a934-46a7-b0b4-11da341386ee
       X-Total-Count:
       - "61"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs
-    method: POST
-  response:
-    body: '{"created_at":"2024-02-22T07:32:02.612055Z","id":"069d0ca3-f4ff-4131-a027-a6dc8771da2e","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:32:02.612055Z"}'
-    headers:
-      Content-Length:
-      - "368"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2483f8a2-9c8f-4ffc-a6ac-01264835d277
     status: 200 OK
     code: 200
     duration: ""
@@ -152,10 +152,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/069d0ca3-f4ff-4131-a027-a6dc8771da2e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/b4e0fca7-b596-4d82-9b0b-d6c2c49af7e4
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:02.612055Z","id":"069d0ca3-f4ff-4131-a027-a6dc8771da2e","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:32:02.612055Z"}'
+    body: '{"created_at":"2024-02-22T07:42:15.267913Z","id":"b4e0fca7-b596-4d82-9b0b-d6c2c49af7e4","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:42:15.267913Z"}'
     headers:
       Content-Length:
       - "368"
@@ -164,7 +164,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:42:15 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -174,7 +174,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1cf751e-3a37-4776-baf8-1559a0329ea5
+      - 65fb9585-2f57-4c20-8f8d-64115b50aad1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null,"vpc_id":"b4e0fca7-b596-4d82-9b0b-d6c2c49af7e4"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2024-02-22T07:42:15.512724Z","dhcp_enabled":true,"id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:42:15.512724Z","id":"92d0ed59-8777-42eb-8b1c-d34caea6cf73","subnet":"172.16.4.0/22","updated_at":"2024-02-22T07:42:15.512724Z"},{"created_at":"2024-02-22T07:42:15.512724Z","id":"142cc505-2ffa-413c-ab68-2b0e38d1dbbb","subnet":"fd5f:519c:6d46:cb7f::/64","updated_at":"2024-02-22T07:42:15.512724Z"}],"tags":[],"updated_at":"2024-02-22T07:42:15.512724Z","vpc_id":"b4e0fca7-b596-4d82-9b0b-d6c2c49af7e4"}'
+    headers:
+      Content-Length:
+      - "736"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:42:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 78553fca-f416-4c7a-9ce6-2e3d95c03d2c
     status: 200 OK
     code: 200
     duration: ""
@@ -192,11 +227,11 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:02.743092+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:42:15.816653+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2788"
@@ -205,9 +240,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:42:16 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -217,7 +252,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6599830f-69b2-4dd3-91fc-54cc5e9c5fe3
+      - ee95ccbb-befc-4704-a5b8-ae6f61d2460a
     status: 201 Created
     code: 201
     duration: ""
@@ -228,25 +263,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:02.743092+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"created_at":"2024-02-22T07:42:15.512724Z","dhcp_enabled":true,"id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:42:15.512724Z","id":"92d0ed59-8777-42eb-8b1c-d34caea6cf73","subnet":"172.16.4.0/22","updated_at":"2024-02-22T07:42:15.512724Z"},{"created_at":"2024-02-22T07:42:15.512724Z","id":"142cc505-2ffa-413c-ab68-2b0e38d1dbbb","subnet":"fd5f:519c:6d46:cb7f::/64","updated_at":"2024-02-22T07:42:15.512724Z"}],"tags":[],"updated_at":"2024-02-22T07:42:15.512724Z","vpc_id":"b4e0fca7-b596-4d82-9b0b-d6c2c49af7e4"}'
     headers:
       Content-Length:
-      - "2788"
+      - "736"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:42:16 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -256,7 +285,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4edd47b-dbb5-4b4f-893e-7e3b10a16a1f
+      - 05831ed5-8b77-4db2-830e-c12fccf32d0a
     status: 200 OK
     code: 200
     duration: ""
@@ -267,16 +296,16 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:02.743092+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:42:15.816653+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2788"
@@ -285,7 +314,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:42:16 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -295,42 +324,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e66f6be-602e-4f58-9102-8570b4d538e6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-tests-ipam-ip-datasource-instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null,"vpc_id":"069d0ca3-f4ff-4131-a027-a6dc8771da2e"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
-    method: POST
-  response:
-    body: '{"created_at":"2024-02-22T07:32:03.021725Z","dhcp_enabled":true,"id":"b72772e8-da19-4421-b779-2f92b04efe75","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:03.021725Z","id":"a83e6d5c-0d56-465d-96fc-89e5079e7121","subnet":"172.16.76.0/22","updated_at":"2024-02-22T07:32:03.021725Z"},{"created_at":"2024-02-22T07:32:03.021725Z","id":"a5b8ee11-4239-4644-bf0e-9ca2e800b43b","subnet":"fd5f:519c:6d46:b555::/64","updated_at":"2024-02-22T07:32:03.021725Z"}],"tags":[],"updated_at":"2024-02-22T07:32:03.021725Z","vpc_id":"069d0ca3-f4ff-4131-a027-a6dc8771da2e"}'
-    headers:
-      Content-Length:
-      - "737"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d9cd3306-2cbf-45e0-80d9-619c96d880cd
+      - 9755b25d-4512-4cee-9569-ad10df127f3c
     status: 200 OK
     code: 200
     duration: ""
@@ -341,19 +335,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b72772e8-da19-4421-b779-2f92b04efe75
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:03.021725Z","dhcp_enabled":true,"id":"b72772e8-da19-4421-b779-2f92b04efe75","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:03.021725Z","id":"a83e6d5c-0d56-465d-96fc-89e5079e7121","subnet":"172.16.76.0/22","updated_at":"2024-02-22T07:32:03.021725Z"},{"created_at":"2024-02-22T07:32:03.021725Z","id":"a5b8ee11-4239-4644-bf0e-9ca2e800b43b","subnet":"fd5f:519c:6d46:b555::/64","updated_at":"2024-02-22T07:32:03.021725Z"}],"tags":[],"updated_at":"2024-02-22T07:32:03.021725Z","vpc_id":"069d0ca3-f4ff-4131-a027-a6dc8771da2e"}'
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:42:15.816653+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "737"
+      - "2788"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:42:16 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -363,7 +363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cee81b92-787d-46f9-b5f8-4f25938c8d9c
+      - b9460640-803b-41a4-a4d2-844eb2626d4a
     status: 200 OK
     code: 200
     duration: ""
@@ -376,10 +376,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/action","href_result":"/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c","id":"c029d1d0-abb8-4ada-bf92-1681899617d6","started_at":"2024-02-22T07:32:03.616748+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/action","href_result":"/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6","id":"de6a786f-1692-41cd-9db6-4e8d493e44ce","started_at":"2024-02-22T07:42:16.625684+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -388,9 +388,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:42:16 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/c029d1d0-abb8-4ada-bf92-1681899617d6
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/de6a786f-1692-41cd-9db6-4e8d493e44ce
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -400,7 +400,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac84b2d9-69f7-485a-83da-a8293e96f8b8
+      - 02918720-bfdc-44e9-b795-0f428a75bd8c
     status: 202 Accepted
     code: 202
     duration: ""
@@ -411,16 +411,16 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:03.437990+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:42:16.488157+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2810"
@@ -429,7 +429,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:04 GMT
+      - Thu, 22 Feb 2024 07:42:17 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -439,7 +439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9e7b86f-68d2-41b7-a7f5-028d78b90fd2
+      - 7097c4b4-6cf8-4c25-a2eb-04be1e7ac16f
     status: 200 OK
     code: 200
     duration: ""
@@ -450,25 +450,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:03.437990+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:42:16.488157+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.160.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2810"
+      - "2920"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:09 GMT
+      - Thu, 22 Feb 2024 07:42:22 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -478,7 +478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d89d54ce-827d-460d-abaf-ade5b9fbf584
+      - 5333681b-830a-4d73-ae0b-337743ff8968
     status: 200 OK
     code: 200
     duration: ""
@@ -489,220 +489,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:03.437990+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2810"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:14 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4175f53a-57ee-4a80-8d37-b8478b6c237c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:03.437990+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2810"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:20 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8878e0f6-4d05-4a62-a7f5-983b56898b9b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:03.437990+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2810"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:25 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - beb19388-48e4-4233-a7fc-efdaf6916b88
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:03.437990+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2810"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fd4143ca-0937-4eb1-b161-94bc73c9097c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:03.437990+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2918"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:35 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 92d4557f-d209-4d47-be4c-e79dca8f5475
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:37.645264+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:42:23.024247+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.160.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2949"
+      - "2951"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:40 GMT
+      - Thu, 22 Feb 2024 07:42:27 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -712,7 +517,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cb2b9a4-b360-41b4-8b82-1edbb639db5d
+      - 3d827294-1fda-4f2a-995c-be7d2d548868
     status: 200 OK
     code: 200
     duration: ""
@@ -723,25 +528,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:37.645264+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:42:23.024247+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.160.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2949"
+      - "2951"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:40 GMT
+      - Thu, 22 Feb 2024 07:42:27 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -751,7 +556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97484453-469f-4639-8f59-cd46da058b55
+      - 2418decf-3661-46e0-a198-a5e11848859d
     status: 200 OK
     code: 200
     duration: ""
@@ -762,7 +567,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -774,7 +579,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:40 GMT
+      - Thu, 22 Feb 2024 07:42:27 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -784,7 +589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a07015ed-f49a-4c3e-8b5c-bafa8474f13b
+      - 553741c5-c2b5-4aaf-864c-4bd625e1814e
     status: 200 OK
     code: 200
     duration: ""
@@ -795,7 +600,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -807,9 +612,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:41 GMT
+      - Thu, 22 Feb 2024 07:42:27 GMT
       Link:
-      - </servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics?page=0&per_page=50&>;
+      - </servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
@@ -820,7 +625,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cfd2500d-e9e7-4be5-a1ba-a9b26fd791e3
+      - 77203a8a-0bec-486c-8996-c963c1757bba
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -833,25 +638,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:37.645264+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:42:23.024247+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.160.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2949"
+      - "2951"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:41 GMT
+      - Thu, 22 Feb 2024 07:42:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -861,12 +666,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7659c28d-cfdf-4583-9816-787bac8c95ab
+      - b670fa60-4943-4548-ba01-294858cc2001
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75"}'
+    body: '{"private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00"}'
     form: {}
     headers:
       Content-Type:
@@ -874,10 +679,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:41.298204+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:42:28.149974+00:00","id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8b:c0","modification_date":"2024-02-22T07:42:28.149974+00:00","private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","server_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -886,7 +691,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:41 GMT
+      - Thu, 22 Feb 2024 07:42:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -896,7 +701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e9d0c5d-cc90-4a6a-9b51-d43bc947a1bb
+      - b10dd27b-700a-45d4-832c-c18c25c2e123
     status: 201 Created
     code: 201
     duration: ""
@@ -907,10 +712,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics/6c5451c0-dbe4-48d1-bec1-efaaf58e9142
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:41.298204+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:42:28.149974+00:00","id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8b:c0","modification_date":"2024-02-22T07:42:28.149974+00:00","private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","server_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -919,7 +724,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:41 GMT
+      - Thu, 22 Feb 2024 07:42:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -929,7 +734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50732c0e-e481-4e01-a0cc-18b7676c3fa9
+      - 12a6fbc5-e9dc-4615-9173-bcaf707f88c9
     status: 200 OK
     code: 200
     duration: ""
@@ -940,10 +745,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics/6c5451c0-dbe4-48d1-bec1-efaaf58e9142
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:42.155663+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:42:28.149974+00:00","id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8b:c0","modification_date":"2024-02-22T07:42:29.040246+00:00","private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","server_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -952,7 +757,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:47 GMT
+      - Thu, 22 Feb 2024 07:42:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -962,7 +767,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b0cfe3f-67c5-4def-aa1b-7a705c50bddd
+      - 2ef58a82-56b6-4172-8317-16fcf3035bd4
     status: 200 OK
     code: 200
     duration: ""
@@ -973,10 +778,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics/6c5451c0-dbe4-48d1-bec1-efaaf58e9142
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:42.155663+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:42:28.149974+00:00","id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8b:c0","modification_date":"2024-02-22T07:42:29.040246+00:00","private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","server_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -985,7 +790,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:52 GMT
+      - Thu, 22 Feb 2024 07:42:38 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -995,7 +800,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5097b8bc-dea8-407e-ad01-2a4fd09c4994
+      - af5f474f-34a6-41e2-8b54-a6be18c39e06
     status: 200 OK
     code: 200
     duration: ""
@@ -1006,10 +811,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics/6c5451c0-dbe4-48d1-bec1-efaaf58e9142
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:42.155663+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:42:28.149974+00:00","id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8b:c0","modification_date":"2024-02-22T07:42:29.040246+00:00","private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","server_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1018,7 +823,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:57 GMT
+      - Thu, 22 Feb 2024 07:42:43 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1028,7 +833,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a11fb9e0-2b92-4b67-af15-f1e052d6838e
+      - bbdf7d96-82f2-4949-b021-fee577029348
     status: 200 OK
     code: 200
     duration: ""
@@ -1039,10 +844,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics/6c5451c0-dbe4-48d1-bec1-efaaf58e9142
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:42.155663+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:42:28.149974+00:00","id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8b:c0","modification_date":"2024-02-22T07:42:29.040246+00:00","private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","server_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1051,7 +856,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:02 GMT
+      - Thu, 22 Feb 2024 07:42:48 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1061,7 +866,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1cf79ef7-3030-4b3a-be60-1f5eaa6898b1
+      - 15058818-95eb-474d-ad0f-3baa0fa6b1b9
     status: 200 OK
     code: 200
     duration: ""
@@ -1072,10 +877,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics/6c5451c0-dbe4-48d1-bec1-efaaf58e9142
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:42.155663+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:42:28.149974+00:00","id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8b:c0","modification_date":"2024-02-22T07:42:29.040246+00:00","private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","server_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1084,7 +889,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:07 GMT
+      - Thu, 22 Feb 2024 07:42:54 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1094,7 +899,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3ccce43-c746-4e72-977d-e5fd9f83473a
+      - 889d9153-b73b-4efb-840d-0c5ef9949f83
     status: 200 OK
     code: 200
     duration: ""
@@ -1105,10 +910,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics/6c5451c0-dbe4-48d1-bec1-efaaf58e9142
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:32:42.155663+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:42:28.149974+00:00","id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8b:c0","modification_date":"2024-02-22T07:42:29.040246+00:00","private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","server_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1117,7 +922,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:12 GMT
+      - Thu, 22 Feb 2024 07:42:59 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1127,7 +932,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c34f122-42a3-48a4-90f3-41ee07be9018
+      - 5ed4ec07-f3b5-44c8-b838-bcaebccd7c46
     status: 200 OK
     code: 200
     duration: ""
@@ -1138,10 +943,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics/6c5451c0-dbe4-48d1-bec1-efaaf58e9142
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:33:12.540465+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:42:28.149974+00:00","id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8b:c0","modification_date":"2024-02-22T07:43:01.344212+00:00","private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","server_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1150,7 +955,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:17 GMT
+      - Thu, 22 Feb 2024 07:43:04 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1160,7 +965,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e9d7ac5-f17a-4a2a-b0e3-e0408bfc3d57
+      - 802b9cb9-8aab-4e64-8943-cea2f3521eab
     status: 200 OK
     code: 200
     duration: ""
@@ -1171,10 +976,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics/6c5451c0-dbe4-48d1-bec1-efaaf58e9142
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:33:12.540465+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:42:28.149974+00:00","id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8b:c0","modification_date":"2024-02-22T07:43:01.344212+00:00","private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","server_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1183,7 +988,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:17 GMT
+      - Thu, 22 Feb 2024 07:43:04 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1193,7 +998,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb9ff94b-a585-4654-ab2b-9b53c377c6a4
+      - d8e3f21c-d4a7-47e0-8554-5f005d2c8364
     status: 200 OK
     code: 200
     duration: ""
@@ -1204,19 +1009,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab8&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=6c5451c0-dbe4-48d1-bec1-efaaf58e9142&resource_type=instance_private_nic
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.4.2/22","created_at":"2024-02-22T07:42:28.961824Z","id":"b60fcf2f-fc09-442e-9c6f-4f5ee95fcf9d","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8B:C0","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"92d0ed59-8777-42eb-8b1c-d34caea6cf73"},"tags":[],"updated_at":"2024-02-22T07:42:28.961824Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "550"
+      - "549"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:17 GMT
+      - Thu, 22 Feb 2024 07:43:04 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1226,7 +1031,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f68e2a75-6eb7-4865-ac4f-fb40a330521a
+      - 55b85160-4d7d-4671-8f94-fdf0acf17672
     status: 200 OK
     code: 200
     duration: ""
@@ -1237,19 +1042,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=04d0831f-b7c0-4d99-9013-1a66402565a0&resource_type=instance_private_nic
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ac0&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.4.2/22","created_at":"2024-02-22T07:42:28.961824Z","id":"b60fcf2f-fc09-442e-9c6f-4f5ee95fcf9d","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8B:C0","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"92d0ed59-8777-42eb-8b1c-d34caea6cf73"},"tags":[],"updated_at":"2024-02-22T07:42:28.961824Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "550"
+      - "549"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:17 GMT
+      - Thu, 22 Feb 2024 07:43:04 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1259,7 +1064,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d82034d-0de2-4401-ae69-093fca929cf7
+      - 4510b323-ad5d-43e3-954a-dac163b60b9c
     status: 200 OK
     code: 200
     duration: ""
@@ -1270,19 +1075,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=04d0831f-b7c0-4d99-9013-1a66402565a0&resource_type=instance_private_nic
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ac0&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.4.2/22","created_at":"2024-02-22T07:42:28.961824Z","id":"b60fcf2f-fc09-442e-9c6f-4f5ee95fcf9d","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8B:C0","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"92d0ed59-8777-42eb-8b1c-d34caea6cf73"},"tags":[],"updated_at":"2024-02-22T07:42:28.961824Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "550"
+      - "549"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:17 GMT
+      - Thu, 22 Feb 2024 07:43:04 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1292,7 +1097,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf12c8d9-92f3-4bc5-a308-24c4c234b671
+      - c9512596-52b0-4f5d-913c-d109c6547378
     status: 200 OK
     code: 200
     duration: ""
@@ -1303,19 +1108,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab8&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=6c5451c0-dbe4-48d1-bec1-efaaf58e9142&resource_type=instance_private_nic
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.4.2/22","created_at":"2024-02-22T07:42:28.961824Z","id":"b60fcf2f-fc09-442e-9c6f-4f5ee95fcf9d","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8B:C0","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"92d0ed59-8777-42eb-8b1c-d34caea6cf73"},"tags":[],"updated_at":"2024-02-22T07:42:28.961824Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "550"
+      - "549"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:17 GMT
+      - Thu, 22 Feb 2024 07:43:04 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1325,7 +1130,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0047514-dc91-4fd6-a2e4-d54ab680c753
+      - a9890756-4443-497b-a28b-25389d9faf4b
     status: 200 OK
     code: 200
     duration: ""
@@ -1336,10 +1141,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/069d0ca3-f4ff-4131-a027-a6dc8771da2e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/b4e0fca7-b596-4d82-9b0b-d6c2c49af7e4
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:02.612055Z","id":"069d0ca3-f4ff-4131-a027-a6dc8771da2e","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:32:02.612055Z"}'
+    body: '{"created_at":"2024-02-22T07:42:15.267913Z","id":"b4e0fca7-b596-4d82-9b0b-d6c2c49af7e4","is_default":false,"name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","tags":[],"updated_at":"2024-02-22T07:42:15.267913Z"}'
     headers:
       Content-Length:
       - "368"
@@ -1348,7 +1153,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:18 GMT
+      - Thu, 22 Feb 2024 07:43:05 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1358,7 +1163,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1395fdc-38a1-4bb6-adce-cfaa84e246bb
+      - 8f867443-973f-4499-8ee7-45de3939be50
     status: 200 OK
     code: 200
     duration: ""
@@ -1369,19 +1174,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b72772e8-da19-4421-b779-2f92b04efe75
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:03.021725Z","dhcp_enabled":true,"id":"b72772e8-da19-4421-b779-2f92b04efe75","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:03.021725Z","id":"a83e6d5c-0d56-465d-96fc-89e5079e7121","subnet":"172.16.76.0/22","updated_at":"2024-02-22T07:32:03.021725Z"},{"created_at":"2024-02-22T07:32:03.021725Z","id":"a5b8ee11-4239-4644-bf0e-9ca2e800b43b","subnet":"fd5f:519c:6d46:b555::/64","updated_at":"2024-02-22T07:32:03.021725Z"}],"tags":[],"updated_at":"2024-02-22T07:32:03.021725Z","vpc_id":"069d0ca3-f4ff-4131-a027-a6dc8771da2e"}'
+    body: '{"created_at":"2024-02-22T07:42:15.512724Z","dhcp_enabled":true,"id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","name":"tf-tests-ipam-ip-datasource-instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:42:15.512724Z","id":"92d0ed59-8777-42eb-8b1c-d34caea6cf73","subnet":"172.16.4.0/22","updated_at":"2024-02-22T07:42:15.512724Z"},{"created_at":"2024-02-22T07:42:15.512724Z","id":"142cc505-2ffa-413c-ab68-2b0e38d1dbbb","subnet":"fd5f:519c:6d46:cb7f::/64","updated_at":"2024-02-22T07:42:15.512724Z"}],"tags":[],"updated_at":"2024-02-22T07:42:15.512724Z","vpc_id":"b4e0fca7-b596-4d82-9b0b-d6c2c49af7e4"}'
     headers:
       Content-Length:
-      - "737"
+      - "736"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:18 GMT
+      - Thu, 22 Feb 2024 07:43:05 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1391,7 +1196,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1350ccfd-3a5a-484e-bf94-57b64b7cf668
+      - 6ba162b5-8ab7-46ac-9498-5f7b969e8aa6
     status: 200 OK
     code: 200
     duration: ""
@@ -1402,25 +1207,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:37.645264+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:33:12.540465+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:42:23.024247+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.160.143","private_nics":[{"creation_date":"2024-02-22T07:42:28.149974+00:00","id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8b:c0","modification_date":"2024-02-22T07:43:01.344212+00:00","private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","server_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3302"
+      - "3304"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:18 GMT
+      - Thu, 22 Feb 2024 07:43:05 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1430,7 +1235,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5c0c8e8-1182-447f-b09f-e61a88d8e6c2
+      - f7438672-0e8f-4cac-82dd-55efbfbbabae
     status: 200 OK
     code: 200
     duration: ""
@@ -1441,7 +1246,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1453,7 +1258,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:18 GMT
+      - Thu, 22 Feb 2024 07:43:05 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1463,7 +1268,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7be3e0b-3caa-4172-962c-538333332948
+      - 75f99d37-506e-4078-af53-680c9dda1e27
     status: 200 OK
     code: 200
     duration: ""
@@ -1474,10 +1279,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:33:12.540465+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:42:28.149974+00:00","id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8b:c0","modification_date":"2024-02-22T07:43:01.344212+00:00","private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","server_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1486,9 +1291,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:18 GMT
+      - Thu, 22 Feb 2024 07:43:05 GMT
       Link:
-      - </servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics?page=1&per_page=50&>;
+      - </servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
@@ -1499,7 +1304,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d144054-c5d5-4d2d-951d-e33b565eae5b
+      - a594109a-735d-49e4-bb71-266e10fbc8f8
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1512,10 +1317,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics/6c5451c0-dbe4-48d1-bec1-efaaf58e9142
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:33:12.540465+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:42:28.149974+00:00","id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8b:c0","modification_date":"2024-02-22T07:43:01.344212+00:00","private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","server_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1524,7 +1329,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:18 GMT
+      - Thu, 22 Feb 2024 07:43:05 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1534,7 +1339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6573ee3c-1284-42d6-9738-78eaf951ea02
+      - 009e32d5-8b0e-4a2e-93e7-e96833e6eefa
     status: 200 OK
     code: 200
     duration: ""
@@ -1545,19 +1350,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab8&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=6c5451c0-dbe4-48d1-bec1-efaaf58e9142&resource_type=instance_private_nic
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.4.2/22","created_at":"2024-02-22T07:42:28.961824Z","id":"b60fcf2f-fc09-442e-9c6f-4f5ee95fcf9d","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8B:C0","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"92d0ed59-8777-42eb-8b1c-d34caea6cf73"},"tags":[],"updated_at":"2024-02-22T07:42:28.961824Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "550"
+      - "549"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:18 GMT
+      - Thu, 22 Feb 2024 07:43:05 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1567,7 +1372,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acec32e8-5732-43ba-b642-e3246128c9f7
+      - 982a662f-8000-4ccb-b0e4-8bfc27c48df0
     status: 200 OK
     code: 200
     duration: ""
@@ -1578,19 +1383,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=04d0831f-b7c0-4d99-9013-1a66402565a0&resource_type=instance_private_nic
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ac0&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.4.2/22","created_at":"2024-02-22T07:42:28.961824Z","id":"b60fcf2f-fc09-442e-9c6f-4f5ee95fcf9d","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8B:C0","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"92d0ed59-8777-42eb-8b1c-d34caea6cf73"},"tags":[],"updated_at":"2024-02-22T07:42:28.961824Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "550"
+      - "549"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:18 GMT
+      - Thu, 22 Feb 2024 07:43:05 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1600,7 +1405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cef2e2e-8290-4e45-93de-5d77fc9e121f
+      - 0de1d4bb-84d2-497b-ad7d-0159d1936224
     status: 200 OK
     code: 200
     duration: ""
@@ -1611,19 +1416,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=04d0831f-b7c0-4d99-9013-1a66402565a0&resource_type=instance_private_nic
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ac0&order_by=created_at_desc&page=1&resource_type=unknown_type
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.4.2/22","created_at":"2024-02-22T07:42:28.961824Z","id":"b60fcf2f-fc09-442e-9c6f-4f5ee95fcf9d","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8B:C0","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"92d0ed59-8777-42eb-8b1c-d34caea6cf73"},"tags":[],"updated_at":"2024-02-22T07:42:28.961824Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "550"
+      - "549"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:18 GMT
+      - Thu, 22 Feb 2024 07:43:05 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1633,7 +1438,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f16d6ebb-c94a-4f97-9235-1097babf386d
+      - fffd888c-65cf-4572-8e5e-e3ea9d00a20e
     status: 200 OK
     code: 200
     duration: ""
@@ -1644,19 +1449,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&mac_address=02%3A00%3A00%3A18%3A8b%3Ab8&order_by=created_at_desc&page=1&resource_type=unknown_type
+    url: https://api.scaleway.com/ipam/v1/regions/fr-par/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=6c5451c0-dbe4-48d1-bec1-efaaf58e9142&resource_type=instance_private_nic
     method: GET
   response:
-    body: '{"ips":[{"address":"172.16.76.2/22","created_at":"2024-02-22T07:32:42.060775Z","id":"1f95115b-ea0f-44c2-9631-e2f709b78f9f","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8B:B8","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"a83e6d5c-0d56-465d-96fc-89e5079e7121"},"tags":[],"updated_at":"2024-02-22T07:32:42.060775Z","zone":null}],"total_count":1}'
+    body: '{"ips":[{"address":"172.16.4.2/22","created_at":"2024-02-22T07:42:28.961824Z","id":"b60fcf2f-fc09-442e-9c6f-4f5ee95fcf9d","is_ipv6":false,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","resource":{"id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8B:C0","name":"tf-tests-ipam-ip-datasource-instance","type":"instance_private_nic"},"reverses":[],"source":{"subnet_id":"92d0ed59-8777-42eb-8b1c-d34caea6cf73"},"tags":[],"updated_at":"2024-02-22T07:42:28.961824Z","zone":null}],"total_count":1}'
     headers:
       Content-Length:
-      - "550"
+      - "549"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:18 GMT
+      - Thu, 22 Feb 2024 07:43:05 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1666,7 +1471,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f6bbbec-2bb9-4e15-ad29-0ca9cf723e53
+      - 009ddae6-d05f-440f-9816-ab266822a21b
     status: 200 OK
     code: 200
     duration: ""
@@ -1677,10 +1482,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics/6c5451c0-dbe4-48d1-bec1-efaaf58e9142
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:41.298204+00:00","id":"04d0831f-b7c0-4d99-9013-1a66402565a0","mac_address":"02:00:00:18:8b:b8","modification_date":"2024-02-22T07:33:12.540465+00:00","private_network_id":"b72772e8-da19-4421-b779-2f92b04efe75","server_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:42:28.149974+00:00","id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","mac_address":"02:00:00:18:8b:c0","modification_date":"2024-02-22T07:43:01.344212+00:00","private_network_id":"907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00","server_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1689,7 +1494,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:19 GMT
+      - Thu, 22 Feb 2024 07:43:06 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1699,7 +1504,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b6825df-3e84-46ad-9911-4ecdda53b418
+      - a5352fe8-8e65-4906-be96-5082da5478a3
     status: 200 OK
     code: 200
     duration: ""
@@ -1710,7 +1515,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics/6c5451c0-dbe4-48d1-bec1-efaaf58e9142
     method: DELETE
   response:
     body: ""
@@ -1718,7 +1523,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 22 Feb 2024 07:33:19 GMT
+      - Thu, 22 Feb 2024 07:43:06 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1728,7 +1533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a27a145e-e285-4725-b61d-867d4329a30c
+      - aebf82bb-d592-406d-8177-241c15c1f8ca
     status: 204 No Content
     code: 204
     duration: ""
@@ -1739,10 +1544,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/private_nics/04d0831f-b7c0-4d99-9013-1a66402565a0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/private_nics/6c5451c0-dbe4-48d1-bec1-efaaf58e9142
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"04d0831f-b7c0-4d99-9013-1a66402565a0","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"6c5451c0-dbe4-48d1-bec1-efaaf58e9142","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -1751,7 +1556,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:19 GMT
+      - Thu, 22 Feb 2024 07:43:06 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1761,7 +1566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5277b3bb-4781-4188-9da1-279ba60a54c7
+      - f9fc1aa0-2f9e-4524-8e6a-f77600362e9c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1772,25 +1577,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:32:37.645264+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:42:23.024247+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.160.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2941"
+      - "2943"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:19 GMT
+      - Thu, 22 Feb 2024 07:43:06 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1800,7 +1605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3837422c-3384-4c7c-9c66-eda1ec48449b
+      - 9815b5d5-ac8d-49e3-a6be-4205267a0a49
     status: 200 OK
     code: 200
     duration: ""
@@ -1813,10 +1618,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c/action","href_result":"/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c","id":"84c98fe4-cdf4-4b0d-a0d0-807861d62df5","started_at":"2024-02-22T07:33:20.021297+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6/action","href_result":"/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6","id":"fbef2777-932b-4fef-a8d6-88fde55028e3","started_at":"2024-02-22T07:43:07.118324+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -1825,9 +1630,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:20 GMT
+      - Thu, 22 Feb 2024 07:43:07 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/84c98fe4-cdf4-4b0d-a0d0-807861d62df5
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/fbef2777-932b-4fef-a8d6-88fde55028e3
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1837,7 +1642,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5cbcec5-4809-41b6-a46c-898f0cea9b77
+      - 2ace8657-50c0-4bc1-904c-2ea4ad1a7839
     status: 202 Accepted
     code: 202
     duration: ""
@@ -1848,59 +1653,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b72772e8-da19-4421-b779-2f92b04efe75
-    method: DELETE
-  response:
-    body: '{"help_message":"Private Network must be empty to be deleted","message":"precondition
-      is not respected","precondition":"resource_still_in_use","type":"precondition_failed"}'
-    headers:
-      Content-Length:
-      - "172"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:33:20 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fd2a9533-3d43-4a6a-a05b-5d83c2a049df
-    status: 412 Precondition Failed
-    code: 412
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:33:19.860342+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:43:06.962323+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.160.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2909"
+      - "2911"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:20 GMT
+      - Thu, 22 Feb 2024 07:43:07 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1910,7 +1681,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d9a848d-d0a2-447e-b106-24b9b8d640f9
+      - 7325db3c-7450-4c53-8f50-145cb01a2921
     status: 200 OK
     code: 200
     duration: ""
@@ -1921,7 +1692,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b72772e8-da19-4421-b779-2f92b04efe75
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/907b63f3-d7ea-4ce8-b6c5-d169ad8e8b00
     method: DELETE
   response:
     body: ""
@@ -1931,7 +1702,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:21 GMT
+      - Thu, 22 Feb 2024 07:43:07 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1941,7 +1712,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - deeae898-e967-454a-8824-ef68b50d576b
+      - a1618a27-6c34-4767-b91b-82b52f984bf0
     status: 204 No Content
     code: 204
     duration: ""
@@ -1952,7 +1723,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/069d0ca3-f4ff-4131-a027-a6dc8771da2e
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/vpcs/b4e0fca7-b596-4d82-9b0b-d6c2c49af7e4
     method: DELETE
   response:
     body: ""
@@ -1962,7 +1733,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:21 GMT
+      - Thu, 22 Feb 2024 07:43:08 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1972,7 +1743,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b32cdeca-9df5-4118-b9c7-6f94845c974b
+      - d57a4a4a-c888-49f0-b0f7-d125861825b4
     status: 204 No Content
     code: 204
     duration: ""
@@ -1983,25 +1754,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:33:19.860342+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:43:06.962323+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.160.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2909"
+      - "2911"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:25 GMT
+      - Thu, 22 Feb 2024 07:43:12 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2011,7 +1782,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9656fec7-2cc8-4558-a640-1814f064bbd8
+      - 8b522c52-f55f-4a92-b7f3-944050135d9c
     status: 200 OK
     code: 200
     duration: ""
@@ -2022,25 +1793,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:33:19.860342+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:43:06.962323+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.160.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2909"
+      - "2911"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:30 GMT
+      - Thu, 22 Feb 2024 07:43:17 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2050,7 +1821,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af38dfa9-b534-44d5-adea-e9f83b8edf43
+      - 02497b42-2aa4-48cb-bc6e-994baf6e0991
     status: 200 OK
     code: 200
     duration: ""
@@ -2061,25 +1832,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"601","node_id":"67","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:33:19.860342+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.75.60.133","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:43:06.962323+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.160.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2909"
+      - "2911"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:35 GMT
+      - Thu, 22 Feb 2024 07:43:23 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2089,7 +1860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2e29f2e-db65-433c-abea-69d68d637d14
+      - 87e55bd0-092e-4c68-a2b4-a40ff4444a98
     status: 200 OK
     code: 200
     duration: ""
@@ -2100,16 +1871,16 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:33:38.943568+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:43:23.882323+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2788"
@@ -2118,7 +1889,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:40 GMT
+      - Thu, 22 Feb 2024 07:43:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2128,7 +1899,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4517ef72-c539-42a4-bc5a-022487138ac2
+      - 13d97f61-6dba-4a1c-94db-7ed8d0aa0172
     status: 200 OK
     code: 200
     duration: ""
@@ -2139,16 +1910,16 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:32:02.743092+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-MICRO","creation_date":"2024-02-22T07:42:15.816653+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-ipam-ip-datasource-instance","id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
       22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a3","maintenances":[],"modification_date":"2024-02-22T07:33:38.943568+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.743092+00:00","export_uri":null,"id":"4af93a15-8dcd-4071-82f5-25822f6944fc","modification_date":"2024-02-22T07:32:02.743092+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:f5","maintenances":[],"modification_date":"2024-02-22T07:43:23.882323+00:00","name":"tf-tests-ipam-ip-datasource-instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","data_scaleway_instance_servers","basic"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:42:15.816653+00:00","export_uri":null,"id":"658b8f76-5e3d-4368-b1c0-e00fa4334957","modification_date":"2024-02-22T07:42:15.816653+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","name":"tf-tests-ipam-ip-datasource-instance"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2788"
@@ -2157,7 +1928,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:41 GMT
+      - Thu, 22 Feb 2024 07:43:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2167,7 +1938,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d013d055-4d5b-4530-ab1a-8c34ca42a194
+      - 01616286-0d8a-4eae-888d-67507d33e06b
     status: 200 OK
     code: 200
     duration: ""
@@ -2178,7 +1949,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: DELETE
   response:
     body: ""
@@ -2186,7 +1957,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 22 Feb 2024 07:33:41 GMT
+      - Thu, 22 Feb 2024 07:43:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2196,7 +1967,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffe7e702-355e-4313-b55e-02a5d7e321fd
+      - e787eed0-94bb-4946-b858-b13126b88273
     status: 204 No Content
     code: 204
     duration: ""
@@ -2207,10 +1978,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -2219,7 +1990,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:41 GMT
+      - Thu, 22 Feb 2024 07:43:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2229,7 +2000,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22725152-9949-48d0-810d-c875f451e449
+      - db283145-580e-4ebf-acdb-43db4006047e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2240,7 +2011,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4af93a15-8dcd-4071-82f5-25822f6944fc
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/658b8f76-5e3d-4368-b1c0-e00fa4334957
     method: DELETE
   response:
     body: ""
@@ -2248,7 +2019,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 22 Feb 2024 07:33:41 GMT
+      - Thu, 22 Feb 2024 07:43:29 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2258,7 +2029,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7c477be-a553-429c-a507-a8478a5c68df
+      - e02675c3-b32a-4b17-80d1-dc57ad285d7e
     status: 204 No Content
     code: 204
     duration: ""
@@ -2269,10 +2040,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3e6fc56-bbf7-46e5-b646-f519767e974c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/42b849af-27c7-42e0-ac1f-7b20af1e5dd6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e3e6fc56-bbf7-46e5-b646-f519767e974c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"42b849af-27c7-42e0-ac1f-7b20af1e5dd6","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -2281,7 +2052,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:41 GMT
+      - Thu, 22 Feb 2024 07:43:29 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2291,7 +2062,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 526e90ec-ccc3-47e0-9317-f390c79bc7c5
+      - 53a82ba3-95b2-4eec-9af1-cb54d229707c
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-vpc-public-gateway-dhcp-reservation-basic.cassette.yaml
+++ b/scaleway/testdata/data-source-vpc-public-gateway-dhcp-reservation-basic.cassette.yaml
@@ -2,18 +2,18 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","subnet":"192.168.1.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -22,9 +22,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:42 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b6413ea-2d16-43c8-be7c-d5c3c37bc0fc
+      - d34c9ff2-bc89-4228-aa1f-366a28d27385
     status: 200 OK
     code: 200
     duration: ""
@@ -41,12 +41,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/70d2fd66-fbb2-4df0-9e0e-ddbe1296f683
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/f7d23fec-9133-4f33-ae5e-94e4723869bc
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -55,9 +55,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:42 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -65,34 +65,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20350060-a8bc-4981-9edd-eeec7e35faaa
+      - af03560c-5ef0-4e85-89b4-0eb198e745c4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":null,"id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":null,"id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "367"
+      - "371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:42 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2942bda-6f66-43ef-906d-0aff3adbd154
+      - 3e222d27-5d71-44fe-8aba-0f626d214adf
     status: 200 OK
     code: 200
     duration: ""
@@ -109,23 +109,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/e07bc539-52e1-4b82-9c89-5cebbcc0753b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/d6db597b-4be9-4404-afb4-3c7ac9b52772
     method: GET
   response:
-    body: '{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":null,"id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":null,"id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "367"
+      - "371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:43 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -133,34 +133,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74fb51eb-e7ab-4e90-8525-a71f6c6d90cc
+      - 27343aa7-d88b-438e-8c7c-e02ff71ec570
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","enable_smtp":false,"enable_bastion":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:43.078930Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:03.359296Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "969"
+      - "1002"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:43 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -168,67 +168,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acb492ac-6b13-4b2b-81dc-39574faa86d9
+      - cf7b5e1d-a35c-4301-9147-cc838413c3c2
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:43.078930Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "969"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 08:59:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 134a6014-fdd2-419e-8fc6-1a923d0e18cc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-27T08:59:42.335705Z","dhcp_enabled":true,"id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T08:59:42.335705Z","id":"6d73c456-fa7c-4640-8932-d74994d73fd7","subnet":"172.16.72.0/22","updated_at":"2023-10-27T08:59:42.335705Z"},{"created_at":"2023-10-27T08:59:42.335705Z","id":"9388d2f4-015d-49eb-a164-3808575ecc31","subnet":"fd46:78ab:30b8:39e5::/64","updated_at":"2023-10-27T08:59:42.335705Z"}],"tags":[],"updated_at":"2023-10-27T08:59:42.335705Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-22T07:32:02.945669Z","dhcp_enabled":true,"id":"d37ac80f-a813-4079-bd5d-e8f89681570d","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.945669Z","id":"57e60c4f-ec5c-4922-8e84-e6d4bbdc8f16","subnet":"172.16.4.0/22","updated_at":"2024-02-22T07:32:02.945669Z"},{"created_at":"2024-02-22T07:32:02.945669Z","id":"2e9dddae-7e6d-4e21-9ac0-9927491ae10c","subnet":"fd5f:519c:6d46:4541::/64","updated_at":"2024-02-22T07:32:02.945669Z"}],"tags":[],"updated_at":"2024-02-22T07:32:02.945669Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "763"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:43 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -236,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea774ffc-23f9-4f4f-ab80-18e8a2a537e7
+      - 27f6e66d-efe9-48b2-903d-0b7ab2d9e410
     status: 200 OK
     code: 200
     duration: ""
@@ -245,23 +212,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ac96a017-00ac-4d5f-9e03-00d3e4ca3113
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d37ac80f-a813-4079-bd5d-e8f89681570d
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T08:59:42.335705Z","dhcp_enabled":true,"id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T08:59:42.335705Z","id":"6d73c456-fa7c-4640-8932-d74994d73fd7","subnet":"172.16.72.0/22","updated_at":"2023-10-27T08:59:42.335705Z"},{"created_at":"2023-10-27T08:59:42.335705Z","id":"9388d2f4-015d-49eb-a164-3808575ecc31","subnet":"fd46:78ab:30b8:39e5::/64","updated_at":"2023-10-27T08:59:42.335705Z"}],"tags":[],"updated_at":"2023-10-27T08:59:42.335705Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-22T07:32:02.945669Z","dhcp_enabled":true,"id":"d37ac80f-a813-4079-bd5d-e8f89681570d","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.945669Z","id":"57e60c4f-ec5c-4922-8e84-e6d4bbdc8f16","subnet":"172.16.4.0/22","updated_at":"2024-02-22T07:32:02.945669Z"},{"created_at":"2024-02-22T07:32:02.945669Z","id":"2e9dddae-7e6d-4e21-9ac0-9927491ae10c","subnet":"fd5f:519c:6d46:4541::/64","updated_at":"2024-02-22T07:32:02.945669Z"}],"tags":[],"updated_at":"2024-02-22T07:32:02.945669Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "763"
+      - "762"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:43 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -269,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1e00f90-ebe7-45b4-9d67-38318de55971
+      - 5bccf422-5d6e-4be4-9009-213424e297f1
     status: 200 OK
     code: 200
     duration: ""
@@ -278,23 +245,56 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:03.359296Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1002"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7b9fd558-56fb-464d-a17b-e8a0f45993db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"10b2d3c3-bfa7-42d4-910b-389e95f95ccb","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2f1f7a57-c508-4f72-9f7f-536b316f36e1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"5d083890-4354-47ab-b769-8b0de601eb3a","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1256"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:43 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -302,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c5c62be-0826-410f-a7e4-b4a5db814576
+      - 6eccde2b-aa83-4b19-b5db-90d94cec2614
     status: 200 OK
     code: 200
     duration: ""
@@ -311,26 +311,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38421"
+      - "38183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:43 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -338,9 +338,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4162a1d8-3e19-476a-b27a-4214040a8cf1
+      - 4b263b52-5363-427a-8366-dcc90f4c8c9f
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
@@ -349,26 +349,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4865"
+      - "8882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:43 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -376,44 +376,44 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b20904ad-e1f3-4fc9-a8a0-ee465b713adc
+      - 453c95bc-972a-4f80-b2b9-dce2cf668c83
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-bold-driscoll","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5"}'
+    body: '{"name":"tf-srv-crazy-meitner","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5d083890-4354-47ab-b769-8b0de601eb3a","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T08:59:43.820693+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:32:03.815709+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2642"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:44 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -421,7 +421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cce2a31d-776e-429e-933f-0e0f9f800d1b
+      - 45e8917b-6392-4673-97bd-352b981fb6b5
     status: 201 Created
     code: 201
     duration: ""
@@ -430,29 +430,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T08:59:43.820693+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:32:03.815709+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2642"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:44 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -460,7 +460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bf0aed7-f54c-4fac-9a19-6f74bf261874
+      - 5018c42c-ab5e-4e40-a5aa-6591999a4759
     status: 200 OK
     code: 200
     duration: ""
@@ -469,29 +469,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T08:59:43.820693+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:32:03.815709+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2642"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:44 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -499,7 +499,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c491e5b6-a4ac-48a5-bb58-c6a4c3703441
+      - 09f27bc7-3442-491b-ba6d-671e75b69b32
     status: 200 OK
     code: 200
     duration: ""
@@ -510,12 +510,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/action","href_result":"/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","id":"a2d1b7d8-40b2-4534-a769-a0169f2d7394","started_at":"2023-10-27T08:59:44.704698+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/action","href_result":"/servers/e07a44a7-d0ea-4221-aac9-887f22e77201","id":"db27f506-2f57-40ef-8b17-5c0755198796","started_at":"2024-02-22T07:32:05.290017+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -524,11 +524,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:44 GMT
+      - Thu, 22 Feb 2024 07:32:05 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/a2d1b7d8-40b2-4534-a769-a0169f2d7394
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/db27f506-2f57-40ef-8b17-5c0755198796
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -536,7 +536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9177db20-50d5-4a1e-978c-6e74defc6664
+      - f359ea53-5bb0-4c2e-8af8-a25e14800c99
     status: 202 Accepted
     code: 202
     duration: ""
@@ -545,29 +545,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T08:59:44.383437+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:32:04.863617+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2664"
+      - "2686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:44 GMT
+      - Thu, 22 Feb 2024 07:32:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -575,7 +575,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7141ef2f-41a2-4d83-b268-333c04fc0428
+      - de0ffc4d-1d3a-43b7-adab-2f2c4984dc31
     status: 200 OK
     code: 200
     duration: ""
@@ -584,23 +584,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:43.708649Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.783441Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "969"
+      - "1002"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:48 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -608,7 +608,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 041182b2-1cf2-4cd8-911f-7bd35c5fec4c
+      - 4f93dd71-38a2-440d-aa83-ff036029d437
     status: 200 OK
     code: 200
     duration: ""
@@ -617,23 +617,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:43.708649Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.783441Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "969"
+      - "1002"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:48 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -641,7 +641,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b55a90e6-cd62-41c8-8c54-df88ae22f8a4
+      - 0059e4b4-0124-4ceb-9441-24dce50804e7
     status: 200 OK
     code: 200
     duration: ""
@@ -650,23 +650,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:43.708649Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.783441Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "969"
+      - "1002"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:48 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -674,23 +674,62 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6691c258-3bb6-493e-84a4-283eb37fbea8
+      - 1d881851-3709-4e3a-9dcf-639adbdab813
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:32:04.863617+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2796"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:10 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b26696a5-8612-403c-b460-477a07cf8655
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"f7d23fec-9133-4f33-ae5e-94e4723869bc"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":null,"private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"created","updated_at":"2023-10-27T08:59:49.605563Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":null,"private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"created","updated_at":"2024-02-22T07:32:10.899845Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "983"
@@ -699,9 +738,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:49 GMT
+      - Thu, 22 Feb 2024 07:32:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -709,7 +748,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0c4bd80-1942-4e2f-92c7-65105ce1d57c
+      - 10648571-c51d-47e0-b58e-54bec6465940
     status: 200 OK
     code: 200
     duration: ""
@@ -718,23 +757,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":null,"private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"created","updated_at":"2023-10-27T08:59:49.605563Z","zone":"fr-par-1"}],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:49.778174Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":null,"private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"created","updated_at":"2024-02-22T07:32:10.899845Z","zone":"fr-par-1"}],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.092036Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1955"
+      - "1988"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:49 GMT
+      - Thu, 22 Feb 2024 07:32:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -742,7 +781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3b1b6d6-13bb-40fb-80dd-9eca2e505c59
+      - f5e4c353-c03f-4c70-87aa-ff49b9e5185e
     status: 200 OK
     code: 200
     duration: ""
@@ -751,29 +790,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T08:59:44.383437+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":null,"private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"created","updated_at":"2024-02-22T07:32:10.899845Z","zone":"fr-par-1"}],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.092036Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2773"
+      - "1988"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:50 GMT
+      - Thu, 22 Feb 2024 07:32:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -781,7 +814,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66539e48-a873-4c38-952b-a00bf5359560
+      - 0f89fd76-1802-4de1-ad79-e58060bbc412
     status: 200 OK
     code: 200
     duration: ""
@@ -790,194 +823,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:51.687639Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1964"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 08:59:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cf7a55f9-eb68-4244-97cc-ab513e140784
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cf3fe49b-ff13-4eaa-a50c-50dbd316737a
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "996"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 08:59:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 38a86d1e-ba5a-4571-bf70-3f1697b9c679
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cf3fe49b-ff13-4eaa-a50c-50dbd316737a
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "996"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 08:59:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 97fe81fa-6c04-40f4-bc8a-5aa108d91dad
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:51.687639Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1964"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 08:59:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 24f61737-53a6-4d89-83b2-b74f2924e60e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cf3fe49b-ff13-4eaa-a50c-50dbd316737a
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "996"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 08:59:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4672ebf5-2c0e-4d3e-a080-331ad6c7486a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T08:59:44.383437+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:32:04.863617+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2773"
+      - "2796"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 08:59:55 GMT
+      - Thu, 22 Feb 2024 07:32:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -985,7 +853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc9416ff-f505-4c61-bc5b-03edd4d0db66
+      - 7b2c3802-b992-4fb6-963d-9142fc566e36
     status: 200 OK
     code: 200
     duration: ""
@@ -994,29 +862,266 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"configuring","updated_at":"2024-02-22T07:32:16.983773Z","zone":"fr-par-1"}],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.092036Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "2007"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eed3607c-e964-47fa-94c6-59d35bd31c62
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:32:04.863617+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2796"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 65d2108f-ee25-416b-9bb6-338ea2cc28a5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:22.124202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1997"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 856db263-038c-4219-a3fd-41b263e4d18e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1418f68a-5d8a-414e-8db6-6855719dcefb
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 28a41586-1bbd-4513-b485-52759324fc6a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1418f68a-5d8a-414e-8db6-6855719dcefb
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 75635616-1353-4da8-9999-1f4e86559739
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:22.124202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1997"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 56541175-a930-4245-985b-aee82bc7858d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1418f68a-5d8a-414e-8db6-6855719dcefb
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5808324f-164c-406d-9bb6-d51084d5bc7a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T08:59:57.280050+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:32:24.635644+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2804"
+      - "2827"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:00 GMT
+      - Thu, 22 Feb 2024 07:32:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1024,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c19385b-922a-4746-933a-707a53670256
+      - 7f17eab4-4690-4317-9d44-30a1df2c53f5
     status: 200 OK
     code: 200
     duration: ""
@@ -1033,12 +1138,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ac96a017-00ac-4d5f-9e03-00d3e4ca3113
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d37ac80f-a813-4079-bd5d-e8f89681570d
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T08:59:42.335705Z","dhcp_enabled":true,"id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T08:59:42.335705Z","id":"6d73c456-fa7c-4640-8932-d74994d73fd7","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:48.640022Z"},{"created_at":"2023-10-27T08:59:42.335705Z","id":"9388d2f4-015d-49eb-a164-3808575ecc31","subnet":"fd46:78ab:30b8:39e5::/64","updated_at":"2023-10-27T08:59:48.643774Z"}],"tags":[],"updated_at":"2023-10-27T08:59:51.308559Z","vpc_id":"37dbace1-345f-4b46-9b6f-35f1ff8c64f9"}'
+    body: '{"created_at":"2024-02-22T07:32:02.945669Z","dhcp_enabled":true,"id":"d37ac80f-a813-4079-bd5d-e8f89681570d","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.945669Z","id":"57e60c4f-ec5c-4922-8e84-e6d4bbdc8f16","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:08.986144Z"},{"created_at":"2024-02-22T07:32:02.945669Z","id":"2e9dddae-7e6d-4e21-9ac0-9927491ae10c","subnet":"fd5f:519c:6d46:4541::/64","updated_at":"2024-02-22T07:32:08.989620Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.313632Z","vpc_id":"aa33fd37-61ad-4b1b-a505-51d345f96316"}'
     headers:
       Content-Length:
       - "763"
@@ -1047,9 +1152,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:00 GMT
+      - Thu, 22 Feb 2024 07:32:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1057,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37ee4c6d-5c59-4a3f-8f94-d1570ad14e23
+      - c6752585-76ad-47d4-94d8-1d7c4aa03125
     status: 200 OK
     code: 200
     duration: ""
@@ -1066,29 +1171,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T08:59:57.280050+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:32:24.635644+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2804"
+      - "2827"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:00 GMT
+      - Thu, 22 Feb 2024 07:32:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1096,23 +1201,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d226480b-75e5-47d0-b884-542997402ac0
+      - 7a209829-424c-4fba-84ef-35eb5b6724a3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113"}'
+    body: '{"private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:00.586198+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:26.835825+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1121,9 +1226,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:01 GMT
+      - Thu, 22 Feb 2024 07:32:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1131,7 +1236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bec5826c-bab6-4c3e-9447-771a3faa4dd8
+      - bb35938c-d34e-4a40-a669-3addc12608a0
     status: 201 Created
     code: 201
     duration: ""
@@ -1140,12 +1245,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics/47261e53-5760-45c7-9f08-88ea679d0cca
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics/f6b2add0-a704-49b5-8947-4573d672a1af
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:01.021591+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:26.835825+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1154,9 +1259,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:01 GMT
+      - Thu, 22 Feb 2024 07:32:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1164,7 +1269,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bf3146a-9444-4bf1-bac6-a03b85685244
+      - 13b043c9-6827-4f7c-9e7b-002403b09576
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,12 +1278,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics/47261e53-5760-45c7-9f08-88ea679d0cca
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics/f6b2add0-a704-49b5-8947-4573d672a1af
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:01.505638+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:27.596360+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1187,9 +1292,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:06 GMT
+      - Thu, 22 Feb 2024 07:32:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1197,7 +1302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cbc9ccc-68b4-41bd-afdf-94ff76f63aa5
+      - b889d390-7313-4b46-bacb-f40d780b1ae3
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,12 +1311,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics/47261e53-5760-45c7-9f08-88ea679d0cca
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics/f6b2add0-a704-49b5-8947-4573d672a1af
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:01.505638+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:27.596360+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1220,9 +1325,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:11 GMT
+      - Thu, 22 Feb 2024 07:32:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1230,7 +1335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ef8895a-14e7-4acc-b21b-854ab5fa2a4f
+      - de76016a-4d9e-46b9-947b-d76b1912a6a0
     status: 200 OK
     code: 200
     duration: ""
@@ -1239,12 +1344,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics/47261e53-5760-45c7-9f08-88ea679d0cca
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics/f6b2add0-a704-49b5-8947-4573d672a1af
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:01.505638+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:27.596360+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1253,9 +1358,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:16 GMT
+      - Thu, 22 Feb 2024 07:32:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1263,7 +1368,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bed6ab7-b958-4056-add0-7239c7772ed9
+      - 428442e3-02ef-40f8-9981-e12cbf74543c
     status: 200 OK
     code: 200
     duration: ""
@@ -1272,12 +1377,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics/47261e53-5760-45c7-9f08-88ea679d0cca
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics/f6b2add0-a704-49b5-8947-4573d672a1af
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:01.505638+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:27.596360+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1286,9 +1391,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:21 GMT
+      - Thu, 22 Feb 2024 07:32:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1296,7 +1401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89991596-0ad8-4e43-b5f0-0dcf539cb0fe
+      - 75d1a8c4-68e4-4355-930b-a0bd21213aab
     status: 200 OK
     code: 200
     duration: ""
@@ -1305,12 +1410,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics/47261e53-5760-45c7-9f08-88ea679d0cca
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics/f6b2add0-a704-49b5-8947-4573d672a1af
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:01.505638+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:27.596360+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1319,9 +1424,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:27 GMT
+      - Thu, 22 Feb 2024 07:32:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1329,7 +1434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6aae158d-3401-47f6-99d0-eb009e23cdee
+      - 48f3afc0-cef3-4301-b1b2-ae006656504a
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,12 +1443,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics/47261e53-5760-45c7-9f08-88ea679d0cca
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics/f6b2add0-a704-49b5-8947-4573d672a1af
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:01.505638+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:27.596360+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1352,9 +1457,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:32 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1362,7 +1467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e17977a2-17a4-423a-bf47-d720e986b321
+      - c9265c90-5cc6-46c0-ac39-8b81f1144fae
     status: 200 OK
     code: 200
     duration: ""
@@ -1371,12 +1476,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics/47261e53-5760-45c7-9f08-88ea679d0cca
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics/f6b2add0-a704-49b5-8947-4573d672a1af
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1385,9 +1490,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:37 GMT
+      - Thu, 22 Feb 2024 07:33:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1395,7 +1500,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2a26af7-3ef0-4e28-aebc-55db4558c8e6
+      - 2b3d9123-15aa-4312-9de4-0eab3c163bfe
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,12 +1509,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics/47261e53-5760-45c7-9f08-88ea679d0cca
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics/f6b2add0-a704-49b5-8947-4573d672a1af
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1418,9 +1523,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:37 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1428,7 +1533,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27edfbc7-0c30-4ec2-bd01-0dea98531cd3
+      - 352448db-c458-4b00-a16c-e5929f2674fe
     status: 200 OK
     code: 200
     duration: ""
@@ -1437,29 +1542,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T08:59:57.280050+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:32:24.635644+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3157"
+      - "3180"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:37 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1467,7 +1572,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d14be901-8b6c-4427-ab5f-0cbeb5c1032e
+      - baaadfeb-b3db-4271-a0bc-90dede50f386
     status: 200 OK
     code: 200
     duration: ""
@@ -1476,9 +1581,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1490,9 +1595,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:37 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1500,7 +1605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7eaed868-96a4-44e1-a326-b26ccce806d7
+      - a516f5ed-4942-4e9b-a3c9-15b76f9b48f3
     status: 200 OK
     code: 200
     duration: ""
@@ -1509,12 +1614,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1523,12 +1628,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:37 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Link:
-      - </servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics?page=1&per_page=50&>;
+      - </servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1536,7 +1641,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ee86326-440f-4fed-a313-34f558aed4f1
+      - 548ac08e-185a-44c2-ae89-89e7c69d19e3
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1547,23 +1652,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/e07bc539-52e1-4b82-9c89-5cebbcc0753b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/d6db597b-4be9-4404-afb4-3c7ac9b52772
     method: GET
   response:
-    body: '{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "401"
+      - "405"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:37 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1571,7 +1676,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 126815e5-fecd-4ae6-91ef-5e123307fb58
+      - e9f48139-0d95-414a-b69a-43b41142c1ab
     status: 200 OK
     code: 200
     duration: ""
@@ -1580,12 +1685,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/70d2fd66-fbb2-4df0-9e0e-ddbe1296f683
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/f7d23fec-9133-4f33-ae5e-94e4723869bc
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -1594,9 +1699,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:37 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1604,7 +1709,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4112daa2-0338-4b38-9093-b0240066aead
+      - fa211c1e-c60b-4e92-8aff-7f62ccf1f63a
     status: 200 OK
     code: 200
     duration: ""
@@ -1613,12 +1718,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ac96a017-00ac-4d5f-9e03-00d3e4ca3113
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d37ac80f-a813-4079-bd5d-e8f89681570d
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T08:59:42.335705Z","dhcp_enabled":true,"id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T08:59:42.335705Z","id":"6d73c456-fa7c-4640-8932-d74994d73fd7","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:48.640022Z"},{"created_at":"2023-10-27T08:59:42.335705Z","id":"9388d2f4-015d-49eb-a164-3808575ecc31","subnet":"fd46:78ab:30b8:39e5::/64","updated_at":"2023-10-27T08:59:48.643774Z"}],"tags":[],"updated_at":"2023-10-27T08:59:51.308559Z","vpc_id":"37dbace1-345f-4b46-9b6f-35f1ff8c64f9"}'
+    body: '{"created_at":"2024-02-22T07:32:02.945669Z","dhcp_enabled":true,"id":"d37ac80f-a813-4079-bd5d-e8f89681570d","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.945669Z","id":"57e60c4f-ec5c-4922-8e84-e6d4bbdc8f16","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:08.986144Z"},{"created_at":"2024-02-22T07:32:02.945669Z","id":"2e9dddae-7e6d-4e21-9ac0-9927491ae10c","subnet":"fd5f:519c:6d46:4541::/64","updated_at":"2024-02-22T07:32:08.989620Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.313632Z","vpc_id":"aa33fd37-61ad-4b1b-a505-51d345f96316"}'
     headers:
       Content-Length:
       - "763"
@@ -1627,9 +1732,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:37 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1637,7 +1742,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c2e1147-78b3-4ace-8c5d-4f3258580c7a
+      - 7476a0bb-5c41-42ab-8684-179deadc5a92
     status: 200 OK
     code: 200
     duration: ""
@@ -1646,23 +1751,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:51.687639Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:22.124202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1964"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1670,7 +1775,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 418c34b8-9046-43b5-ad01-f1c97f8138c8
+      - 8fe969d2-e1ac-4869-bcb3-2f1754a8f859
     status: 200 OK
     code: 200
     duration: ""
@@ -1679,12 +1784,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cf3fe49b-ff13-4eaa-a50c-50dbd316737a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1418f68a-5d8a-414e-8db6-6855719dcefb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -1693,9 +1798,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1703,7 +1808,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f70bd4eb-99e5-47e1-8284-84316fb97d0a
+      - 44c39fa4-8dbc-449f-854e-ccc663b48f23
     status: 200 OK
     code: 200
     duration: ""
@@ -1712,23 +1817,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:51.687639Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:22.124202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1964"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1736,7 +1841,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef408eb6-a5a5-4a55-8d33-83129a93a5ff
+      - b91ec8a6-be76-4bb7-b8dc-01d6a538cdc2
     status: 200 OK
     code: 200
     duration: ""
@@ -1745,29 +1850,62 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1418f68a-5d8a-414e-8db6-6855719dcefb
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e7fe94c1-1661-4ae3-b8f4-8ebccb15eec2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T08:59:57.280050+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:32:24.635644+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3157"
+      - "3180"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1775,7 +1913,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 046d0ceb-8839-487d-909f-ea2bb725c8d7
+      - e2039020-b9d7-444c-929f-1e3897030edc
     status: 200 OK
     code: 200
     duration: ""
@@ -1784,9 +1922,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1798,9 +1936,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1808,7 +1946,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17976791-a9c6-4e37-9f81-010f44a98c5e
+      - 5acb6a73-8fad-4fac-b885-914d79b2aa5f
     status: 200 OK
     code: 200
     duration: ""
@@ -1817,45 +1955,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cf3fe49b-ff13-4eaa-a50c-50dbd316737a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "996"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 917a2d3a-4b17-4690-8649-6fde5ba18333
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics
-    method: GET
-  response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1864,12 +1969,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Link:
-      - </servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics?page=1&per_page=50&>;
+      - </servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1877,7 +1982,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7335a260-1a40-482a-a5c9-4a5b58f4b4a4
+      - 57501d7e-7709-43a9-b32b-196dcdfd11b8
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1888,23 +1993,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/e07bc539-52e1-4b82-9c89-5cebbcc0753b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/d6db597b-4be9-4404-afb4-3c7ac9b52772
     method: GET
   response:
-    body: '{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "401"
+      - "405"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1912,7 +2017,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3bb9807-b29f-4255-b0ae-cb0f28a55204
+      - 09a5273f-ff62-44f6-b5b4-5c07d28388b1
     status: 200 OK
     code: 200
     duration: ""
@@ -1921,12 +2026,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/70d2fd66-fbb2-4df0-9e0e-ddbe1296f683
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/f7d23fec-9133-4f33-ae5e-94e4723869bc
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -1935,9 +2040,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1945,7 +2050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c4af8ce-91c2-4f0a-9127-ff9454bf9dcf
+      - 7f3d6d7c-f3e7-4a2a-9a7b-111d8435478d
     status: 200 OK
     code: 200
     duration: ""
@@ -1954,12 +2059,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ac96a017-00ac-4d5f-9e03-00d3e4ca3113
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d37ac80f-a813-4079-bd5d-e8f89681570d
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T08:59:42.335705Z","dhcp_enabled":true,"id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T08:59:42.335705Z","id":"6d73c456-fa7c-4640-8932-d74994d73fd7","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:48.640022Z"},{"created_at":"2023-10-27T08:59:42.335705Z","id":"9388d2f4-015d-49eb-a164-3808575ecc31","subnet":"fd46:78ab:30b8:39e5::/64","updated_at":"2023-10-27T08:59:48.643774Z"}],"tags":[],"updated_at":"2023-10-27T08:59:51.308559Z","vpc_id":"37dbace1-345f-4b46-9b6f-35f1ff8c64f9"}'
+    body: '{"created_at":"2024-02-22T07:32:02.945669Z","dhcp_enabled":true,"id":"d37ac80f-a813-4079-bd5d-e8f89681570d","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.945669Z","id":"57e60c4f-ec5c-4922-8e84-e6d4bbdc8f16","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:08.986144Z"},{"created_at":"2024-02-22T07:32:02.945669Z","id":"2e9dddae-7e6d-4e21-9ac0-9927491ae10c","subnet":"fd5f:519c:6d46:4541::/64","updated_at":"2024-02-22T07:32:08.989620Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.313632Z","vpc_id":"aa33fd37-61ad-4b1b-a505-51d345f96316"}'
     headers:
       Content-Length:
       - "763"
@@ -1968,9 +2073,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1978,7 +2083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09ce1ae0-d896-40a0-9a9d-8ed417b6c3db
+      - 46d05d29-0ff1-4690-b243-cc0a48712713
     status: 200 OK
     code: 200
     duration: ""
@@ -1987,23 +2092,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:51.687639Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:22.124202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1964"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2011,7 +2116,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 078ee75e-ff94-4506-b13e-dc0dc89e17db
+      - 3b2f62b1-e995-4121-8ad2-133873624787
     status: 200 OK
     code: 200
     duration: ""
@@ -2020,12 +2125,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cf3fe49b-ff13-4eaa-a50c-50dbd316737a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1418f68a-5d8a-414e-8db6-6855719dcefb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -2034,9 +2139,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2044,7 +2149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edd4079f-7809-42b6-bf45-fa287e707c10
+      - d7ab84fb-2b28-4f6e-bf3b-ececcc03651e
     status: 200 OK
     code: 200
     duration: ""
@@ -2053,23 +2158,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:51.687639Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:22.124202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1964"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2077,7 +2182,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf42ec4f-315f-4c6f-849f-4c19a0b07d18
+      - 5225651c-e96c-446f-94e1-e076250bd571
     status: 200 OK
     code: 200
     duration: ""
@@ -2086,29 +2191,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T08:59:57.280050+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:32:24.635644+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3157"
+      - "3180"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2116,7 +2221,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfc6b172-f050-4e15-9e44-9e1345bd321b
+      - 3c617757-9253-48c9-a070-f414d70b2066
     status: 200 OK
     code: 200
     duration: ""
@@ -2125,12 +2230,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cf3fe49b-ff13-4eaa-a50c-50dbd316737a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1418f68a-5d8a-414e-8db6-6855719dcefb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -2139,9 +2244,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2149,7 +2254,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e4d9a55-df1e-4e5d-804a-3e74d9388056
+      - b01ff059-8765-4b80-98c6-208340e1af4a
     status: 200 OK
     code: 200
     duration: ""
@@ -2158,9 +2263,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2172,9 +2277,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2182,7 +2287,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6950ec65-d2cf-4714-85ac-7f30ebf03b8e
+      - 427ecb1c-d90d-41a7-81df-db44a316a53e
     status: 200 OK
     code: 200
     duration: ""
@@ -2191,12 +2296,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2205,12 +2310,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:38 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Link:
-      - </servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics?page=1&per_page=50&>;
+      - </servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2218,7 +2323,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bc769f2-276f-4bfd-a8d4-f6b6c1ed6181
+      - 919d8c5f-31df-4893-ad5c-4247d0be9215
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2229,12 +2334,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=cf3fe49b-ff13-4eaa-a50c-50dbd316737a&mac_address=02%3A00%3A00%3A14%3A74%3A01&order_by=created_at_asc&type=unknown
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=1418f68a-5d8a-414e-8db6-6855719dcefb&mac_address=02%3A00%3A00%3A18%3A8b%3Ab2&order_by=created_at_asc&type=unknown
     method: GET
   response:
-    body: '{"dhcp_entries":[{"created_at":"2023-10-27T09:00:01.379190Z","gateway_network_id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","hostname":"tf-srv-bold-driscoll","id":"cb27b9fb-fe44-47db-be3d-0fd014b719e8","ip_address":"192.168.1.2","mac_address":"02:00:00:14:74:01","type":"reservation","updated_at":"2023-10-27T09:00:01.379190Z","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"dhcp_entries":[{"created_at":"2024-02-22T07:32:27.515793Z","gateway_network_id":"1418f68a-5d8a-414e-8db6-6855719dcefb","hostname":"tf-srv-crazy-meitner","id":"e7e04041-d61d-4d12-a7f9-c6f35ffa1728","ip_address":"192.168.1.2","mac_address":"02:00:00:18:8b:b2","type":"reservation","updated_at":"2024-02-22T07:32:27.515793Z","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "369"
@@ -2243,9 +2348,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:39 GMT
+      - Thu, 22 Feb 2024 07:33:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2253,7 +2358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01f1aab7-6a31-4be3-88bf-6665537d014a
+      - 75a0e445-3bb2-4632-8aae-297055f8872f
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,12 +2367,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/cb27b9fb-fe44-47db-be3d-0fd014b719e8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/e7e04041-d61d-4d12-a7f9-c6f35ffa1728
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T09:00:01.379190Z","gateway_network_id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","hostname":"tf-srv-bold-driscoll","id":"cb27b9fb-fe44-47db-be3d-0fd014b719e8","ip_address":"192.168.1.2","mac_address":"02:00:00:14:74:01","type":"reservation","updated_at":"2023-10-27T09:00:01.379190Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:27.515793Z","gateway_network_id":"1418f68a-5d8a-414e-8db6-6855719dcefb","hostname":"tf-srv-crazy-meitner","id":"e7e04041-d61d-4d12-a7f9-c6f35ffa1728","ip_address":"192.168.1.2","mac_address":"02:00:00:18:8b:b2","type":"reservation","updated_at":"2024-02-22T07:32:27.515793Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "333"
@@ -2276,9 +2381,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:39 GMT
+      - Thu, 22 Feb 2024 07:33:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2286,7 +2391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb66bd1e-9714-490e-b4d1-4d37546e8b36
+      - 4c38d698-cc4a-417e-a4c6-98016321e68b
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,12 +2400,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=cf3fe49b-ff13-4eaa-a50c-50dbd316737a&mac_address=02%3A00%3A00%3A14%3A74%3A01&order_by=created_at_asc&type=unknown
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=1418f68a-5d8a-414e-8db6-6855719dcefb&mac_address=02%3A00%3A00%3A18%3A8b%3Ab2&order_by=created_at_asc&type=unknown
     method: GET
   response:
-    body: '{"dhcp_entries":[{"created_at":"2023-10-27T09:00:01.379190Z","gateway_network_id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","hostname":"tf-srv-bold-driscoll","id":"cb27b9fb-fe44-47db-be3d-0fd014b719e8","ip_address":"192.168.1.2","mac_address":"02:00:00:14:74:01","type":"reservation","updated_at":"2023-10-27T09:00:01.379190Z","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"dhcp_entries":[{"created_at":"2024-02-22T07:32:27.515793Z","gateway_network_id":"1418f68a-5d8a-414e-8db6-6855719dcefb","hostname":"tf-srv-crazy-meitner","id":"e7e04041-d61d-4d12-a7f9-c6f35ffa1728","ip_address":"192.168.1.2","mac_address":"02:00:00:18:8b:b2","type":"reservation","updated_at":"2024-02-22T07:32:27.515793Z","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "369"
@@ -2309,9 +2414,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:40 GMT
+      - Thu, 22 Feb 2024 07:33:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2319,7 +2424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2a57b68-84d7-453f-ae16-301a679c249b
+      - 9712a963-6a93-426d-89c2-6d9e6fe45ca9
     status: 200 OK
     code: 200
     duration: ""
@@ -2328,12 +2433,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/cb27b9fb-fe44-47db-be3d-0fd014b719e8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/e7e04041-d61d-4d12-a7f9-c6f35ffa1728
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T09:00:01.379190Z","gateway_network_id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","hostname":"tf-srv-bold-driscoll","id":"cb27b9fb-fe44-47db-be3d-0fd014b719e8","ip_address":"192.168.1.2","mac_address":"02:00:00:14:74:01","type":"reservation","updated_at":"2023-10-27T09:00:01.379190Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:27.515793Z","gateway_network_id":"1418f68a-5d8a-414e-8db6-6855719dcefb","hostname":"tf-srv-crazy-meitner","id":"e7e04041-d61d-4d12-a7f9-c6f35ffa1728","ip_address":"192.168.1.2","mac_address":"02:00:00:18:8b:b2","type":"reservation","updated_at":"2024-02-22T07:32:27.515793Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "333"
@@ -2342,9 +2447,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:40 GMT
+      - Thu, 22 Feb 2024 07:33:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2352,7 +2457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ed05683-0ef3-44c8-9330-c9e12c59814f
+      - 888beb2d-728e-4c0d-a74d-384e7a2abd81
     status: 200 OK
     code: 200
     duration: ""
@@ -2361,12 +2466,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=cf3fe49b-ff13-4eaa-a50c-50dbd316737a&mac_address=02%3A00%3A00%3A14%3A74%3A01&order_by=created_at_asc&type=unknown
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=1418f68a-5d8a-414e-8db6-6855719dcefb&mac_address=02%3A00%3A00%3A18%3A8b%3Ab2&order_by=created_at_asc&type=unknown
     method: GET
   response:
-    body: '{"dhcp_entries":[{"created_at":"2023-10-27T09:00:01.379190Z","gateway_network_id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","hostname":"tf-srv-bold-driscoll","id":"cb27b9fb-fe44-47db-be3d-0fd014b719e8","ip_address":"192.168.1.2","mac_address":"02:00:00:14:74:01","type":"reservation","updated_at":"2023-10-27T09:00:01.379190Z","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"dhcp_entries":[{"created_at":"2024-02-22T07:32:27.515793Z","gateway_network_id":"1418f68a-5d8a-414e-8db6-6855719dcefb","hostname":"tf-srv-crazy-meitner","id":"e7e04041-d61d-4d12-a7f9-c6f35ffa1728","ip_address":"192.168.1.2","mac_address":"02:00:00:18:8b:b2","type":"reservation","updated_at":"2024-02-22T07:32:27.515793Z","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "369"
@@ -2375,9 +2480,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:40 GMT
+      - Thu, 22 Feb 2024 07:33:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2385,7 +2490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f96e37df-f0e0-4a69-b2c1-c6efe22800a8
+      - 0c43cfb1-ca0b-407f-b329-5b12ce8aca2f
     status: 200 OK
     code: 200
     duration: ""
@@ -2394,12 +2499,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/cb27b9fb-fe44-47db-be3d-0fd014b719e8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/e7e04041-d61d-4d12-a7f9-c6f35ffa1728
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T09:00:01.379190Z","gateway_network_id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","hostname":"tf-srv-bold-driscoll","id":"cb27b9fb-fe44-47db-be3d-0fd014b719e8","ip_address":"192.168.1.2","mac_address":"02:00:00:14:74:01","type":"reservation","updated_at":"2023-10-27T09:00:01.379190Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:27.515793Z","gateway_network_id":"1418f68a-5d8a-414e-8db6-6855719dcefb","hostname":"tf-srv-crazy-meitner","id":"e7e04041-d61d-4d12-a7f9-c6f35ffa1728","ip_address":"192.168.1.2","mac_address":"02:00:00:18:8b:b2","type":"reservation","updated_at":"2024-02-22T07:32:27.515793Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "333"
@@ -2408,9 +2513,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:40 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2418,7 +2523,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db4475f7-246e-45b6-a649-61295793a856
+      - dfe3403d-f4a1-4456-9abc-d6e1494f6734
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,23 +2532,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/e07bc539-52e1-4b82-9c89-5cebbcc0753b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/d6db597b-4be9-4404-afb4-3c7ac9b52772
     method: GET
   response:
-    body: '{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "401"
+      - "405"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:40 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2451,7 +2556,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 272ebfd2-f267-48af-bb05-943dee3843a9
+      - 8ddec744-d02a-4a23-a43d-64cef516ffe5
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,12 +2565,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/70d2fd66-fbb2-4df0-9e0e-ddbe1296f683
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/f7d23fec-9133-4f33-ae5e-94e4723869bc
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -2474,9 +2579,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:40 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2484,7 +2589,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11deb01f-ba51-497e-8c13-3336631e7e06
+      - d34a404b-7ad4-4353-a5c3-e94ecfd0897d
     status: 200 OK
     code: 200
     duration: ""
@@ -2493,12 +2598,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ac96a017-00ac-4d5f-9e03-00d3e4ca3113
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d37ac80f-a813-4079-bd5d-e8f89681570d
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T08:59:42.335705Z","dhcp_enabled":true,"id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T08:59:42.335705Z","id":"6d73c456-fa7c-4640-8932-d74994d73fd7","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:48.640022Z"},{"created_at":"2023-10-27T08:59:42.335705Z","id":"9388d2f4-015d-49eb-a164-3808575ecc31","subnet":"fd46:78ab:30b8:39e5::/64","updated_at":"2023-10-27T08:59:48.643774Z"}],"tags":[],"updated_at":"2023-10-27T08:59:51.308559Z","vpc_id":"37dbace1-345f-4b46-9b6f-35f1ff8c64f9"}'
+    body: '{"created_at":"2024-02-22T07:32:02.945669Z","dhcp_enabled":true,"id":"d37ac80f-a813-4079-bd5d-e8f89681570d","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Basic","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.945669Z","id":"57e60c4f-ec5c-4922-8e84-e6d4bbdc8f16","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:08.986144Z"},{"created_at":"2024-02-22T07:32:02.945669Z","id":"2e9dddae-7e6d-4e21-9ac0-9927491ae10c","subnet":"fd5f:519c:6d46:4541::/64","updated_at":"2024-02-22T07:32:08.989620Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.313632Z","vpc_id":"aa33fd37-61ad-4b1b-a505-51d345f96316"}'
     headers:
       Content-Length:
       - "763"
@@ -2507,9 +2612,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:40 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2517,7 +2622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a72d4f58-a60f-402e-8397-9b45741359a1
+      - ca2da1f3-8dc0-4f57-a40a-55da0e2d8bb8
     status: 200 OK
     code: 200
     duration: ""
@@ -2526,23 +2631,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:51.687639Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:22.124202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1964"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:40 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2550,7 +2655,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1b0c55e-020a-4e15-b809-a813ee4be803
+      - badcfdbe-8d3f-4fde-ab1c-3263080a01bc
     status: 200 OK
     code: 200
     duration: ""
@@ -2559,12 +2664,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cf3fe49b-ff13-4eaa-a50c-50dbd316737a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1418f68a-5d8a-414e-8db6-6855719dcefb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -2573,9 +2678,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:41 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2583,7 +2688,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d12734f-93d4-4f20-8baa-db2429e79f0b
+      - 30d691c1-08c5-4712-bd3d-a24dc3c84355
     status: 200 OK
     code: 200
     duration: ""
@@ -2592,23 +2697,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:51.687639Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:22.124202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1964"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:41 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2616,7 +2721,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb7e53fb-f161-478e-8212-54bf3f956a98
+      - 74599289-90f5-49b1-8be5-98c39bad6ff7
     status: 200 OK
     code: 200
     duration: ""
@@ -2625,29 +2730,62 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1418f68a-5d8a-414e-8db6-6855719dcefb
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:06 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3bd425b2-1a33-47a5-af5f-48e7f30b0ac5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T08:59:57.280050+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:32:24.635644+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3157"
+      - "3180"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:41 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2655,7 +2793,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e7ea89b-8902-459b-8ef5-6e08d1196a63
+      - e3ae2040-a03a-4b31-a25f-3a8ad39531bf
     status: 200 OK
     code: 200
     duration: ""
@@ -2664,42 +2802,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cf3fe49b-ff13-4eaa-a50c-50dbd316737a
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "996"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:00:41 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7cc4c8bd-40eb-4a64-9cef-1df62aa96691
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2711,9 +2816,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:41 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2721,7 +2826,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 261b0992-3b51-44b2-a327-72d9d06d02a8
+      - 33c307c4-8f61-4bb3-8453-9abb6dcce21c
     status: 200 OK
     code: 200
     duration: ""
@@ -2730,12 +2835,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2744,12 +2849,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:41 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Link:
-      - </servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics?page=1&per_page=50&>;
+      - </servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2757,7 +2862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29dff847-5892-4cce-b5e8-0011ea480d5a
+      - 4272e026-2bc9-4540-a33e-29e88c2ac33d
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2768,12 +2873,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=cf3fe49b-ff13-4eaa-a50c-50dbd316737a&mac_address=02%3A00%3A00%3A14%3A74%3A01&order_by=created_at_asc&type=unknown
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=1418f68a-5d8a-414e-8db6-6855719dcefb&mac_address=02%3A00%3A00%3A18%3A8b%3Ab2&order_by=created_at_asc&type=unknown
     method: GET
   response:
-    body: '{"dhcp_entries":[{"created_at":"2023-10-27T09:00:01.379190Z","gateway_network_id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","hostname":"tf-srv-bold-driscoll","id":"cb27b9fb-fe44-47db-be3d-0fd014b719e8","ip_address":"192.168.1.2","mac_address":"02:00:00:14:74:01","type":"reservation","updated_at":"2023-10-27T09:00:01.379190Z","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"dhcp_entries":[{"created_at":"2024-02-22T07:32:27.515793Z","gateway_network_id":"1418f68a-5d8a-414e-8db6-6855719dcefb","hostname":"tf-srv-crazy-meitner","id":"e7e04041-d61d-4d12-a7f9-c6f35ffa1728","ip_address":"192.168.1.2","mac_address":"02:00:00:18:8b:b2","type":"reservation","updated_at":"2024-02-22T07:32:27.515793Z","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "369"
@@ -2782,9 +2887,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:41 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2792,7 +2897,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5251c97d-77da-4307-b3c1-772bf80275e0
+      - f99be4c0-9fa3-4605-980b-dfd01e3017dc
     status: 200 OK
     code: 200
     duration: ""
@@ -2801,12 +2906,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/cb27b9fb-fe44-47db-be3d-0fd014b719e8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/e7e04041-d61d-4d12-a7f9-c6f35ffa1728
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T09:00:01.379190Z","gateway_network_id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","hostname":"tf-srv-bold-driscoll","id":"cb27b9fb-fe44-47db-be3d-0fd014b719e8","ip_address":"192.168.1.2","mac_address":"02:00:00:14:74:01","type":"reservation","updated_at":"2023-10-27T09:00:01.379190Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:27.515793Z","gateway_network_id":"1418f68a-5d8a-414e-8db6-6855719dcefb","hostname":"tf-srv-crazy-meitner","id":"e7e04041-d61d-4d12-a7f9-c6f35ffa1728","ip_address":"192.168.1.2","mac_address":"02:00:00:18:8b:b2","type":"reservation","updated_at":"2024-02-22T07:32:27.515793Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "333"
@@ -2815,9 +2920,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:41 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2825,7 +2930,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d0b8ee4-0e56-43f8-a134-788c4db70333
+      - cacdac3b-b800-4f96-9bf6-82c801e7e0b0
     status: 200 OK
     code: 200
     duration: ""
@@ -2834,12 +2939,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=cf3fe49b-ff13-4eaa-a50c-50dbd316737a&mac_address=02%3A00%3A00%3A14%3A74%3A01&order_by=created_at_asc&type=unknown
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries?gateway_network_id=1418f68a-5d8a-414e-8db6-6855719dcefb&mac_address=02%3A00%3A00%3A18%3A8b%3Ab2&order_by=created_at_asc&type=unknown
     method: GET
   response:
-    body: '{"dhcp_entries":[{"created_at":"2023-10-27T09:00:01.379190Z","gateway_network_id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","hostname":"tf-srv-bold-driscoll","id":"cb27b9fb-fe44-47db-be3d-0fd014b719e8","ip_address":"192.168.1.2","mac_address":"02:00:00:14:74:01","type":"reservation","updated_at":"2023-10-27T09:00:01.379190Z","zone":"fr-par-1"}],"total_count":1}'
+    body: '{"dhcp_entries":[{"created_at":"2024-02-22T07:32:27.515793Z","gateway_network_id":"1418f68a-5d8a-414e-8db6-6855719dcefb","hostname":"tf-srv-crazy-meitner","id":"e7e04041-d61d-4d12-a7f9-c6f35ffa1728","ip_address":"192.168.1.2","mac_address":"02:00:00:18:8b:b2","type":"reservation","updated_at":"2024-02-22T07:32:27.515793Z","zone":"fr-par-1"}],"total_count":1}'
     headers:
       Content-Length:
       - "369"
@@ -2848,9 +2953,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:41 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2858,7 +2963,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c20cf45c-d4cd-4052-9c60-ac1b05d6c180
+      - 90e16735-b606-472f-a44e-f292757bc8bb
     status: 200 OK
     code: 200
     duration: ""
@@ -2867,12 +2972,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/cb27b9fb-fe44-47db-be3d-0fd014b719e8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/e7e04041-d61d-4d12-a7f9-c6f35ffa1728
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T09:00:01.379190Z","gateway_network_id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","hostname":"tf-srv-bold-driscoll","id":"cb27b9fb-fe44-47db-be3d-0fd014b719e8","ip_address":"192.168.1.2","mac_address":"02:00:00:14:74:01","type":"reservation","updated_at":"2023-10-27T09:00:01.379190Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:27.515793Z","gateway_network_id":"1418f68a-5d8a-414e-8db6-6855719dcefb","hostname":"tf-srv-crazy-meitner","id":"e7e04041-d61d-4d12-a7f9-c6f35ffa1728","ip_address":"192.168.1.2","mac_address":"02:00:00:18:8b:b2","type":"reservation","updated_at":"2024-02-22T07:32:27.515793Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "333"
@@ -2881,9 +2986,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:41 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2891,7 +2996,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 773ddd54-e6a2-41b9-8c2f-aa7ad611ad79
+      - 7206c701-33bb-4dd3-8c77-d016842eadf9
     status: 200 OK
     code: 200
     duration: ""
@@ -2900,12 +3005,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cf3fe49b-ff13-4eaa-a50c-50dbd316737a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1418f68a-5d8a-414e-8db6-6855719dcefb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"ready","updated_at":"2023-10-27T08:59:51.578910Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"ready","updated_at":"2024-02-22T07:32:21.976395Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -2914,9 +3019,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:42 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2924,7 +3029,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 959cd739-d650-47cb-b392-e2ccf5b14a0c
+      - f1f57c13-e449-4abe-8019-9b29977be4dc
     status: 200 OK
     code: 200
     duration: ""
@@ -2933,48 +3038,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T08:59:57.280050+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3157"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:00:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a6045bb2-f51e-49bb-bb52-c3aab5ece809
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cf3fe49b-ff13-4eaa-a50c-50dbd316737a?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1418f68a-5d8a-414e-8db6-6855719dcefb?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -2984,9 +3050,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:42 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2994,7 +3060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 146beca4-d783-4a21-81f3-91c8ab29ff22
+      - 9bee15c8-6bf1-4b73-8d2a-a6f260cb4d83
     status: 204 No Content
     code: 204
     duration: ""
@@ -3003,12 +3069,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cf3fe49b-ff13-4eaa-a50c-50dbd316737a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1418f68a-5d8a-414e-8db6-6855719dcefb
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T08:59:49.605563Z","dhcp":{"address":"192.168.1.1","created_at":"2023-10-27T08:59:42.326443Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-10-27T08:59:42.326443Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","ipam_config":null,"mac_address":"02:00:00:14:74:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","status":"detaching","updated_at":"2023-10-27T09:00:42.193812Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.899845Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.394689Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.394689Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"1418f68a-5d8a-414e-8db6-6855719dcefb","ipam_config":null,"mac_address":"02:00:00:18:8B:AD","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","status":"detaching","updated_at":"2024-02-22T07:33:07.652046Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "1000"
@@ -3017,9 +3083,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:42 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3027,7 +3093,46 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d033752-783e-4c3a-a3e4-b9015fa3079d
+      - 09ab7339-01cc-4300-addb-b43ab34099a3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:32:24.635644+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3180"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:07 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3af8180c-381a-42ae-a7a4-cb227fe34a2e
     status: 200 OK
     code: 200
     duration: ""
@@ -3038,12 +3143,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/action","href_result":"/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","id":"efca927c-1b9d-4e0f-a406-9bda0f6df3ad","started_at":"2023-10-27T09:00:42.510260+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/action","href_result":"/servers/e07a44a7-d0ea-4221-aac9-887f22e77201","id":"5374813e-b2d9-4f35-858d-135c6c47f0ff","started_at":"2024-02-22T07:33:07.904287+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -3052,11 +3157,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:42 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/efca927c-1b9d-4e0f-a406-9bda0f6df3ad
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/5374813e-b2d9-4f35-858d-135c6c47f0ff
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3064,7 +3169,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ed9c2d2-d465-4d98-8353-92f18007c847
+      - 07e2a0d4-1780-4216-a105-92cb6cc9e10c
     status: 202 Accepted
     code: 202
     duration: ""
@@ -3073,29 +3178,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T09:00:42.218943+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:33:07.750788+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3125"
+      - "3148"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:42 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3103,7 +3208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1951b40d-3198-4706-a9a2-35572f767c32
+      - e75709de-8f91-4636-82d6-d11ceb201e13
     status: 200 OK
     code: 200
     duration: ""
@@ -3112,12 +3217,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/cf3fe49b-ff13-4eaa-a50c-50dbd316737a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1418f68a-5d8a-414e-8db6-6855719dcefb
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"cf3fe49b-ff13-4eaa-a50c-50dbd316737a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"1418f68a-5d8a-414e-8db6-6855719dcefb","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3126,9 +3231,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:47 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3136,7 +3241,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd081a9e-3392-4efd-9495-7623186ca0eb
+      - 0afbd752-6838-4efa-9678-a89acaf44b5f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3145,23 +3250,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:51.687639Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:22.124202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "968"
+      - "1001"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:47 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3169,7 +3274,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 999e425f-b62f-40cd-88a8-cb2187b4f28e
+      - 08da73b8-39ce-441f-8234-78809b8ce26a
     status: 200 OK
     code: 200
     duration: ""
@@ -3178,12 +3283,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/70d2fd66-fbb2-4df0-9e0e-ddbe1296f683
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/f7d23fec-9133-4f33-ae5e-94e4723869bc
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3192,9 +3297,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:47 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3202,7 +3307,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfc77503-25a7-4e04-9d72-5b3670efe1b9
+      - a195df92-e074-4ec6-a226-77d6bffb7e86
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3211,23 +3316,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T08:59:43.078930Z","gateway_networks":[],"id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","ip":{"address":"51.15.138.206","created_at":"2023-10-27T08:59:42.907036Z","gateway_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","id":"e07bc539-52e1-4b82-9c89-5cebbcc0753b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"206-138-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T08:59:42.907036Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T08:59:51.687639Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:22.124202Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "968"
+      - "1001"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:47 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3235,7 +3340,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41f7ace2-78df-4532-a3aa-6d4d75dbcb3b
+      - b7a312c4-d9ff-4e72-b73c-cbbbd0c7c95a
     status: 200 OK
     code: 200
     duration: ""
@@ -3244,9 +3349,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -3256,9 +3361,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:47 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3266,7 +3371,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 396209e3-728f-434b-8dab-bcd9c706f297
+      - 29128515-5d3d-4492-aafd-c0ce3f15b25d
     status: 204 No Content
     code: 204
     duration: ""
@@ -3275,12 +3380,84 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/e65b0b4a-e65c-44d9-9170-0ae6ac9338f2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"e65b0b4a-e65c-44d9-9170-0ae6ac9338f2","type":"not_found"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.359296Z","gateway_networks":[],"id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","ip":{"address":"163.172.146.254","created_at":"2024-02-22T07:32:03.158877Z","gateway_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","id":"d6db597b-4be9-4404-afb4-3c7ac9b52772","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"254-146-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.158877Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"deleting","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:33:12.825650Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1002"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:12 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a0671dec-67d2-4722-ab96-5b57a1a1688f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:33:07.750788+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3148"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:13 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 21c3790d-9da6-4e50-9075-8b34dcb1b222
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/8eee6b84-d61e-4c9d-9e00-b8fb254222b3
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"8eee6b84-d61e-4c9d-9e00-b8fb254222b3","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3289,9 +3466,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:47 GMT
+      - Thu, 22 Feb 2024 07:33:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3299,7 +3476,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d38d692c-2efc-49d0-9648-907c2553c192
+      - 3ec8baa2-adaa-48d6-8f59-63fb41d1fbbb
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3308,9 +3485,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/e07bc539-52e1-4b82-9c89-5cebbcc0753b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/d6db597b-4be9-4404-afb4-3c7ac9b52772
     method: DELETE
   response:
     body: ""
@@ -3320,9 +3497,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:47 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3330,7 +3507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 410cfbf1-589c-4786-a7ea-ba8996c263d3
+      - d0e08aba-129f-4a49-9b08-03862c38d497
     status: 204 No Content
     code: 204
     duration: ""
@@ -3339,29 +3516,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T09:00:42.218943+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:33:07.750788+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3125"
+      - "3148"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:47 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3369,7 +3546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 388ec186-0e14-4f91-9fe5-9089f8bae887
+      - 4a1443b9-1834-4a0c-a40e-d10074003a9b
     status: 200 OK
     code: 200
     duration: ""
@@ -3378,29 +3555,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T09:00:42.218943+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:33:07.750788+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3125"
+      - "3148"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:53 GMT
+      - Thu, 22 Feb 2024 07:33:23 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3408,7 +3585,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f861e8e2-3009-4bf1-977e-44145aa1e92e
+      - 5849001e-f6b0-499d-bd6e-99b0e3eafefd
     status: 200 OK
     code: 200
     duration: ""
@@ -3417,29 +3594,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T09:00:42.218943+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:33:07.750788+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3125"
+      - "3148"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:00:58 GMT
+      - Thu, 22 Feb 2024 07:33:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3447,7 +3624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e374f8d-9c0a-4eca-9c5a-965b3c56c6bf
+      - 87e39851-ad07-43f6-b4c4-de6e59cdc41b
     status: 200 OK
     code: 200
     duration: ""
@@ -3456,29 +3633,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T09:00:42.218943+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:33:07.750788+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3125"
+      - "3148"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:01:03 GMT
+      - Thu, 22 Feb 2024 07:33:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3486,7 +3663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9c17ec4-0e74-44b9-ba6e-a6c096d43352
+      - d107584f-3679-40bc-8d46-10a412c76825
     status: 200 OK
     code: 200
     duration: ""
@@ -3495,29 +3672,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T09:00:42.218943+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:33:07.750788+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3125"
+      - "3148"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:01:08 GMT
+      - Thu, 22 Feb 2024 07:33:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3525,7 +3702,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef15a524-c7b1-4b1e-85cb-2643e7efcf36
+      - 6eed56bd-d846-46ee-8694-50c6cebceba5
     status: 200 OK
     code: 200
     duration: ""
@@ -3534,29 +3711,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"802","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T09:00:42.218943+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.68.110.85","private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:33:07.750788+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3125"
+      - "3148"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:01:13 GMT
+      - Thu, 22 Feb 2024 07:33:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3564,7 +3741,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77574dc0-eec0-4a93-b9fc-5bc7f0c93df8
+      - 82dee65e-5249-4241-8dc9-44d2ec73ebc8
     status: 200 OK
     code: 200
     duration: ""
@@ -3573,29 +3750,68 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:33:07.750788+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.69.140.55","private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3148"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ef6a452d-4d1a-4c25-afec-363fba06d863
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T09:01:16.369350+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:33:51.423051+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3003"
+      - "3025"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:01:18 GMT
+      - Thu, 22 Feb 2024 07:33:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3603,7 +3819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5372a459-20d2-4740-9165-bee21dc52792
+      - 63460faa-3882-40d3-8618-b18043093210
     status: 200 OK
     code: 200
     duration: ""
@@ -3612,12 +3828,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3626,12 +3842,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:01:18 GMT
+      - Thu, 22 Feb 2024 07:33:55 GMT
       Link:
-      - </servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics?page=1&per_page=50&>;
+      - </servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3639,7 +3855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b00d87c1-385f-4437-bebc-b87393971148
+      - 8f5497b0-f277-49ac-a4a0-90b09e4ebdcd
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3650,12 +3866,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics/47261e53-5760-45c7-9f08-88ea679d0cca
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics/f6b2add0-a704-49b5-8947-4573d672a1af
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:00:00.586198+00:00","id":"47261e53-5760-45c7-9f08-88ea679d0cca","mac_address":"02:00:00:14:74:01","modification_date":"2023-10-27T09:00:33.200421+00:00","private_network_id":"ac96a017-00ac-4d5f-9e03-00d3e4ca3113","server_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:26.835825+00:00","id":"f6b2add0-a704-49b5-8947-4573d672a1af","mac_address":"02:00:00:18:8b:b2","modification_date":"2024-02-22T07:32:58.184461+00:00","private_network_id":"d37ac80f-a813-4079-bd5d-e8f89681570d","server_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -3664,9 +3880,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:01:18 GMT
+      - Thu, 22 Feb 2024 07:33:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3674,7 +3890,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 742e26a5-a7f8-46f0-ba20-7a462bc4a56b
+      - a86b77b4-7081-4bca-a6f9-ee77daf43abe
     status: 200 OK
     code: 200
     duration: ""
@@ -3683,9 +3899,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics/47261e53-5760-45c7-9f08-88ea679d0cca
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics/f6b2add0-a704-49b5-8947-4573d672a1af
     method: DELETE
   response:
     body: ""
@@ -3693,9 +3909,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 27 Oct 2023 09:01:19 GMT
+      - Thu, 22 Feb 2024 07:33:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3703,7 +3919,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 055e9463-acf1-42c0-be39-710861c05544
+      - 31340b13-32f5-4d72-92ec-1c93aa0cff5e
     status: 204 No Content
     code: 204
     duration: ""
@@ -3712,12 +3928,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7/private_nics/47261e53-5760-45c7-9f08-88ea679d0cca
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201/private_nics/f6b2add0-a704-49b5-8947-4573d672a1af
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"47261e53-5760-45c7-9f08-88ea679d0cca","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"f6b2add0-a704-49b5-8947-4573d672a1af","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -3726,9 +3942,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:01:19 GMT
+      - Thu, 22 Feb 2024 07:33:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3736,7 +3952,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 269da198-4192-4152-8e3c-dcf2d96b0149
+      - e8f9ed86-73ea-455f-8dd6-bdebfdd66ed8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3745,29 +3961,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T08:59:43.820693+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-bold-driscoll","id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:bc:d7","maintenances":[],"modification_date":"2023-10-27T09:01:16.369350+00:00","name":"tf-srv-bold-driscoll","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T08:59:43.820693+00:00","export_uri":null,"id":"83b8c92a-5d52-4f7f-9601-2c1bdde8eb94","modification_date":"2023-10-27T08:59:43.820693+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","name":"tf-srv-bold-driscoll"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.815709+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-meitner","id":"e07a44a7-d0ea-4221-aac9-887f22e77201","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:af","maintenances":[],"modification_date":"2024-02-22T07:33:51.423051+00:00","name":"tf-srv-crazy-meitner","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.815709+00:00","export_uri":null,"id":"78bdbb7d-a2e4-44bd-8ae1-5e1498add230","modification_date":"2024-02-22T07:32:03.815709+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e07a44a7-d0ea-4221-aac9-887f22e77201","name":"tf-srv-crazy-meitner"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2642"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:01:19 GMT
+      - Thu, 22 Feb 2024 07:33:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3775,7 +3991,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49c556df-d5f8-4bb2-a41d-343e7b1b6812
+      - c95ec69a-2c6f-4dc5-a24e-628c8aeceecc
     status: 200 OK
     code: 200
     duration: ""
@@ -3784,9 +4000,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: DELETE
   response:
     body: ""
@@ -3794,9 +4010,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 27 Oct 2023 09:01:19 GMT
+      - Thu, 22 Feb 2024 07:33:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3804,7 +4020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61446c4f-35a4-4a62-8d91-772532ca1d9a
+      - 51211d83-dba9-47fb-bf6b-f306a1fb5ea7
     status: 204 No Content
     code: 204
     duration: ""
@@ -3813,12 +4029,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e07a44a7-d0ea-4221-aac9-887f22e77201
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"fa8804f1-5cbc-4d2c-8db2-53b03ed40ed7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e07a44a7-d0ea-4221-aac9-887f22e77201","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -3827,9 +4043,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:01:19 GMT
+      - Thu, 22 Feb 2024 07:33:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3837,7 +4053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49fcec34-e8ec-4b7f-b63a-64ce3fb5f53b
+      - 07b5880a-0858-491d-b9b2-3de3c215d5db
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3846,9 +4062,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/83b8c92a-5d52-4f7f-9601-2c1bdde8eb94
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/78bdbb7d-a2e4-44bd-8ae1-5e1498add230
     method: DELETE
   response:
     body: ""
@@ -3856,9 +4072,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 27 Oct 2023 09:01:19 GMT
+      - Thu, 22 Feb 2024 07:33:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3866,7 +4082,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f8f29a5-fdb3-4264-9fe2-59fcb194b088
+      - e6e9e751-95a3-41ae-a393-45e438568302
     status: 204 No Content
     code: 204
     duration: ""
@@ -3875,9 +4091,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/ac96a017-00ac-4d5f-9e03-00d3e4ca3113
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d37ac80f-a813-4079-bd5d-e8f89681570d
     method: DELETE
   response:
     body: ""
@@ -3887,9 +4103,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:01:20 GMT
+      - Thu, 22 Feb 2024 07:33:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3897,7 +4113,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 972385fa-78c2-4229-8325-e6b0255fb352
+      - 8c9f36b6-581f-4cef-8872-9895f447980e
     status: 204 No Content
     code: 204
     duration: ""
@@ -3906,12 +4122,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/70d2fd66-fbb2-4df0-9e0e-ddbe1296f683
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/f7d23fec-9133-4f33-ae5e-94e4723869bc
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"70d2fd66-fbb2-4df0-9e0e-ddbe1296f683","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"f7d23fec-9133-4f33-ae5e-94e4723869bc","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3920,9 +4136,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:01:20 GMT
+      - Thu, 22 Feb 2024 07:33:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3930,7 +4146,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bce2354-461e-4e88-8c81-0eb48be1037c
+      - 3a1b557f-e9ed-4132-a10e-af83580b660f
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-vpc-public-gateway-dhcp-reservation-static.cassette.yaml
+++ b/scaleway/testdata/data-source-vpc-public-gateway-dhcp-reservation-static.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:46:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e4d3dc3-51e3-4d4b-b716-f88cf0ed2652
+      - 86941bff-09d8-42d1-82ee-8cc75050cf53
     status: 200 OK
     code: 200
     duration: ""
@@ -43,10 +43,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/21b394bb-412e-4659-b93a-3a6071f45bac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/9f234a0d-c636-41ea-9191-bcbc3d8b6397
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:46:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -65,12 +65,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d22db6f9-e50d-483d-a5cf-f3a9e8b7178a
+      - 5858d09c-4339-4e80-b750-1cbe2426326b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-sg-funny-saha","project":"105bdce1-64c0-48ab-899d-868455867ecf","stateful":true,"inbound_default_policy":"drop","outbound_default_policy":"accept","enable_default_security":true}'
+    body: '{"name":"tf-sg-vigilant-sanderson","project":"105bdce1-64c0-48ab-899d-868455867ecf","stateful":true,"inbound_default_policy":"drop","outbound_default_policy":"accept","enable_default_security":true}'
     form: {}
     headers:
       Content-Type:
@@ -81,18 +81,18 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups
     method: POST
   response:
-    body: '{"security_group":{"creation_date":"2024-02-22T07:32:02.442517+00:00","description":null,"enable_default_security":true,"id":"d5661f2e-df14-433a-8915-27cf81fcca35","inbound_default_policy":"drop","modification_date":"2024-02-22T07:32:02.442517+00:00","name":"tf-sg-funny-saha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+    body: '{"security_group":{"creation_date":"2024-02-22T07:46:33.751362+00:00","description":null,"enable_default_security":true,"id":"8706fc71-8132-4d4d-884f-195a46a857ab","inbound_default_policy":"drop","modification_date":"2024-02-22T07:46:33.751362+00:00","name":"tf-sg-vigilant-sanderson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "578"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:46:33 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/8706fc71-8132-4d4d-884f-195a46a857ab
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -102,7 +102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0974fb5a-9e13-4952-8412-6bedddc5c234
+      - 572f65d2-edca-436c-b9b1-32645d535af5
     status: 201 Created
     code: 201
     duration: ""
@@ -115,19 +115,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/8706fc71-8132-4d4d-884f-195a46a857ab
     method: PATCH
   response:
-    body: '{"security_group":{"creation_date":"2024-02-22T07:32:02.442517+00:00","description":null,"enable_default_security":true,"id":"d5661f2e-df14-433a-8915-27cf81fcca35","inbound_default_policy":"drop","modification_date":"2024-02-22T07:32:02.442517+00:00","name":"tf-sg-funny-saha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+    body: '{"security_group":{"creation_date":"2024-02-22T07:46:33.751362+00:00","description":null,"enable_default_security":true,"id":"8706fc71-8132-4d4d-884f-195a46a857ab","inbound_default_policy":"drop","modification_date":"2024-02-22T07:46:33.751362+00:00","name":"tf-sg-vigilant-sanderson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "578"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:46:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -137,75 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5b19a1c-7b6b-4139-a7a0-869559196f57
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"rules":[{"id":null,"action":"accept","protocol":"TCP","direction":"inbound","ip_range":"0.0.0.0/0","dest_port_from":22,"dest_port_to":null,"position":0,"editable":null,"zone":"fr-par-1"}]}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35/rules
-    method: PUT
-  response:
-    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"5da3cecd-121d-49c3-b77c-8b907329e930","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
-    headers:
-      Content-Length:
-      - "1792"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8245b7cf-6356-4376-9c15-241f1e9ffaba
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35
-    method: GET
-  response:
-    body: '{"security_group":{"creation_date":"2024-02-22T07:32:02.442517+00:00","description":null,"enable_default_security":true,"id":"d5661f2e-df14-433a-8915-27cf81fcca35","inbound_default_policy":"drop","modification_date":"2024-02-22T07:32:02.618685+00:00","name":"tf-sg-funny-saha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "578"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 06228d84-0e8a-4da2-95a0-b8ed95f13af7
+      - 26103d35-b711-4f3b-87d1-3cd27132c901
     status: 200 OK
     code: 200
     duration: ""
@@ -221,16 +153,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":null,"id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":null,"id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "367"
+      - "371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:46:34 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -240,7 +172,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 981b0ab8-b76a-431b-a090-f7db8bcc0a27
+      - 5c16404b-5547-4e29-bd32-99986768f030
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2024-02-22T07:46:33.687931Z","dhcp_enabled":true,"id":"05a58304-ad72-4fcd-a574-bb69e773d939","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:46:33.687931Z","id":"24ba09c9-f5b4-4dfb-b90a-548857c677b0","subnet":"172.16.76.0/22","updated_at":"2024-02-22T07:46:33.687931Z"},{"created_at":"2024-02-22T07:46:33.687931Z","id":"3f1cabf6-e325-418a-878f-296dcfc842f1","subnet":"fd5f:519c:6d46:6ee::/64","updated_at":"2024-02-22T07:46:33.687931Z"}],"tags":[],"updated_at":"2024-02-22T07:46:33.687931Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "763"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:46:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3f97a975-0676-4ff2-8f4f-ac3255f0e486
     status: 200 OK
     code: 200
     duration: ""
@@ -251,19 +218,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35/rules?page=1
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05a58304-ad72-4fcd-a574-bb69e773d939
     method: GET
   response:
-    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"5da3cecd-121d-49c3-b77c-8b907329e930","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
+    body: '{"created_at":"2024-02-22T07:46:33.687931Z","dhcp_enabled":true,"id":"05a58304-ad72-4fcd-a574-bb69e773d939","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:46:33.687931Z","id":"24ba09c9-f5b4-4dfb-b90a-548857c677b0","subnet":"172.16.76.0/22","updated_at":"2024-02-22T07:46:33.687931Z"},{"created_at":"2024-02-22T07:46:33.687931Z","id":"3f1cabf6-e325-418a-878f-296dcfc842f1","subnet":"fd5f:519c:6d46:6ee::/64","updated_at":"2024-02-22T07:46:33.687931Z"}],"tags":[],"updated_at":"2024-02-22T07:46:33.687931Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1792"
+      - "763"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:46:34 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -273,7 +240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2dfb2eff-288c-4130-a98f-f8a00b1ff21e
+      - 8a2dcbdb-1944-4377-bfec-62701a63738e
     status: 200 OK
     code: 200
     duration: ""
@@ -284,19 +251,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/9b38f399-ac05-4bf9-b402-2780dd84ffd2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/5b665069-fbb9-4325-b249-6cb109b5e200
     method: GET
   response:
-    body: '{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":null,"id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":null,"id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "367"
+      - "371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:46:34 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -306,12 +273,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e17ed50a-c59d-489b-b1f0-ed362b82d9aa
+      - 568220f5-0486-44bd-a61c-2b4553f7faaf
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","enable_smtp":false,"enable_bastion":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"5b665069-fbb9-4325-b249-6cb109b5e200","enable_smtp":false,"enable_bastion":false}'
     form: {}
     headers:
       Content-Type:
@@ -322,16 +289,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:03.155432Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:34.397432Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "998"
+      - "1002"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:46:34 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -341,7 +308,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1f377db-5a2f-4c38-be9b-f3ce5d34d96f
+      - ce74c99a-c0d7-487a-88c2-03ad0bb9d711
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"rules":[{"id":null,"action":"accept","protocol":"TCP","direction":"inbound","ip_range":"0.0.0.0/0","dest_port_from":22,"dest_port_to":null,"position":0,"editable":null,"zone":"fr-par-1"}]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/8706fc71-8132-4d4d-884f-195a46a857ab/rules
+    method: PUT
+  response:
+    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"0ab8d3f7-68ae-42e2-9558-e5dec50f7d82","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
+    headers:
+      Content-Length:
+      - "1792"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:46:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 16de020b-0cff-4d51-96ee-af69ebc17136
     status: 200 OK
     code: 200
     duration: ""
@@ -352,19 +354,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:03.155432Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:34.490759Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "998"
+      - "1005"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:46:34 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -374,77 +376,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b0db272-8182-4dd4-9db0-4eabaee990e9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
-    method: POST
-  response:
-    body: '{"message":"internal error"}'
-    headers:
-      Content-Length:
-      - "28"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:04 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 71fea3a1-337e-4613-af34-64711f4eae2c
-    status: 500 Internal Server Error
-    code: 500
-    duration: ""
-- request:
-    body: '{"name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
-    method: POST
-  response:
-    body: '{"created_at":"2024-02-22T07:32:06.861460Z","dhcp_enabled":true,"id":"d12edf3a-6ab9-420c-87de-aabaa2480974","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.861460Z","id":"021b49c3-09e3-47a7-b703-59f414e1be2d","subnet":"172.16.44.0/22","updated_at":"2024-02-22T07:32:06.861460Z"},{"created_at":"2024-02-22T07:32:06.861460Z","id":"e3ea9c12-4847-4ca9-817a-60c201c2f7b3","subnet":"fd5f:519c:6d46:cb04::/64","updated_at":"2024-02-22T07:32:06.861460Z"}],"tags":[],"updated_at":"2024-02-22T07:32:06.861460Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "764"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:07 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 246d8b37-a9f4-43a8-9805-6699a1107db6
+      - a8cee02e-8cd5-487e-88fc-b5ec23e889bd
     status: 200 OK
     code: 200
     duration: ""
@@ -455,19 +387,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d12edf3a-6ab9-420c-87de-aabaa2480974
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/8706fc71-8132-4d4d-884f-195a46a857ab
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:06.861460Z","dhcp_enabled":true,"id":"d12edf3a-6ab9-420c-87de-aabaa2480974","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.861460Z","id":"021b49c3-09e3-47a7-b703-59f414e1be2d","subnet":"172.16.44.0/22","updated_at":"2024-02-22T07:32:06.861460Z"},{"created_at":"2024-02-22T07:32:06.861460Z","id":"e3ea9c12-4847-4ca9-817a-60c201c2f7b3","subnet":"fd5f:519c:6d46:cb04::/64","updated_at":"2024-02-22T07:32:06.861460Z"}],"tags":[],"updated_at":"2024-02-22T07:32:06.861460Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"security_group":{"creation_date":"2024-02-22T07:46:33.751362+00:00","description":null,"enable_default_security":true,"id":"8706fc71-8132-4d4d-884f-195a46a857ab","inbound_default_policy":"drop","modification_date":"2024-02-22T07:46:34.030768+00:00","name":"tf-sg-vigilant-sanderson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "764"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:07 GMT
+      - Thu, 22 Feb 2024 07:46:34 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -477,7 +409,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 957b55a6-dfb6-438a-941f-8ed58884c6cc
+      - 73223766-bdee-4175-a311-4992f5c0a733
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/8706fc71-8132-4d4d-884f-195a46a857ab/rules?page=1
+    method: GET
+  response:
+    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"0ab8d3f7-68ae-42e2-9558-e5dec50f7d82","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
+    headers:
+      Content-Length:
+      - "1792"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:46:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 76b4f52f-d2a7-4339-933c-ab7eae132be2
     status: 200 OK
     code: 200
     duration: ""
@@ -500,7 +465,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:07 GMT
+      - Thu, 22 Feb 2024 07:46:34 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -510,7 +475,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87687213-d50c-46a4-9ea6-55f9c293318e
+      - e9e82cb0-fd09-400c-90e3-74cdf83a6391
     status: 200 OK
     code: 200
     duration: ""
@@ -533,7 +498,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:07 GMT
+      - Thu, 22 Feb 2024 07:46:34 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
@@ -546,7 +511,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0f26433-80a3-427e-b86d-42d561ae0a9b
+      - 375cf237-30cb-4f05-813f-fc68da515dce
       X-Total-Count:
       - "61"
     status: 200 OK
@@ -571,7 +536,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:07 GMT
+      - Thu, 22 Feb 2024 07:46:34 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
@@ -584,14 +549,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0e8223d-b2c2-4bea-a680-57b1bb8aba63
+      - 1bb49bb4-513d-46d6-bc53-18b070d67d4e
       X-Total-Count:
       - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-dazzling-ptolemy","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5d083890-4354-47ab-b769-8b0de601eb3a","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","security_group":"d5661f2e-df14-433a-8915-27cf81fcca35"}'
+    body: '{"name":"tf-srv-jovial-ptolemy","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5d083890-4354-47ab-b769-8b0de601eb3a","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","security_group":"8706fc71-8132-4d4d-884f-195a46a857ab"}'
     form: {}
     headers:
       Content-Type:
@@ -604,21 +569,21 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:07.791550+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:46:35.185247+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2667"
+      - "2669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:08 GMT
+      - Thu, 22 Feb 2024 07:46:35 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -628,7 +593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98f0c45e-97ce-4c91-84d1-1f51c8bbf8fe
+      - 356ec0d6-ff95-46e6-9a92-09a9836b4044
     status: 201 Created
     code: 201
     duration: ""
@@ -639,123 +604,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.281269Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "998"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:08 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 619e87d4-a05b-432c-bf1e-cc3a8faa0c76
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.281269Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "998"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:08 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 07690bf2-c99a-4697-9127-834016b1dade
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.281269Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "998"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:08 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6d66c5b1-042c-441d-8321-2ecf35fe8701
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:07.791550+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:46:35.185247+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2667"
+      - "2669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:08 GMT
+      - Thu, 22 Feb 2024 07:46:36 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -765,7 +631,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 576922cc-e3d3-47af-aa67-8faa413834ab
+      - a933f2f6-748a-42d6-8ffa-2c666dcb9b1c
     status: 200 OK
     code: 200
     duration: ""
@@ -776,24 +642,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:07.791550+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:46:35.185247+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2667"
+      - "2669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:08 GMT
+      - Thu, 22 Feb 2024 07:46:36 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -803,7 +669,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11c87d19-3c35-46e3-9134-36dec475b63e
+      - 7fbe1320-4a4c-4227-99f8-e85afc83b5d6
     status: 200 OK
     code: 200
     duration: ""
@@ -816,10 +682,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/04f78869-fd94-417e-945c-c72b0d2041d6/action","href_result":"/servers/04f78869-fd94-417e-945c-c72b0d2041d6","id":"5757a0af-3652-4ab8-8915-c04fc0df6ee6","started_at":"2024-02-22T07:32:08.779485+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/action","href_result":"/servers/db46d636-5b29-491f-82f2-e9a5da5a5609","id":"207bfe57-f45d-4cf4-9240-99c7556710f1","started_at":"2024-02-22T07:46:36.514758+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -828,9 +694,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:08 GMT
+      - Thu, 22 Feb 2024 07:46:36 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/5757a0af-3652-4ab8-8915-c04fc0df6ee6
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/207bfe57-f45d-4cf4-9240-99c7556710f1
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -840,7 +706,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ae94e51-b465-4b26-8a6a-a6b72c06cf13
+      - 7fa677d5-ac26-4dfe-a8ee-8800216c1a0a
     status: 202 Accepted
     code: 202
     duration: ""
@@ -851,25 +717,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:08.618896+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"starting","state_detail":"allocating
-      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:46:36.301991+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"starting","state_detail":"allocating
+      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2689"
+      - "2691"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:09 GMT
+      - Thu, 22 Feb 2024 07:46:37 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -879,12 +745,111 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65b4b5e3-1b9b-46d2-b483-21825c6e0f2e
+      - 465a829f-2734-4a95-92e8-c1455221eea7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"21b394bb-412e-4659-b93a-3a6071f45bac"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:35.436747Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1002"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:46:39 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f1cdd1c3-8af3-4bc1-a4a2-b299c2de30ee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:35.436747Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1002"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:46:39 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c229ccfd-a41d-4085-ba6c-cabc47d70277
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:35.436747Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1002"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:46:39 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d80b3e54-f52d-4b41-a5b8-e110a73e1d13
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397"}'
     form: {}
     headers:
       Content-Type:
@@ -895,7 +860,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":null,"private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"created","updated_at":"2024-02-22T07:32:11.091310Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":null,"private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"created","updated_at":"2024-02-22T07:46:41.483541Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "983"
@@ -904,7 +869,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:11 GMT
+      - Thu, 22 Feb 2024 07:46:41 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -914,7 +879,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60f3857f-c938-4d79-87ba-1e89c101a823
+      - acb8ee8b-513d-4302-a076-7cf7ad8e1d71
     status: 200 OK
     code: 200
     duration: ""
@@ -925,19 +890,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":null,"private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"created","updated_at":"2024-02-22T07:32:11.091310Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.264279Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":null,"private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"created","updated_at":"2024-02-22T07:46:41.483541Z","zone":"fr-par-1"}],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:41.721225Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1984"
+      - "1988"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:11 GMT
+      - Thu, 22 Feb 2024 07:46:41 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -947,7 +912,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 858ecbb7-8777-4ede-a77d-e582244c1baf
+      - 9235894b-394a-4cf6-803e-40c715dde680
     status: 200 OK
     code: 200
     duration: ""
@@ -958,25 +923,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:08.618896+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"starting","state_detail":"allocating
-      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:46:36.301991+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"starting","state_detail":"provisioning
+      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2689"
+      - "2799"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:14 GMT
+      - Thu, 22 Feb 2024 07:46:42 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -986,7 +951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e472d400-be0e-4c01-ab7f-7fc9a97d64d7
+      - 85544c97-5ffa-4608-8c4a-303d64717e55
     status: 200 OK
     code: 200
     duration: ""
@@ -997,19 +962,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":null,"private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"created","updated_at":"2024-02-22T07:32:11.091310Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.264279Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":null,"private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"created","updated_at":"2024-02-22T07:46:41.483541Z","zone":"fr-par-1"}],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:41.721225Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1984"
+      - "1988"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:16 GMT
+      - Thu, 22 Feb 2024 07:46:46 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1019,7 +984,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 384f77f6-d819-4752-ba48-b00cd496db85
+      - db256bc4-34cc-461e-bd92-67b38628f978
     status: 200 OK
     code: 200
     duration: ""
@@ -1030,25 +995,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:08.618896+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"starting","state_detail":"provisioning
-      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:46:36.301991+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"starting","state_detail":"provisioning
+      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2798"
+      - "2799"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:19 GMT
+      - Thu, 22 Feb 2024 07:46:47 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1058,7 +1023,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0e3edaf-606e-4287-bd5d-119009e84350
+      - 27ca93b7-6f71-4de7-92ce-aae243be207c
     status: 200 OK
     code: 200
     duration: ""
@@ -1069,19 +1034,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"configuring","updated_at":"2024-02-22T07:32:17.121837Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.264279Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:50.629745Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2003"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:21 GMT
+      - Thu, 22 Feb 2024 07:46:51 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1091,7 +1056,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7dde300a-f852-4917-a029-3babc68b768e
+      - 210baf89-9753-44c7-9c29-54a828c5fc27
     status: 200 OK
     code: 200
     duration: ""
@@ -1102,82 +1067,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4f45e019-c7f2-4e36-abb1-7722050b6f56
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:08.618896+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"starting","state_detail":"provisioning
-      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2798"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:24 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d7da4f2f-3cb0-44e3-ba77-6d6e2756687b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1993"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:26 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 242fb9be-9c08-4fbc-a2f1-b2e24d691944
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -1186,7 +1079,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:26 GMT
+      - Thu, 22 Feb 2024 07:46:51 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1196,7 +1089,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e197a59-1a04-46d5-8238-6b76b09ab76a
+      - 9d5f840f-d396-4ae0-b682-1efbee6fdbf9
     status: 200 OK
     code: 200
     duration: ""
@@ -1207,10 +1100,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4f45e019-c7f2-4e36-abb1-7722050b6f56
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -1219,7 +1112,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:26 GMT
+      - Thu, 22 Feb 2024 07:46:51 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1229,7 +1122,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8387838e-54ed-4714-b698-ff4347dee3e6
+      - 8e5d21b0-0865-428e-844f-f8112cef2237
     status: 200 OK
     code: 200
     duration: ""
@@ -1240,19 +1133,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:50.629745Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1993"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:26 GMT
+      - Thu, 22 Feb 2024 07:46:52 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1262,7 +1155,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 19b1b9ff-3a71-439a-8b7e-c9782e811c91
+      - 15ad943c-b65c-4c8b-8d9e-cb733f9d8624
     status: 200 OK
     code: 200
     duration: ""
@@ -1273,10 +1166,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4f45e019-c7f2-4e36-abb1-7722050b6f56
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -1285,7 +1178,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:26 GMT
+      - Thu, 22 Feb 2024 07:46:52 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1295,7 +1188,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64c6ea4a-c476-49fb-9d0d-2a4ea3f6bdd4
+      - c262dc69-0d11-446c-afb8-4380171ae60e
     status: 200 OK
     code: 200
     duration: ""
@@ -1306,64 +1199,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:08.618896+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"starting","state_detail":"provisioning
-      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2798"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:29 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c31c3cfe-1d24-4d48-8eef-4861def4c2e9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:29.921486+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"running","state_detail":"booting
-      kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:46:52.124126+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"running","state_detail":"booting
+      kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2829"
+      - "2830"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:35 GMT
+      - Thu, 22 Feb 2024 07:46:52 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1373,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61514995-b3b0-473a-9f41-4789f9378aa8
+      - 1b0077c9-5c79-458f-8d23-86576bc3372f
     status: 200 OK
     code: 200
     duration: ""
@@ -1384,19 +1238,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d12edf3a-6ab9-420c-87de-aabaa2480974
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05a58304-ad72-4fcd-a574-bb69e773d939
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:06.861460Z","dhcp_enabled":true,"id":"d12edf3a-6ab9-420c-87de-aabaa2480974","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.861460Z","id":"021b49c3-09e3-47a7-b703-59f414e1be2d","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:09.121448Z"},{"created_at":"2024-02-22T07:32:06.861460Z","id":"e3ea9c12-4847-4ca9-817a-60c201c2f7b3","subnet":"fd5f:519c:6d46:cb04::/64","updated_at":"2024-02-22T07:32:09.123958Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.459497Z","vpc_id":"ecc51364-65b4-4870-8b19-c6f3e7939b63"}'
+    body: '{"created_at":"2024-02-22T07:46:33.687931Z","dhcp_enabled":true,"id":"05a58304-ad72-4fcd-a574-bb69e773d939","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:46:33.687931Z","id":"24ba09c9-f5b4-4dfb-b90a-548857c677b0","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:40.035742Z"},{"created_at":"2024-02-22T07:46:33.687931Z","id":"3f1cabf6-e325-418a-878f-296dcfc842f1","subnet":"fd5f:519c:6d46:6ee::/64","updated_at":"2024-02-22T07:46:40.037713Z"}],"tags":[],"updated_at":"2024-02-22T07:46:48.006448Z","vpc_id":"da299c41-0771-4e82-b6df-49f167010207"}'
     headers:
       Content-Length:
-      - "764"
+      - "763"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:35 GMT
+      - Thu, 22 Feb 2024 07:46:52 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1406,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0240117d-5e10-49fc-a2a8-c4c7ae13491f
+      - 3d4171fb-caf5-47b9-abae-80a4a8a98aa6
     status: 200 OK
     code: 200
     duration: ""
@@ -1417,25 +1271,25 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:29.921486+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"running","state_detail":"booting
-      kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:46:52.124126+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"running","state_detail":"booting
+      kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2829"
+      - "2830"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:35 GMT
+      - Thu, 22 Feb 2024 07:46:52 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1445,12 +1299,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32b1aca8-5fc6-4588-bc39-775e7a54adea
+      - 4e2a6605-111f-46ce-a8cd-132fa881cdc6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974"}'
+    body: '{"private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939"}'
     form: {}
     headers:
       Content-Type:
@@ -1458,10 +1312,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:35.320655+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:46:52.958861+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1470,7 +1324,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:35 GMT
+      - Thu, 22 Feb 2024 07:46:53 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1480,7 +1334,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1402aae-3503-483c-afa5-30ffc58acd10
+      - 65a95ecd-511c-4d4f-93de-061589222203
     status: 201 Created
     code: 201
     duration: ""
@@ -1491,10 +1345,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics/4870ce34-3835-4bc7-b0db-3279553ddd08
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:35.320655+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:46:52.958861+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1503,7 +1357,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:35 GMT
+      - Thu, 22 Feb 2024 07:46:53 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1513,7 +1367,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50564247-1656-4c94-b93c-e14103e12a02
+      - 1ab6af88-f73e-449f-a5d0-ae15a9eccdd6
     status: 200 OK
     code: 200
     duration: ""
@@ -1524,10 +1378,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics/4870ce34-3835-4bc7-b0db-3279553ddd08
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:36.047446+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:46:53.852888+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1536,7 +1390,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:40 GMT
+      - Thu, 22 Feb 2024 07:46:58 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1546,7 +1400,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 538626d4-fa01-4df2-bd27-7a332a53922d
+      - b5557fb1-3ae0-45f8-bca3-962a7b5c6d59
     status: 200 OK
     code: 200
     duration: ""
@@ -1557,10 +1411,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics/4870ce34-3835-4bc7-b0db-3279553ddd08
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:36.047446+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:46:53.852888+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1569,7 +1423,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:45 GMT
+      - Thu, 22 Feb 2024 07:47:03 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1579,7 +1433,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8aca2882-0213-4471-8238-c6b19c599c85
+      - f2e1c8a3-402a-40c0-a422-65e140050156
     status: 200 OK
     code: 200
     duration: ""
@@ -1590,10 +1444,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics/4870ce34-3835-4bc7-b0db-3279553ddd08
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:36.047446+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:46:53.852888+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1602,7 +1456,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:51 GMT
+      - Thu, 22 Feb 2024 07:47:08 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1612,7 +1466,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 152805dc-1c44-4c0c-84a2-e04ac9f644b7
+      - 25c77e6f-ca1b-412c-9b77-d9293d0c9b49
     status: 200 OK
     code: 200
     duration: ""
@@ -1623,10 +1477,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics/4870ce34-3835-4bc7-b0db-3279553ddd08
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:36.047446+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:46:53.852888+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1635,7 +1489,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:56 GMT
+      - Thu, 22 Feb 2024 07:47:14 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1645,7 +1499,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a1be9e0-ca2a-4638-a8c8-1acbc91566f9
+      - c10172f1-7a52-4dcb-8dc6-36a26a5956a3
     status: 200 OK
     code: 200
     duration: ""
@@ -1656,10 +1510,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics/4870ce34-3835-4bc7-b0db-3279553ddd08
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:36.047446+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:46:53.852888+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1668,7 +1522,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:01 GMT
+      - Thu, 22 Feb 2024 07:47:19 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1678,7 +1532,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eaddf721-0fbf-4e0c-ad3c-01d8f48f7107
+      - 0f9ee5c0-dc74-484b-945e-dd81ee3057ce
     status: 200 OK
     code: 200
     duration: ""
@@ -1689,10 +1543,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics/4870ce34-3835-4bc7-b0db-3279553ddd08
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:36.047446+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:46:53.852888+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1701,7 +1555,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:06 GMT
+      - Thu, 22 Feb 2024 07:47:24 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1711,7 +1565,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbc12e50-3775-491b-a176-21ac6348a83b
+      - 43b33b5f-18e7-4d2d-a511-c8c28206f39f
     status: 200 OK
     code: 200
     duration: ""
@@ -1722,10 +1576,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics/4870ce34-3835-4bc7-b0db-3279553ddd08
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1734,7 +1588,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:11 GMT
+      - Thu, 22 Feb 2024 07:47:29 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1744,7 +1598,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb14ee62-b50d-425d-9069-a5d1db911c5f
+      - 52e46458-251b-4bf9-926c-ab77114ee67c
     status: 200 OK
     code: 200
     duration: ""
@@ -1755,10 +1609,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics/4870ce34-3835-4bc7-b0db-3279553ddd08
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1767,7 +1621,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:11 GMT
+      - Thu, 22 Feb 2024 07:47:29 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1777,7 +1631,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4924ba6e-81c1-4ee2-9ec4-e72090b1f3a6
+      - 7a816985-6782-45f5-98ef-25bb11d92b4f
     status: 200 OK
     code: 200
     duration: ""
@@ -1788,24 +1642,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:29.921486+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:46:52.124126+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3182"
+      - "3183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:11 GMT
+      - Thu, 22 Feb 2024 07:47:29 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1815,7 +1669,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e28d6f2f-b26e-4da3-944f-f6b68666da56
+      - 2840ca51-e767-4fc5-94b9-b8880cf3c83e
     status: 200 OK
     code: 200
     duration: ""
@@ -1826,7 +1680,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1838,7 +1692,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:11 GMT
+      - Thu, 22 Feb 2024 07:47:29 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1848,7 +1702,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac744a39-7950-46cd-8f30-d68a84770547
+      - 4ecfd65b-ebcd-4fd9-b05c-12ac1a448bb0
     status: 200 OK
     code: 200
     duration: ""
@@ -1859,10 +1713,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1871,9 +1725,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:11 GMT
+      - Thu, 22 Feb 2024 07:47:29 GMT
       Link:
-      - </servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics?page=1&per_page=50&>;
+      - </servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
@@ -1884,7 +1738,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6572e4c2-70b5-4da3-9219-87028de97da9
+      - c9da484b-0bfe-40b0-a75b-e122342483ee
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1897,10 +1751,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4f45e019-c7f2-4e36-abb1-7722050b6f56
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -1909,7 +1763,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:11 GMT
+      - Thu, 22 Feb 2024 07:47:29 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1919,12 +1773,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 556b87d1-860e-4603-ba02-1b3f8d3b1b9c
+      - b6670793-995d-4b79-b6df-7fe19c5cdc5c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","mac_address":"02:00:00:18:8b:b6","ip_address":"192.168.1.4"}'
+    body: '{"gateway_network_id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","mac_address":"02:00:00:18:8b:cc","ip_address":"192.168.1.4"}'
     form: {}
     headers:
       Content-Type:
@@ -1935,16 +1789,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries
     method: POST
   response:
-    body: '{"created_at":"2024-02-22T07:32:35.955612Z","gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","hostname":"tf-srv-dazzling-ptolemy","id":"ad334fa3-3aea-4693-8d0a-e69774d137af","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:b6","type":"reservation","updated_at":"2024-02-22T07:33:11.916983Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:46:53.780985Z","gateway_network_id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","hostname":"tf-srv-jovial-ptolemy","id":"a0aa0767-8ee1-4f7a-bf4b-e5d272df55ad","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:cc","type":"reservation","updated_at":"2024-02-22T07:47:30.036969Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "336"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:11 GMT
+      - Thu, 22 Feb 2024 07:47:30 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1954,7 +1808,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dc65a1f-662e-4a28-87bc-80d7a14de288
+      - 7e4a9a52-4ed6-4468-94ab-56f68ac422ca
     status: 200 OK
     code: 200
     duration: ""
@@ -1965,10 +1819,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4f45e019-c7f2-4e36-abb1-7722050b6f56
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -1977,7 +1831,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:11 GMT
+      - Thu, 22 Feb 2024 07:47:30 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1987,7 +1841,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 752d5a20-bfc0-4b6c-b647-2dfc3d994bac
+      - 63edf5b7-2118-4655-809a-0e936bb00207
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,19 +1852,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ad334fa3-3aea-4693-8d0a-e69774d137af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0aa0767-8ee1-4f7a-bf4b-e5d272df55ad
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:35.955612Z","gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","hostname":"tf-srv-dazzling-ptolemy","id":"ad334fa3-3aea-4693-8d0a-e69774d137af","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:b6","type":"reservation","updated_at":"2024-02-22T07:33:11.916983Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:46:53.780985Z","gateway_network_id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","hostname":"tf-srv-jovial-ptolemy","id":"a0aa0767-8ee1-4f7a-bf4b-e5d272df55ad","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:cc","type":"reservation","updated_at":"2024-02-22T07:47:30.036969Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "336"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:12 GMT
+      - Thu, 22 Feb 2024 07:47:30 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2020,7 +1874,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba35102d-4a6d-4c41-b224-0fd6412231e2
+      - 09795c7a-7012-43b0-9ff6-58fafd88fd88
     status: 200 OK
     code: 200
     duration: ""
@@ -2031,19 +1885,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:50.629745Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1993"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:12 GMT
+      - Thu, 22 Feb 2024 07:47:30 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2053,7 +1907,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38131b0c-b379-4895-816b-8d30eef11344
+      - 6fb636ac-9c12-45c9-b336-405522cf548b
     status: 200 OK
     code: 200
     duration: ""
@@ -2064,19 +1918,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0aa0767-8ee1-4f7a-bf4b-e5d272df55ad
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:46:53.780985Z","gateway_network_id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","hostname":"tf-srv-jovial-ptolemy","id":"a0aa0767-8ee1-4f7a-bf4b-e5d272df55ad","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:cc","type":"reservation","updated_at":"2024-02-22T07:47:30.036969Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1993"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:12 GMT
+      - Thu, 22 Feb 2024 07:47:30 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2086,7 +1940,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54d4c4bc-7d31-48e0-983e-3b91fcb6e551
+      - d6fcab9f-806e-48bf-973d-32e20dd53fd0
     status: 200 OK
     code: 200
     duration: ""
@@ -2097,19 +1951,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ad334fa3-3aea-4693-8d0a-e69774d137af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:35.955612Z","gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","hostname":"tf-srv-dazzling-ptolemy","id":"ad334fa3-3aea-4693-8d0a-e69774d137af","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:b6","type":"reservation","updated_at":"2024-02-22T07:33:11.916983Z","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:50.629745Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "336"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:12 GMT
+      - Thu, 22 Feb 2024 07:47:30 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2119,12 +1973,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cdcd588e-e5b8-43b6-b56e-9a5c7fbef455
+      - 162550e2-e7e6-4194-9ba2-23b0dd0cca3e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","public_port":2222,"private_ip":"192.168.1.4","private_port":22,"protocol":"tcp"}'
+    body: '{"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","public_port":2222,"private_ip":"192.168.1.4","private_port":22,"protocol":"tcp"}'
     form: {}
     headers:
       Content-Type:
@@ -2135,7 +1989,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules
     method: POST
   response:
-    body: '{"created_at":"2024-02-22T07:33:12.183475Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"b8afff61-1474-4dfb-aa85-fbb715bd254e","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2024-02-22T07:33:12.183475Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:47:30.390581Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"b4da4853-1b49-4991-a9b8-132c3d11c730","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2024-02-22T07:47:30.390581Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "290"
@@ -2144,7 +1998,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:12 GMT
+      - Thu, 22 Feb 2024 07:47:30 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2154,7 +2008,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87cc8094-5ffd-4469-842c-2a967c27dc9f
+      - bb06e04d-9c9a-4d8c-8a8a-8816c167bbe5
     status: 200 OK
     code: 200
     duration: ""
@@ -2165,19 +2019,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:50.629745Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1993"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:12 GMT
+      - Thu, 22 Feb 2024 07:47:30 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2187,7 +2041,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a6db2063-ca5b-4e9b-8648-89cb2b3a39b6
+      - 0ea9b973-7758-4d65-afcc-8afe71e19da2
     status: 200 OK
     code: 200
     duration: ""
@@ -2198,10 +2052,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/b8afff61-1474-4dfb-aa85-fbb715bd254e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/b4da4853-1b49-4991-a9b8-132c3d11c730
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:33:12.183475Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"b8afff61-1474-4dfb-aa85-fbb715bd254e","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2024-02-22T07:33:12.183475Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:47:30.390581Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"b4da4853-1b49-4991-a9b8-132c3d11c730","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2024-02-22T07:47:30.390581Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "290"
@@ -2210,7 +2064,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:12 GMT
+      - Thu, 22 Feb 2024 07:47:30 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2220,7 +2074,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a5cf30b-d132-4bf8-b10d-9b592f79517d
+      - a3faa0f4-7a37-4389-b5ba-d9a962dcff56
     status: 200 OK
     code: 200
     duration: ""
@@ -2231,19 +2085,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ad334fa3-3aea-4693-8d0a-e69774d137af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0aa0767-8ee1-4f7a-bf4b-e5d272df55ad
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:35.955612Z","gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","hostname":"tf-srv-dazzling-ptolemy","id":"ad334fa3-3aea-4693-8d0a-e69774d137af","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:b6","type":"reservation","updated_at":"2024-02-22T07:33:11.916983Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:46:53.780985Z","gateway_network_id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","hostname":"tf-srv-jovial-ptolemy","id":"a0aa0767-8ee1-4f7a-bf4b-e5d272df55ad","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:cc","type":"reservation","updated_at":"2024-02-22T07:47:30.036969Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "336"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:12 GMT
+      - Thu, 22 Feb 2024 07:47:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2253,7 +2107,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dca552c6-fc5a-4518-abd4-03c22e7a1de0
+      - d4e62151-b686-43e9-ac30-489c5ff6ced0
     status: 200 OK
     code: 200
     duration: ""
@@ -2264,10 +2118,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/21b394bb-412e-4659-b93a-3a6071f45bac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/5b665069-fbb9-4325-b249-6cb109b5e200
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "405"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:47:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f27a3575-8e8e-45f9-a582-fcb091ecd705
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05a58304-ad72-4fcd-a574-bb69e773d939
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-22T07:46:33.687931Z","dhcp_enabled":true,"id":"05a58304-ad72-4fcd-a574-bb69e773d939","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:46:33.687931Z","id":"24ba09c9-f5b4-4dfb-b90a-548857c677b0","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:40.035742Z"},{"created_at":"2024-02-22T07:46:33.687931Z","id":"3f1cabf6-e325-418a-878f-296dcfc842f1","subnet":"fd5f:519c:6d46:6ee::/64","updated_at":"2024-02-22T07:46:40.037713Z"}],"tags":[],"updated_at":"2024-02-22T07:46:48.006448Z","vpc_id":"da299c41-0771-4e82-b6df-49f167010207"}'
+    headers:
+      Content-Length:
+      - "763"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:47:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9cdcb9ed-7522-41d7-a855-af90346712e1
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/9f234a0d-c636-41ea-9191-bcbc3d8b6397
+    method: GET
+  response:
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "586"
@@ -2276,7 +2196,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:12 GMT
+      - Thu, 22 Feb 2024 07:47:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2286,7 +2206,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7cfef53-d0b2-4055-becc-9e3bf8680393
+      - 956db45b-2180-4db6-9cfd-3fd055667b5d
     status: 200 OK
     code: 200
     duration: ""
@@ -2297,19 +2217,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/9b38f399-ac05-4bf9-b402-2780dd84ffd2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:50.629745Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "401"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
+      - Thu, 22 Feb 2024 07:47:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2319,7 +2239,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4930b5f-83b8-465c-9778-e80055cb003b
+      - 2ce5d1e5-5721-4be5-99fd-3a6bbb7aec40
     status: 200 OK
     code: 200
     duration: ""
@@ -2330,19 +2250,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d12edf3a-6ab9-420c-87de-aabaa2480974
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/8706fc71-8132-4d4d-884f-195a46a857ab
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:06.861460Z","dhcp_enabled":true,"id":"d12edf3a-6ab9-420c-87de-aabaa2480974","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.861460Z","id":"021b49c3-09e3-47a7-b703-59f414e1be2d","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:09.121448Z"},{"created_at":"2024-02-22T07:32:06.861460Z","id":"e3ea9c12-4847-4ca9-817a-60c201c2f7b3","subnet":"fd5f:519c:6d46:cb04::/64","updated_at":"2024-02-22T07:32:09.123958Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.459497Z","vpc_id":"ecc51364-65b4-4870-8b19-c6f3e7939b63"}'
+    body: '{"security_group":{"creation_date":"2024-02-22T07:46:33.751362+00:00","description":null,"enable_default_security":true,"id":"8706fc71-8132-4d4d-884f-195a46a857ab","inbound_default_policy":"drop","modification_date":"2024-02-22T07:46:34.672335+00:00","name":"tf-sg-vigilant-sanderson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"}],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "764"
+      - "667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
+      - Thu, 22 Feb 2024 07:47:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2352,7 +2272,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81eb77f0-c25d-4d45-a2c8-83501f8d9091
+      - 1ead2099-06d1-4325-85f9-da209a58b761
     status: 200 OK
     code: 200
     duration: ""
@@ -2363,76 +2283,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4f45e019-c7f2-4e36-abb1-7722050b6f56
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1993"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 35e816a9-1cf5-45f4-8d3c-1ee4f7cca7ac
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35
-    method: GET
-  response:
-    body: '{"security_group":{"creation_date":"2024-02-22T07:32:02.442517+00:00","description":null,"enable_default_security":true,"id":"d5661f2e-df14-433a-8915-27cf81fcca35","inbound_default_policy":"drop","modification_date":"2024-02-22T07:32:02.974944+00:00","name":"tf-sg-funny-saha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"}],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "661"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 35d090d1-945c-42cd-9694-cb7cd66ec351
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -2441,7 +2295,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
+      - Thu, 22 Feb 2024 07:47:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2451,7 +2305,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed049304-3020-4d94-b28a-baa4abe01ca2
+      - 52b873a0-ad2d-4066-891a-298391769bb0
     status: 200 OK
     code: 200
     duration: ""
@@ -2462,43 +2316,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/8706fc71-8132-4d4d-884f-195a46a857ab/rules?page=1
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1993"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a77859d1-16b8-464c-97d6-605ab24ef30a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35/rules?page=1
-    method: GET
-  response:
-    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"5da3cecd-121d-49c3-b77c-8b907329e930","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
+    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"0ab8d3f7-68ae-42e2-9558-e5dec50f7d82","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "1792"
@@ -2507,7 +2328,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
+      - Thu, 22 Feb 2024 07:47:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2517,7 +2338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53efb2c1-b1b9-44de-bd28-040f05371f10
+      - 19baecb4-047a-40d8-af32-be0a2c1257b1
     status: 200 OK
     code: 200
     duration: ""
@@ -2528,10 +2349,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:50.629745Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1997"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:47:31 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ff538b48-006b-4383-b280-064bd94f838f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4f45e019-c7f2-4e36-abb1-7722050b6f56
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -2540,7 +2394,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
+      - Thu, 22 Feb 2024 07:47:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2550,7 +2404,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67149e5b-32e9-4d19-848c-1e7efe73110c
+      - 41185e21-a6b9-4a7f-9e6e-9fe2a56e3265
     status: 200 OK
     code: 200
     duration: ""
@@ -2561,24 +2415,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:29.921486+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:46:52.124126+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3182"
+      - "3183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
+      - Thu, 22 Feb 2024 07:47:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2588,7 +2442,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6d303b3-9755-4196-9858-7f7398244ed6
+      - e5dfca43-50af-445f-b17f-63d56e9f948e
     status: 200 OK
     code: 200
     duration: ""
@@ -2599,7 +2453,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2611,7 +2465,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
+      - Thu, 22 Feb 2024 07:47:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2621,7 +2475,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8134542-8d87-4729-baf7-fde75e5cb840
+      - 6ee6a43e-0304-4e1f-b49b-e0424339693f
     status: 200 OK
     code: 200
     duration: ""
@@ -2632,10 +2486,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2644,9 +2498,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
+      - Thu, 22 Feb 2024 07:47:31 GMT
       Link:
-      - </servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics?page=1&per_page=50&>;
+      - </servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
@@ -2657,7 +2511,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9200688f-8046-4b9e-a9c8-649491115256
+      - 54550702-0e2a-4f13-aead-68be1e2fe3a0
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2670,19 +2524,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ad334fa3-3aea-4693-8d0a-e69774d137af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0aa0767-8ee1-4f7a-bf4b-e5d272df55ad
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:35.955612Z","gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","hostname":"tf-srv-dazzling-ptolemy","id":"ad334fa3-3aea-4693-8d0a-e69774d137af","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:b6","type":"reservation","updated_at":"2024-02-22T07:33:11.916983Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:46:53.780985Z","gateway_network_id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","hostname":"tf-srv-jovial-ptolemy","id":"a0aa0767-8ee1-4f7a-bf4b-e5d272df55ad","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:cc","type":"reservation","updated_at":"2024-02-22T07:47:30.036969Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "336"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
+      - Thu, 22 Feb 2024 07:47:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2692,7 +2546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ac4ec85-dc84-47c5-abca-14accea23121
+      - 541c70b9-360f-423f-ae53-d2d74f6c2d0f
     status: 200 OK
     code: 200
     duration: ""
@@ -2703,109 +2557,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/b8afff61-1474-4dfb-aa85-fbb715bd254e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/b4da4853-1b49-4991-a9b8-132c3d11c730
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:33:12.183475Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"b8afff61-1474-4dfb-aa85-fbb715bd254e","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2024-02-22T07:33:12.183475Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "290"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dd727556-2ae8-4129-aaca-e8d8eaf79717
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ad334fa3-3aea-4693-8d0a-e69774d137af
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-22T07:32:35.955612Z","gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","hostname":"tf-srv-dazzling-ptolemy","id":"ad334fa3-3aea-4693-8d0a-e69774d137af","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:b6","type":"reservation","updated_at":"2024-02-22T07:33:11.916983Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "336"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6030a0eb-b2e6-4fb9-850b-0704e708ebe8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ad334fa3-3aea-4693-8d0a-e69774d137af
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-22T07:32:35.955612Z","gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","hostname":"tf-srv-dazzling-ptolemy","id":"ad334fa3-3aea-4693-8d0a-e69774d137af","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:b6","type":"reservation","updated_at":"2024-02-22T07:33:11.916983Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "336"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:33:13 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5435b321-93fc-4a73-90c5-2c1f1057c140
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/b8afff61-1474-4dfb-aa85-fbb715bd254e
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-22T07:33:12.183475Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"b8afff61-1474-4dfb-aa85-fbb715bd254e","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2024-02-22T07:33:12.183475Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:47:30.390581Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"b4da4853-1b49-4991-a9b8-132c3d11c730","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2024-02-22T07:47:30.390581Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "290"
@@ -2814,7 +2569,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:47:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2824,7 +2579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8203abb6-9a2e-4656-87d6-18eb52b5a996
+      - 24fc4a80-6590-4aad-806e-fc5a60f2dea5
     status: 200 OK
     code: 200
     duration: ""
@@ -2835,19 +2590,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0aa0767-8ee1-4f7a-bf4b-e5d272df55ad
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:46:53.780985Z","gateway_network_id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","hostname":"tf-srv-jovial-ptolemy","id":"a0aa0767-8ee1-4f7a-bf4b-e5d272df55ad","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:cc","type":"reservation","updated_at":"2024-02-22T07:47:30.036969Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1993"
+      - "334"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:47:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2857,7 +2612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a25405d7-2096-4659-bb14-2756d3905421
+      - 502c6c0e-a52a-4cc7-b77f-cece6b012539
     status: 200 OK
     code: 200
     duration: ""
@@ -2868,7 +2623,106 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/b8afff61-1474-4dfb-aa85-fbb715bd254e
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0aa0767-8ee1-4f7a-bf4b-e5d272df55ad
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-22T07:46:53.780985Z","gateway_network_id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","hostname":"tf-srv-jovial-ptolemy","id":"a0aa0767-8ee1-4f7a-bf4b-e5d272df55ad","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:cc","type":"reservation","updated_at":"2024-02-22T07:47:30.036969Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "334"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:47:32 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e9473a90-7b53-44de-96b8-9c966ca1a9f8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/b4da4853-1b49-4991-a9b8-132c3d11c730
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-22T07:47:30.390581Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"b4da4853-1b49-4991-a9b8-132c3d11c730","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2024-02-22T07:47:30.390581Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "290"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:47:32 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5254d86f-ca26-407e-8f98-494779ca4e6d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:50.629745Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1997"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:47:32 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3349fe5b-592a-4969-8da2-adc41fe842da
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/b4da4853-1b49-4991-a9b8-132c3d11c730
     method: DELETE
   response:
     body: ""
@@ -2878,7 +2732,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:47:32 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2888,7 +2742,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a980fdb-8e15-4d97-890c-27e67168a101
+      - 14d543ae-603c-4443-bdf7-8787c03bdd04
     status: 204 No Content
     code: 204
     duration: ""
@@ -2899,19 +2753,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:50.629745Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1993"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:47:32 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2921,7 +2775,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa7de0c2-84aa-455b-8d6a-76fc410f795a
+      - 98db5b7f-5015-4097-bdce-fd48c9a54d82
     status: 200 OK
     code: 200
     duration: ""
@@ -2932,10 +2786,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4f45e019-c7f2-4e36-abb1-7722050b6f56
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -2944,7 +2798,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:47:32 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2954,7 +2808,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 651e8689-0ec8-42af-873b-632fdc966b8c
+      - 5555c4c5-e0a2-4291-a716-7db21b76c30d
     status: 200 OK
     code: 200
     duration: ""
@@ -2965,7 +2819,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ad334fa3-3aea-4693-8d0a-e69774d137af
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/a0aa0767-8ee1-4f7a-bf4b-e5d272df55ad
     method: DELETE
   response:
     body: ""
@@ -2975,7 +2829,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:47:32 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2985,7 +2839,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b279025-01a6-4d7f-88e8-90705b5d2070
+      - ed2f75ea-f336-47d3-9fb6-b291b4d7b08c
     status: 204 No Content
     code: 204
     duration: ""
@@ -2996,10 +2850,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4f45e019-c7f2-4e36-abb1-7722050b6f56
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -3008,7 +2862,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:47:32 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3018,7 +2872,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3be9915f-0095-405d-9441-d75647ca7685
+      - 23c95805-8703-43f2-8957-672451e46add
     status: 200 OK
     code: 200
     duration: ""
@@ -3029,10 +2883,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4f45e019-c7f2-4e36-abb1-7722050b6f56
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"ready","updated_at":"2024-02-22T07:46:50.503987Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "996"
@@ -3041,7 +2895,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:47:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3051,7 +2905,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3db8fd6f-4e4d-4aec-8188-019b58569164
+      - 7044bbc6-973d-4ffd-b2cc-46fedd05dd9b
     status: 200 OK
     code: 200
     duration: ""
@@ -3062,7 +2916,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4f45e019-c7f2-4e36-abb1-7722050b6f56?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -3072,7 +2926,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:47:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3082,7 +2936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a9b551f-0525-472a-86e8-be6bf97e6797
+      - 33eb42f6-128b-4777-9fc9-ab2d3c0c7465
     status: 204 No Content
     code: 204
     duration: ""
@@ -3093,24 +2947,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:29.921486+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:46:52.124126+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3182"
+      - "3183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:47:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3120,7 +2974,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 684804ba-6e04-46a2-a5a5-e92150435f85
+      - 86b43630-9a3e-491b-a92e-a8753d7884dd
     status: 200 OK
     code: 200
     duration: ""
@@ -3131,10 +2985,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4f45e019-c7f2-4e36-abb1-7722050b6f56
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"detaching","updated_at":"2024-02-22T07:33:14.715069Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:46:41.483541Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:46:33.685684Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:46:33.685684Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","ipam_config":null,"mac_address":"02:00:00:18:8B:CB","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","status":"detaching","updated_at":"2024-02-22T07:47:33.080977Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "1000"
@@ -3143,7 +2997,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:47:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3153,7 +3007,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d72b6364-d73e-4756-b690-a59ad265b986
+      - c28a1841-0109-43ca-9f18-91de23ad06dc
     status: 200 OK
     code: 200
     duration: ""
@@ -3166,10 +3020,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/04f78869-fd94-417e-945c-c72b0d2041d6/action","href_result":"/servers/04f78869-fd94-417e-945c-c72b0d2041d6","id":"340155f9-82df-4651-b864-f79f07c4c7c7","started_at":"2024-02-22T07:33:14.960131+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/action","href_result":"/servers/db46d636-5b29-491f-82f2-e9a5da5a5609","id":"9c06e89e-6627-4e0c-b8ad-250572557925","started_at":"2024-02-22T07:47:33.541074+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -3178,9 +3032,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:15 GMT
+      - Thu, 22 Feb 2024 07:47:33 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/340155f9-82df-4651-b864-f79f07c4c7c7
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/9c06e89e-6627-4e0c-b8ad-250572557925
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3190,7 +3044,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 404c41da-7d9d-4d7d-a463-0ea4024ac994
+      - f87505cd-665f-4416-9ce9-6545a41be7fe
     status: 202 Accepted
     code: 202
     duration: ""
@@ -3201,24 +3055,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:14.822923+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:47:33.166616+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3151"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:15 GMT
+      - Thu, 22 Feb 2024 07:47:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3228,7 +3082,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a02e7645-9a2e-4837-89db-49f850f0fa9f
+      - fd26486a-a0e8-4cdc-8971-73084d80815b
     status: 200 OK
     code: 200
     duration: ""
@@ -3239,10 +3093,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/4f45e019-c7f2-4e36-abb1-7722050b6f56
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"4f45e019-c7f2-4e36-abb1-7722050b6f56","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3251,7 +3105,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:19 GMT
+      - Thu, 22 Feb 2024 07:47:38 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3261,7 +3115,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5de488c7-679d-46f7-8bde-9385d3fafba0
+      - ef5428fc-3364-405a-9e04-bf7e60230b52
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3272,19 +3126,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:50.629745Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "997"
+      - "1001"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:19 GMT
+      - Thu, 22 Feb 2024 07:47:38 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3294,7 +3148,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - adebcdf1-75fd-4048-83ba-9cbda112b228
+      - 8c2a3396-8e18-4f29-bad1-1829885dba85
     status: 200 OK
     code: 200
     duration: ""
@@ -3305,10 +3159,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/21b394bb-412e-4659-b93a-3a6071f45bac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/9f234a0d-c636-41ea-9191-bcbc3d8b6397
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"21b394bb-412e-4659-b93a-3a6071f45bac","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3317,7 +3171,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:19 GMT
+      - Thu, 22 Feb 2024 07:47:38 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3327,7 +3181,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f150638d-f9b3-4702-ae31-bb64f1ee7e6c
+      - 2e02aa24-674f-4f56-92ca-dbaecbfcfcc9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3338,19 +3192,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:46:50.629745Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "997"
+      - "1001"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:19 GMT
+      - Thu, 22 Feb 2024 07:47:38 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3360,7 +3214,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d2792c6-7ed4-4858-a44e-8764a96d91c4
+      - 098f50bd-3167-4cba-a105-47636d8ca557
     status: 200 OK
     code: 200
     duration: ""
@@ -3371,7 +3225,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -3381,7 +3235,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:19 GMT
+      - Thu, 22 Feb 2024 07:47:38 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3391,7 +3245,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82f6aa6e-d840-4418-b12b-674593bf4111
+      - 5f03692e-cb5a-4c5e-968e-239ff8bae061
     status: 204 No Content
     code: 204
     duration: ""
@@ -3402,19 +3256,19 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"deleting","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:33:19.902961Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:46:34.397432Z","gateway_networks":[],"id":"37917f9d-5a72-4fce-a407-993b854ffc7e","ip":{"address":"163.172.131.206","created_at":"2024-02-22T07:46:34.238576Z","gateway_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","id":"5b665069-fbb9-4325-b249-6cb109b5e200","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"206-131-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:46:34.238576Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"deleting","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:47:38.297896Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "998"
+      - "1002"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:19 GMT
+      - Thu, 22 Feb 2024 07:47:38 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3424,7 +3278,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74299060-d001-471e-8be9-72e65c824742
+      - 5c28f42b-8c7f-48f9-9617-2c6582046f33
     status: 200 OK
     code: 200
     duration: ""
@@ -3435,24 +3289,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:14.822923+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:47:33.166616+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3151"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:20 GMT
+      - Thu, 22 Feb 2024 07:47:39 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3462,7 +3316,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae68a12a-bec8-442c-b53f-25ed9fc6806b
+      - af6388d6-3c41-4c1c-94f5-fceade80ffdf
     status: 200 OK
     code: 200
     duration: ""
@@ -3473,10 +3327,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/37917f9d-5a72-4fce-a407-993b854ffc7e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"37917f9d-5a72-4fce-a407-993b854ffc7e","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3485,7 +3339,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:24 GMT
+      - Thu, 22 Feb 2024 07:47:43 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3495,7 +3349,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa70a752-7d47-4e27-8157-2ef086a045c5
+      - 0454cc95-168e-4fa0-80b6-927a1fd91a57
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3506,7 +3360,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/9b38f399-ac05-4bf9-b402-2780dd84ffd2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/5b665069-fbb9-4325-b249-6cb109b5e200
     method: DELETE
   response:
     body: ""
@@ -3516,7 +3370,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:25 GMT
+      - Thu, 22 Feb 2024 07:47:43 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3526,7 +3380,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 611c0051-c51b-4f56-a6f3-6adcac2ed88e
+      - 4bf8688e-728a-4b9d-97d4-288554aa239f
     status: 204 No Content
     code: 204
     duration: ""
@@ -3537,24 +3391,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:14.822923+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:47:33.166616+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3151"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:25 GMT
+      - Thu, 22 Feb 2024 07:47:44 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3564,7 +3418,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81bad793-204a-40e9-86f2-5230a77fa237
+      - 00e5f4f1-c996-4cd1-993c-f20783a5af0b
     status: 200 OK
     code: 200
     duration: ""
@@ -3575,24 +3429,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:14.822923+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:47:33.166616+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3151"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:30 GMT
+      - Thu, 22 Feb 2024 07:47:49 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3602,7 +3456,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e94161e7-c54a-46dc-b3e2-82701a57ee84
+      - 5392b8f8-ce6e-49ed-8287-1043c46bd69c
     status: 200 OK
     code: 200
     duration: ""
@@ -3613,24 +3467,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:14.822923+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:47:33.166616+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3151"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:35 GMT
+      - Thu, 22 Feb 2024 07:47:54 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3640,7 +3494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51706298-810d-4871-acad-b0a188b2f83c
+      - 99cadab2-cb73-426f-b995-4be25f95d22a
     status: 200 OK
     code: 200
     duration: ""
@@ -3651,24 +3505,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:14.822923+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:47:33.166616+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3151"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:41 GMT
+      - Thu, 22 Feb 2024 07:48:00 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3678,7 +3532,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eaf0615d-ec69-4682-a88e-11b4c58e9852
+      - 027db6b9-7d0d-44bc-9386-85a91ced4359
     status: 200 OK
     code: 200
     duration: ""
@@ -3689,24 +3543,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:14.822923+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:47:33.166616+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3151"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:46 GMT
+      - Thu, 22 Feb 2024 07:48:05 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3716,7 +3570,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0ae817d-5e0c-4012-bd04-f68f92dd2bd9
+      - bdad908e-e6ca-4f70-8e51-4d080d7ec1f1
     status: 200 OK
     code: 200
     duration: ""
@@ -3727,24 +3581,62 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"37","hypervisor_id":"1702","node_id":"1","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:47:33.166616+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.226.1","private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3151"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:48:10 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1426a871-1563-487b-a0bc-b73a3b18f394
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:46.854446+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:48:12.402643+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3028"
+      - "3030"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:51 GMT
+      - Thu, 22 Feb 2024 07:48:15 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3754,7 +3646,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0e973a6b-0123-4e1e-b2ef-47226a4493bc
+      - 57272bfa-4b2e-488f-9c43-bc088459ef5a
     status: 200 OK
     code: 200
     duration: ""
@@ -3765,10 +3657,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3777,9 +3669,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:51 GMT
+      - Thu, 22 Feb 2024 07:48:15 GMT
       Link:
-      - </servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics?page=1&per_page=50&>;
+      - </servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
@@ -3790,7 +3682,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e61dbb65-7814-4970-a4a5-a000929ddd9c
+      - ad0890ed-2408-4b18-a9ea-d400de7059f0
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3803,10 +3695,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics/4870ce34-3835-4bc7-b0db-3279553ddd08
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:46:52.958861+00:00","id":"4870ce34-3835-4bc7-b0db-3279553ddd08","mac_address":"02:00:00:18:8b:cc","modification_date":"2024-02-22T07:47:24.242631+00:00","private_network_id":"05a58304-ad72-4fcd-a574-bb69e773d939","server_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -3815,7 +3707,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:51 GMT
+      - Thu, 22 Feb 2024 07:48:15 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3825,7 +3717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fae1bc94-c901-436c-aa4c-b75e629edfdb
+      - 4b288e9f-b347-457a-8f56-b33ad347c4c7
     status: 200 OK
     code: 200
     duration: ""
@@ -3836,7 +3728,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics/4870ce34-3835-4bc7-b0db-3279553ddd08
     method: DELETE
   response:
     body: ""
@@ -3844,7 +3736,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 22 Feb 2024 07:33:51 GMT
+      - Thu, 22 Feb 2024 07:48:16 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3854,7 +3746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db749f9a-c8e4-4f49-a4d4-c8ff93cc7a61
+      - da00e243-1b07-40f4-baf9-19628ee9d114
     status: 204 No Content
     code: 204
     duration: ""
@@ -3865,10 +3757,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609/private_nics/4870ce34-3835-4bc7-b0db-3279553ddd08
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"4870ce34-3835-4bc7-b0db-3279553ddd08","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -3877,7 +3769,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:51 GMT
+      - Thu, 22 Feb 2024 07:48:16 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3887,7 +3779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40a104df-09a2-4371-8cc4-245951d04918
+      - e111f4af-93fb-4975-a3da-b983790356f7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3898,24 +3790,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:46:35.185247+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-jovial-ptolemy","id":"db46d636-5b29-491f-82f2-e9a5da5a5609","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
       20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:46.854446+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:02:15","maintenances":[],"modification_date":"2024-02-22T07:48:12.402643+00:00","name":"tf-srv-jovial-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"8706fc71-8132-4d4d-884f-195a46a857ab","name":"tf-sg-vigilant-sanderson"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:46:35.185247+00:00","export_uri":null,"id":"1e00c311-0f10-48cf-867e-2c553985c254","modification_date":"2024-02-22T07:46:35.185247+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"db46d636-5b29-491f-82f2-e9a5da5a5609","name":"tf-srv-jovial-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2667"
+      - "2669"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:52 GMT
+      - Thu, 22 Feb 2024 07:48:16 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3925,7 +3817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c40845c-65ae-4a6b-b80c-bf409949dce2
+      - 7d161907-21cb-49dd-b6c4-c1e83ebb5fe4
     status: 200 OK
     code: 200
     duration: ""
@@ -3936,7 +3828,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: DELETE
   response:
     body: ""
@@ -3944,7 +3836,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 22 Feb 2024 07:33:52 GMT
+      - Thu, 22 Feb 2024 07:48:16 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3954,7 +3846,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1403c33-388e-4793-814f-e8b134ea1373
+      - 002bed8f-a29f-4803-82c3-ce2d4a09724c
     status: 204 No Content
     code: 204
     duration: ""
@@ -3965,10 +3857,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/db46d636-5b29-491f-82f2-e9a5da5a5609
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"04f78869-fd94-417e-945c-c72b0d2041d6","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"db46d636-5b29-491f-82f2-e9a5da5a5609","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -3977,7 +3869,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:52 GMT
+      - Thu, 22 Feb 2024 07:48:16 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3987,7 +3879,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a46b474-00d4-4c1c-8a88-37e3d5436637
+      - d660e4b2-0c57-4aeb-8bfb-813d268feb6c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3998,7 +3890,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f2e13700-9110-4c65-a8cf-c5287a2a51a8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1e00c311-0f10-48cf-867e-2c553985c254
     method: DELETE
   response:
     body: ""
@@ -4006,7 +3898,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 22 Feb 2024 07:33:52 GMT
+      - Thu, 22 Feb 2024 07:48:17 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -4016,7 +3908,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66e029d8-3d13-48da-b92c-e346fb294132
+      - 3013f474-5390-4797-9f7a-d12ca5bade6b
     status: 204 No Content
     code: 204
     duration: ""
@@ -4027,7 +3919,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/8706fc71-8132-4d4d-884f-195a46a857ab
     method: DELETE
   response:
     body: ""
@@ -4035,7 +3927,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 22 Feb 2024 07:33:52 GMT
+      - Thu, 22 Feb 2024 07:48:17 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -4045,7 +3937,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1aaa89b9-601e-4c10-a3c8-30b7504af954
+      - 625c7121-2df6-45d4-b6e1-29836721e19c
     status: 204 No Content
     code: 204
     duration: ""
@@ -4056,7 +3948,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d12edf3a-6ab9-420c-87de-aabaa2480974
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/05a58304-ad72-4fcd-a574-bb69e773d939
     method: DELETE
   response:
     body: ""
@@ -4066,7 +3958,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:53 GMT
+      - Thu, 22 Feb 2024 07:48:18 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -4076,7 +3968,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2845fc0-ff4c-44e0-bb42-de21b1c6d53e
+      - 3c85704b-cbb9-4cc0-a972-6367c5e04799
     status: 204 No Content
     code: 204
     duration: ""
@@ -4087,10 +3979,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/21b394bb-412e-4659-b93a-3a6071f45bac
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/9f234a0d-c636-41ea-9191-bcbc3d8b6397
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"21b394bb-412e-4659-b93a-3a6071f45bac","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"9f234a0d-c636-41ea-9191-bcbc3d8b6397","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -4099,7 +3991,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:54 GMT
+      - Thu, 22 Feb 2024 07:48:18 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -4109,7 +4001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27a7c8b2-ad62-4c95-9489-85a04f0b5518
+      - 1c4de500-7ff5-412d-bf99-d1276f1d0db1
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/data-source-vpc-public-gateway-dhcp-reservation-static.cassette.yaml
+++ b/scaleway/testdata/data-source-vpc-public-gateway-dhcp-reservation-static.cassette.yaml
@@ -13,18 +13,18 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "562"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:26 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad6aa7fa-a76e-4826-ac7a-6595e616806c
+      - 4e4d3dc3-51e3-4d4b-b716-f88cf0ed2652
     status: 200 OK
     code: 200
     duration: ""
@@ -43,21 +43,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/450eb185-eebf-4501-ad0c-fc592e26e7eb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/21b394bb-412e-4659-b93a-3a6071f45bac
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "562"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:26 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -65,12 +65,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8286af4-a71f-45d5-90c3-18248439c495
+      - d22db6f9-e50d-483d-a5cf-f3a9e8b7178a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-sg-elated-cartwright","project":"105bdce1-64c0-48ab-899d-868455867ecf","stateful":true,"inbound_default_policy":"drop","outbound_default_policy":"accept","enable_default_security":true}'
+    body: '{"name":"tf-sg-funny-saha","project":"105bdce1-64c0-48ab-899d-868455867ecf","stateful":true,"inbound_default_policy":"drop","outbound_default_policy":"accept","enable_default_security":true}'
     form: {}
     headers:
       Content-Type:
@@ -81,20 +81,20 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups
     method: POST
   response:
-    body: '{"security_group":{"creation_date":"2023-12-05T15:01:26.494563+00:00","description":null,"enable_default_security":true,"id":"52531df8-eb41-44b1-a49f-28280d42c32b","inbound_default_policy":"drop","modification_date":"2023-12-05T15:01:26.494563+00:00","name":"tf-sg-elated-cartwright","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+    body: '{"security_group":{"creation_date":"2024-02-22T07:32:02.442517+00:00","description":null,"enable_default_security":true,"id":"d5661f2e-df14-433a-8915-27cf81fcca35","inbound_default_policy":"drop","modification_date":"2024-02-22T07:32:02.442517+00:00","name":"tf-sg-funny-saha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "585"
+      - "578"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:26 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/52531df8-eb41-44b1-a49f-28280d42c32b
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -102,44 +102,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6627c6db-88d9-4d0a-8c1c-e547b8e96fdc
+      - 0974fb5a-9e13-4952-8412-6bedddc5c234
     status: 201 Created
     code: 201
-    duration: ""
-- request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
-    method: POST
-  response:
-    body: '{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":null,"id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "358"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:01:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e4a153ec-90ad-4cc2-b1a8-55b6d4ad0e93
-    status: 200 OK
-    code: 200
     duration: ""
 - request:
     body: '{"enable_default_security":true,"inbound_default_policy":"drop","tags":[],"outbound_default_policy":"accept","stateful":true}'
@@ -150,21 +115,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/52531df8-eb41-44b1-a49f-28280d42c32b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35
     method: PATCH
   response:
-    body: '{"security_group":{"creation_date":"2023-12-05T15:01:26.494563+00:00","description":null,"enable_default_security":true,"id":"52531df8-eb41-44b1-a49f-28280d42c32b","inbound_default_policy":"drop","modification_date":"2023-12-05T15:01:26.494563+00:00","name":"tf-sg-elated-cartwright","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+    body: '{"security_group":{"creation_date":"2024-02-22T07:32:02.442517+00:00","description":null,"enable_default_security":true,"id":"d5661f2e-df14-433a-8915-27cf81fcca35","inbound_default_policy":"drop","modification_date":"2024-02-22T07:32:02.442517+00:00","name":"tf-sg-funny-saha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "585"
+      - "578"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:27 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -172,40 +137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1eb02234-209f-43df-9d30-75d0fe3dacb7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/b8119cf7-580b-4fa2-bd1a-91c71e90a6b8
-    method: GET
-  response:
-    body: '{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":null,"id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "358"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:01:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1be980a2-21b4-41f2-8d26-3081a5f6809d
+      - e5b19a1c-7b6b-4139-a7a0-869559196f57
     status: 200 OK
     code: 200
     duration: ""
@@ -218,10 +150,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/52531df8-eb41-44b1-a49f-28280d42c32b/rules
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35/rules
     method: PUT
   response:
-    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"534512f5-e348-4518-a031-7dc286c7caae","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
+    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"5da3cecd-121d-49c3-b77c-8b907329e930","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "1792"
@@ -230,9 +162,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:27 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -240,7 +172,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbf9cdb2-54a7-46da-8768-accf88bf5d2c
+      - 8245b7cf-6356-4376-9c15-241f1e9ffaba
     status: 200 OK
     code: 200
     duration: ""
@@ -251,21 +183,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/52531df8-eb41-44b1-a49f-28280d42c32b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35
     method: GET
   response:
-    body: '{"security_group":{"creation_date":"2023-12-05T15:01:26.494563+00:00","description":null,"enable_default_security":true,"id":"52531df8-eb41-44b1-a49f-28280d42c32b","inbound_default_policy":"drop","modification_date":"2023-12-05T15:01:27.130168+00:00","name":"tf-sg-elated-cartwright","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+    body: '{"security_group":{"creation_date":"2024-02-22T07:32:02.442517+00:00","description":null,"enable_default_security":true,"id":"d5661f2e-df14-433a-8915-27cf81fcca35","inbound_default_policy":"drop","modification_date":"2024-02-22T07:32:02.618685+00:00","name":"tf-sg-funny-saha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[],"state":"syncing","stateful":true,"tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "585"
+      - "578"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:27 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -273,12 +205,113 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec3196d8-8d85-4660-89e8-adb09e6538d4
+      - 06228d84-0e8a-4da2-95a0-b8ed95f13af7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","enable_smtp":false,"enable_bastion":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
+    method: POST
+  response:
+    body: '{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":null,"id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "367"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 981b0ab8-b76a-431b-a090-f7db8bcc0a27
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35/rules?page=1
+    method: GET
+  response:
+    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"5da3cecd-121d-49c3-b77c-8b907329e930","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
+    headers:
+      Content-Length:
+      - "1792"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2dfb2eff-288c-4130-a98f-f8a00b1ff21e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/9b38f399-ac05-4bf9-b402-2780dd84ffd2
+    method: GET
+  response:
+    body: '{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":null,"id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "367"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e17ed50a-c59d-489b-b1f0-ed362b82d9aa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","enable_smtp":false,"enable_bastion":false}'
     form: {}
     headers:
       Content-Type:
@@ -289,18 +322,18 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:27.369504Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:03.155432Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "940"
+      - "998"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:27 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -308,7 +341,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ddda911c-e1e7-4141-b95d-ab283738ae4f
+      - f1f377db-5a2f-4c38-be9b-f3ce5d34d96f
     status: 200 OK
     code: 200
     duration: ""
@@ -319,21 +352,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/52531df8-eb41-44b1-a49f-28280d42c32b/rules?page=1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
     method: GET
   response:
-    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"534512f5-e348-4518-a031-7dc286c7caae","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:03.155432Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1792"
+      - "998"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:27 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -341,45 +374,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cb0bdb4-5ed9-46fb-958e-fd10bc11309c
+      - 5b0db272-8182-4dd4-9db0-4eabaee990e9
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:27.369504Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "940"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:01:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ce4c7e8f-6e22-477d-84b4-782e55d8cbb0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":null,"subnets":null}'
+    body: '{"name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
@@ -390,18 +390,18 @@ interactions:
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-12-05T15:01:26.408681Z","dhcp_enabled":true,"id":"57540f72-2de8-4647-8171-9a93e39b8ee6","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-05T15:01:26.408681Z","id":"0bdf46dd-0df4-4c83-b08f-5f2718beb3bc","subnet":"172.16.56.0/22","updated_at":"2023-12-05T15:01:26.408681Z"},{"created_at":"2023-12-05T15:01:26.408681Z","id":"1a72ca7c-9c13-432f-a4ca-836d75b55148","subnet":"fd5f:519c:6d46:c40b::/64","updated_at":"2023-12-05T15:01:26.408681Z"}],"tags":[],"updated_at":"2023-12-05T15:01:26.408681Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"message":"internal error"}'
     headers:
       Content-Length:
-      - "747"
+      - "28"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:27 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -409,7 +409,42 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8519f8b-e68d-46f7-89bb-4acf5b6ad017
+      - 71fea3a1-337e-4613-af34-64711f4eae2c
+    status: 500 Internal Server Error
+    code: 500
+    duration: ""
+- request:
+    body: '{"name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2024-02-22T07:32:06.861460Z","dhcp_enabled":true,"id":"d12edf3a-6ab9-420c-87de-aabaa2480974","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.861460Z","id":"021b49c3-09e3-47a7-b703-59f414e1be2d","subnet":"172.16.44.0/22","updated_at":"2024-02-22T07:32:06.861460Z"},{"created_at":"2024-02-22T07:32:06.861460Z","id":"e3ea9c12-4847-4ca9-817a-60c201c2f7b3","subnet":"fd5f:519c:6d46:cb04::/64","updated_at":"2024-02-22T07:32:06.861460Z"}],"tags":[],"updated_at":"2024-02-22T07:32:06.861460Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "764"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:07 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 246d8b37-a9f4-43a8-9805-6699a1107db6
     status: 200 OK
     code: 200
     duration: ""
@@ -420,21 +455,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/57540f72-2de8-4647-8171-9a93e39b8ee6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d12edf3a-6ab9-420c-87de-aabaa2480974
     method: GET
   response:
-    body: '{"created_at":"2023-12-05T15:01:26.408681Z","dhcp_enabled":true,"id":"57540f72-2de8-4647-8171-9a93e39b8ee6","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-05T15:01:26.408681Z","id":"0bdf46dd-0df4-4c83-b08f-5f2718beb3bc","subnet":"172.16.56.0/22","updated_at":"2023-12-05T15:01:26.408681Z"},{"created_at":"2023-12-05T15:01:26.408681Z","id":"1a72ca7c-9c13-432f-a4ca-836d75b55148","subnet":"fd5f:519c:6d46:c40b::/64","updated_at":"2023-12-05T15:01:26.408681Z"}],"tags":[],"updated_at":"2023-12-05T15:01:26.408681Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    body: '{"created_at":"2024-02-22T07:32:06.861460Z","dhcp_enabled":true,"id":"d12edf3a-6ab9-420c-87de-aabaa2480974","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.861460Z","id":"021b49c3-09e3-47a7-b703-59f414e1be2d","subnet":"172.16.44.0/22","updated_at":"2024-02-22T07:32:06.861460Z"},{"created_at":"2024-02-22T07:32:06.861460Z","id":"e3ea9c12-4847-4ca9-817a-60c201c2f7b3","subnet":"fd5f:519c:6d46:cb04::/64","updated_at":"2024-02-22T07:32:06.861460Z"}],"tags":[],"updated_at":"2024-02-22T07:32:06.861460Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "747"
+      - "764"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:27 GMT
+      - Thu, 22 Feb 2024 07:32:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -442,7 +477,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d9d15b9-fbe2-4cde-bcb1-237bc22e6266
+      - 957b55a6-dfb6-438a-941f-8ed58884c6cc
     status: 200 OK
     code: 200
     duration: ""
@@ -456,18 +491,18 @@ interactions:
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"492d66d3-b14d-46d3-80c6-3945d5b61b21","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2f1f7a57-c508-4f72-9f7f-536b316f36e1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"5d083890-4354-47ab-b769-8b0de601eb3a","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1183"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:27 GMT
+      - Thu, 22 Feb 2024 07:32:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -475,7 +510,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59db46c4-dfd5-4a99-afc1-767c913b42da
+      - 87687213-d50c-46a4-9ea6-55f9c293318e
     status: 200 OK
     code: 200
     duration: ""
@@ -498,12 +533,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:27 GMT
+      - Thu, 22 Feb 2024 07:32:07 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -511,7 +546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c0d5707-1275-403f-8f03-f38c0cfb5126
+      - d0f26433-80a3-427e-b86d-42d561ae0a9b
       X-Total-Count:
       - "61"
     status: 200 OK
@@ -536,12 +571,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:28 GMT
+      - Thu, 22 Feb 2024 07:32:07 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -549,14 +584,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b27d5f6-09fb-4e63-a946-6e2dbb612d0c
+      - f0e8223d-b2c2-4bea-a680-57b1bb8aba63
       X-Total-Count:
       - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-elastic-payne","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","security_group":"52531df8-eb41-44b1-a49f-28280d42c32b"}'
+    body: '{"name":"tf-srv-dazzling-ptolemy","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5d083890-4354-47ab-b769-8b0de601eb3a","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","security_group":"d5661f2e-df14-433a-8915-27cf81fcca35"}'
     form: {}
     headers:
       Content-Type:
@@ -569,23 +604,23 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:01:28.272230+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:07.791550+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2643"
+      - "2667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:28 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -593,7 +628,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04b464a3-ca12-419a-a715-fa4a24cb0eb3
+      - 98f0c45e-97ce-4c91-84d1-1f51c8bbf8fe
     status: 201 Created
     code: 201
     duration: ""
@@ -604,26 +639,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:01:28.272230+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.281269Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2643"
+      - "998"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:28 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -631,7 +661,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98544836-4eda-42cb-8a6b-fe184c227bd8
+      - 619e87d4-a05b-432c-bf1e-cc3a8faa0c76
     status: 200 OK
     code: 200
     duration: ""
@@ -642,26 +672,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:01:28.272230+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.281269Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2643"
+      - "998"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:29 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -669,7 +694,116 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce71ae1f-3a7f-4f1e-86a1-f8dcb145e9d3
+      - 07690bf2-c99a-4697-9127-834016b1dade
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.281269Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "998"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6d66c5b1-042c-441d-8321-2ecf35fe8701
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:07.791550+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2667"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 576922cc-e3d3-47af-aa67-8faa413834ab
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:07.791550+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2667"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 11c87d19-3c35-46e3-9134-36dec475b63e
     status: 200 OK
     code: 200
     duration: ""
@@ -682,10 +816,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/32196297-5eb8-4800-8c3b-35f057428ec4/action","href_result":"/servers/32196297-5eb8-4800-8c3b-35f057428ec4","id":"9b536244-a19c-4303-b870-8bb5bf368c38","started_at":"2023-12-05T15:01:29.307234+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/04f78869-fd94-417e-945c-c72b0d2041d6/action","href_result":"/servers/04f78869-fd94-417e-945c-c72b0d2041d6","id":"5757a0af-3652-4ab8-8915-c04fc0df6ee6","started_at":"2024-02-22T07:32:08.779485+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -694,11 +828,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:29 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/9b536244-a19c-4303-b870-8bb5bf368c38
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/5757a0af-3652-4ab8-8915-c04fc0df6ee6
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -706,7 +840,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b351c0d-7753-4ceb-ab23-3b51f6c7ee7d
+      - 8ae94e51-b465-4b26-8a6a-a6b72c06cf13
     status: 202 Accepted
     code: 202
     duration: ""
@@ -717,27 +851,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:01:29.165378+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"starting","state_detail":"allocating
-      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:08.618896+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"starting","state_detail":"allocating
+      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2665"
+      - "2689"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:29 GMT
+      - Thu, 22 Feb 2024 07:32:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -745,111 +879,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a81fb136-b563-47b7-9cf0-b2191ee7374b
+      - 65b4b5e3-1b9b-46d2-b483-21825c6e0f2e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:28.247621Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "940"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:01:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5f432e0a-0e2d-49c1-a1d5-684a307f4235
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:28.247621Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "940"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:01:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3d8e1f27-4977-4131-888f-5348f2491129
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:28.247621Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "940"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:01:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d51b7e07-7e0c-4847-b6c7-8e2be06dc5cb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"450eb185-eebf-4501-ad0c-fc592e26e7eb"}'
+    body: '{"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"21b394bb-412e-4659-b93a-3a6071f45bac"}'
     form: {}
     headers:
       Content-Type:
@@ -860,18 +895,18 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":null,"private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"created","updated_at":"2023-12-05T15:01:33.809809Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":null,"private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"created","updated_at":"2024-02-22T07:32:11.091310Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "947"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:33 GMT
+      - Thu, 22 Feb 2024 07:32:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -879,7 +914,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f3cf365-f9eb-4227-a95d-730f58349068
+      - 60f3857f-c938-4d79-87ba-1e89c101a823
     status: 200 OK
     code: 200
     duration: ""
@@ -890,21 +925,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":null,"private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"created","updated_at":"2023-12-05T15:01:33.809809Z","zone":"fr-par-1"}],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:33.990510Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":null,"private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"created","updated_at":"2024-02-22T07:32:11.091310Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.264279Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1890"
+      - "1984"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:34 GMT
+      - Thu, 22 Feb 2024 07:32:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -912,7 +947,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f47a853b-dbd5-47e3-a28b-8b89bc166ee5
+      - 858ecbb7-8777-4ede-a77d-e582244c1baf
     status: 200 OK
     code: 200
     duration: ""
@@ -923,99 +958,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:01:29.165378+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"starting","state_detail":"allocating
-      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2665"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:01:34 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6d9c3787-b715-45c2-a5ce-c2b406d4b9f7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":null,"private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"created","updated_at":"2023-12-05T15:01:33.809809Z","zone":"fr-par-1"}],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:33.990510Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1890"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:01:39 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2bbef26e-fd6f-482e-8df0-37d8cb134fc8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:01:29.165378+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"starting","state_detail":"provisioning
-      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:08.618896+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"starting","state_detail":"allocating
+      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2773"
+      - "2689"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:40 GMT
+      - Thu, 22 Feb 2024 07:32:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1023,7 +986,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f1a54cc-f587-4a64-b356-651dfc63c3ea
+      - e472d400-be0e-4c01-ab7f-7fc9a97d64d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1034,21 +997,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:43.690528Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":null,"private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"created","updated_at":"2024-02-22T07:32:11.091310Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.264279Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1899"
+      - "1984"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:44 GMT
+      - Thu, 22 Feb 2024 07:32:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1056,7 +1019,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b4809eb-1721-4793-b07a-61438b745da6
+      - 384f77f6-d819-4752-ba48-b00cd496db85
     status: 200 OK
     code: 200
     duration: ""
@@ -1067,159 +1030,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/115662f0-5d52-4bbe-a0dd-574652ae2ae9
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "960"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:01:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - caad95eb-dd61-4cde-bd10-a1626309d4ce
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/115662f0-5d52-4bbe-a0dd-574652ae2ae9
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "960"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:01:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 473fc7ff-b9f8-4ffd-ac3b-eeaac224f4e3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:43.690528Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1899"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:01:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 98573cb5-b868-4d58-8fdc-87f4fa766cc9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/115662f0-5d52-4bbe-a0dd-574652ae2ae9
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "960"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:01:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6214196f-cae1-4f54-9f53-033dd1e568b5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:01:29.165378+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"starting","state_detail":"provisioning
-      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:08.618896+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"starting","state_detail":"provisioning
+      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2773"
+      - "2798"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:45 GMT
+      - Thu, 22 Feb 2024 07:32:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1227,7 +1058,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41192b57-fc38-4d6e-b4fe-72d1460731fe
+      - b0e3edaf-606e-4287-bd5d-119009e84350
     status: 200 OK
     code: 200
     duration: ""
@@ -1238,27 +1069,303 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"configuring","updated_at":"2024-02-22T07:32:17.121837Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.264279Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "2003"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7dde300a-f852-4917-a029-3babc68b768e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:08.618896+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"starting","state_detail":"provisioning
+      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2798"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:24 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d7da4f2f-3cb0-44e3-ba77-6d6e2756687b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1993"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 242fb9be-9c08-4fbc-a2f1-b2e24d691944
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3e197a59-1a04-46d5-8238-6b76b09ab76a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8387838e-54ed-4714-b698-ff4347dee3e6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1993"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 19b1b9ff-3a71-439a-8b7e-c9782e811c91
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 64c6ea4a-c476-49fb-9d0d-2a4ea3f6bdd4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:08.618896+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"starting","state_detail":"provisioning
+      node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2798"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:29 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c31c3cfe-1d24-4d48-8eef-4861def4c2e9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:01:49.457389+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"running","state_detail":"booting
-      kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:29.921486+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"running","state_detail":"booting
+      kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2804"
+      - "2829"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:50 GMT
+      - Thu, 22 Feb 2024 07:32:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1266,7 +1373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06a437c7-27a6-4f87-b2fb-a075049988b0
+      - 61514995-b3b0-473a-9f41-4789f9378aa8
     status: 200 OK
     code: 200
     duration: ""
@@ -1277,21 +1384,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/57540f72-2de8-4647-8171-9a93e39b8ee6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d12edf3a-6ab9-420c-87de-aabaa2480974
     method: GET
   response:
-    body: '{"created_at":"2023-12-05T15:01:26.408681Z","dhcp_enabled":true,"id":"57540f72-2de8-4647-8171-9a93e39b8ee6","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-05T15:01:26.408681Z","id":"0bdf46dd-0df4-4c83-b08f-5f2718beb3bc","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:33.422635Z"},{"created_at":"2023-12-05T15:01:26.408681Z","id":"1a72ca7c-9c13-432f-a4ca-836d75b55148","subnet":"fd5f:519c:6d46:c40b::/64","updated_at":"2023-12-05T15:01:33.425618Z"}],"tags":[],"updated_at":"2023-12-05T15:01:40.356999Z","vpc_id":"c55de21b-aadc-4275-a275-955999d7d57c"}'
+    body: '{"created_at":"2024-02-22T07:32:06.861460Z","dhcp_enabled":true,"id":"d12edf3a-6ab9-420c-87de-aabaa2480974","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.861460Z","id":"021b49c3-09e3-47a7-b703-59f414e1be2d","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:09.121448Z"},{"created_at":"2024-02-22T07:32:06.861460Z","id":"e3ea9c12-4847-4ca9-817a-60c201c2f7b3","subnet":"fd5f:519c:6d46:cb04::/64","updated_at":"2024-02-22T07:32:09.123958Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.459497Z","vpc_id":"ecc51364-65b4-4870-8b19-c6f3e7939b63"}'
     headers:
       Content-Length:
-      - "747"
+      - "764"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:50 GMT
+      - Thu, 22 Feb 2024 07:32:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1299,7 +1406,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7144a3d0-b96a-423e-a585-0ef0244245aa
+      - 0240117d-5e10-49fc-a2a8-c4c7ae13491f
     status: 200 OK
     code: 200
     duration: ""
@@ -1310,27 +1417,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:01:49.457389+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"running","state_detail":"booting
-      kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:29.921486+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"running","state_detail":"booting
+      kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2804"
+      - "2829"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:51 GMT
+      - Thu, 22 Feb 2024 07:32:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1338,12 +1445,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 473af845-39f9-4b67-856c-8ed0deafb504
+      - 32b1aca8-5fc6-4588-bc39-775e7a54adea
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6"}'
+    body: '{"private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974"}'
     form: {}
     headers:
       Content-Type:
@@ -1351,10 +1458,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:01:51.077787+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:35.320655+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1363,9 +1470,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:51 GMT
+      - Thu, 22 Feb 2024 07:32:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1373,7 +1480,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f64fb886-5ca6-4669-9ef2-c4fd17339bef
+      - a1402aae-3503-483c-afa5-30ffc58acd10
     status: 201 Created
     code: 201
     duration: ""
@@ -1384,10 +1491,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics/936b802d-34f7-4781-9018-392ab419baac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:01:51.077787+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:35.320655+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1396,9 +1503,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:51 GMT
+      - Thu, 22 Feb 2024 07:32:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1406,7 +1513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 952d815a-f05f-468b-86c9-a016cfac604a
+      - 50564247-1656-4c94-b93c-e14103e12a02
     status: 200 OK
     code: 200
     duration: ""
@@ -1417,10 +1524,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics/936b802d-34f7-4781-9018-392ab419baac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:01:53.360458+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:36.047446+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1429,9 +1536,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:01:56 GMT
+      - Thu, 22 Feb 2024 07:32:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1439,7 +1546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a01d7734-b8ee-43e3-ab3e-c957ec83d266
+      - 538626d4-fa01-4df2-bd27-7a332a53922d
     status: 200 OK
     code: 200
     duration: ""
@@ -1450,10 +1557,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics/936b802d-34f7-4781-9018-392ab419baac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:01:53.360458+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:36.047446+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1462,9 +1569,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:01 GMT
+      - Thu, 22 Feb 2024 07:32:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1472,7 +1579,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5dcbeb5-6032-4178-80ef-ef737c2691cf
+      - 8aca2882-0213-4471-8238-c6b19c599c85
     status: 200 OK
     code: 200
     duration: ""
@@ -1483,10 +1590,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics/936b802d-34f7-4781-9018-392ab419baac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:01:53.360458+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:36.047446+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1495,9 +1602,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:06 GMT
+      - Thu, 22 Feb 2024 07:32:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1505,7 +1612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cffb9d30-6f43-47c9-8211-32ce65702bf1
+      - 152805dc-1c44-4c0c-84a2-e04ac9f644b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1516,10 +1623,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics/936b802d-34f7-4781-9018-392ab419baac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:01:53.360458+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:36.047446+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1528,9 +1635,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:11 GMT
+      - Thu, 22 Feb 2024 07:32:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1538,7 +1645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50d5f2f1-a2dc-4481-88bf-4ae4f60d6506
+      - 0a1be9e0-ca2a-4638-a8c8-1acbc91566f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1549,10 +1656,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics/936b802d-34f7-4781-9018-392ab419baac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:01:53.360458+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:36.047446+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1561,9 +1668,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:17 GMT
+      - Thu, 22 Feb 2024 07:33:01 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1571,7 +1678,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a210ee3f-d979-4fb1-a0ff-2bc8bacb6527
+      - eaddf721-0fbf-4e0c-ad3c-01d8f48f7107
     status: 200 OK
     code: 200
     duration: ""
@@ -1582,10 +1689,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics/936b802d-34f7-4781-9018-392ab419baac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:01:53.360458+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:32:36.047446+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1594,9 +1701,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:22 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1604,7 +1711,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4ef2a7b-5a65-41d3-9af0-209c05da232e
+      - cbc12e50-3775-491b-a176-21ac6348a83b
     status: 200 OK
     code: 200
     duration: ""
@@ -1615,43 +1722,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics/936b802d-34f7-4781-9018-392ab419baac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:01:53.360458+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:02:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 71dd5533-9f38-4da3-9b6f-9ad0cbb79c0e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics/936b802d-34f7-4781-9018-392ab419baac
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1660,9 +1734,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:32 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1670,7 +1744,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51d1a1f5-7d15-4b22-866a-bcecf06c4081
+      - bb14ee62-b50d-425d-9069-a5d1db911c5f
     status: 200 OK
     code: 200
     duration: ""
@@ -1681,10 +1755,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics/936b802d-34f7-4781-9018-392ab419baac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1693,9 +1767,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:32 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1703,7 +1777,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 439f5839-a940-42f8-a8c7-679c9f40efee
+      - 4924ba6e-81c1-4ee2-9ec4-e72090b1f3a6
     status: 200 OK
     code: 200
     duration: ""
@@ -1714,26 +1788,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:01:49.457389+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:29.921486+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3157"
+      - "3182"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:32 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1741,7 +1815,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7e3b802-617a-4884-a244-b8fc4ef99dbf
+      - e28d6f2f-b26e-4da3-944f-f6b68666da56
     status: 200 OK
     code: 200
     duration: ""
@@ -1752,7 +1826,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1764,9 +1838,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:32 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1774,7 +1848,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16e96c49-a6fb-430a-a380-e894a4d69f1e
+      - ac744a39-7950-46cd-8f30-d68a84770547
     status: 200 OK
     code: 200
     duration: ""
@@ -1785,10 +1859,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1797,12 +1871,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:32 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Link:
-      - </servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics?page=1&per_page=50&>;
+      - </servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1810,7 +1884,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7bd1025-3846-431f-b326-fac528923b0d
+      - 6572e4c2-70b5-4da3-9219-87028de97da9
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1823,21 +1897,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/115662f0-5d52-4bbe-a0dd-574652ae2ae9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "960"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:32 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1845,12 +1919,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4ad5513-c9b2-4538-bfa5-4650d0229e57
+      - 556b87d1-860e-4603-ba02-1b3f8d3b1b9c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_network_id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","mac_address":"02:00:00:15:2e:49","ip_address":"192.168.1.4"}'
+    body: '{"gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","mac_address":"02:00:00:18:8b:b6","ip_address":"192.168.1.4"}'
     form: {}
     headers:
       Content-Type:
@@ -1861,18 +1935,18 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries
     method: POST
   response:
-    body: '{"created_at":"2023-12-05T15:01:53.253763Z","gateway_network_id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","hostname":"tf-srv-elastic-payne","id":"3573fcad-2510-45c0-a5c9-331a06002f76","ip_address":"192.168.1.4","mac_address":"02:00:00:15:2e:49","type":"reservation","updated_at":"2023-12-05T15:02:33.252810Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:35.955612Z","gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","hostname":"tf-srv-dazzling-ptolemy","id":"ad334fa3-3aea-4693-8d0a-e69774d137af","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:b6","type":"reservation","updated_at":"2024-02-22T07:33:11.916983Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "325"
+      - "336"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:33 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1880,7 +1954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1715c612-a922-44a0-8414-946d922f54ff
+      - 9dc65a1f-662e-4a28-87bc-80d7a14de288
     status: 200 OK
     code: 200
     duration: ""
@@ -1891,21 +1965,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/115662f0-5d52-4bbe-a0dd-574652ae2ae9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "960"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:33 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1913,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 037b7329-642e-45ea-875d-e0099295c4b7
+      - 752d5a20-bfc0-4b6c-b647-2dfc3d994bac
     status: 200 OK
     code: 200
     duration: ""
@@ -1924,21 +1998,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3573fcad-2510-45c0-a5c9-331a06002f76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ad334fa3-3aea-4693-8d0a-e69774d137af
     method: GET
   response:
-    body: '{"created_at":"2023-12-05T15:01:53.253763Z","gateway_network_id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","hostname":"tf-srv-elastic-payne","id":"3573fcad-2510-45c0-a5c9-331a06002f76","ip_address":"192.168.1.4","mac_address":"02:00:00:15:2e:49","type":"reservation","updated_at":"2023-12-05T15:02:33.252810Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:35.955612Z","gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","hostname":"tf-srv-dazzling-ptolemy","id":"ad334fa3-3aea-4693-8d0a-e69774d137af","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:b6","type":"reservation","updated_at":"2024-02-22T07:33:11.916983Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "325"
+      - "336"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:33 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1946,7 +2020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e9ba291-173a-4600-9db8-d759d8b92c29
+      - ba35102d-4a6d-4c41-b224-0fd6412231e2
     status: 200 OK
     code: 200
     duration: ""
@@ -1957,21 +2031,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3573fcad-2510-45c0-a5c9-331a06002f76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
     method: GET
   response:
-    body: '{"created_at":"2023-12-05T15:01:53.253763Z","gateway_network_id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","hostname":"tf-srv-elastic-payne","id":"3573fcad-2510-45c0-a5c9-331a06002f76","ip_address":"192.168.1.4","mac_address":"02:00:00:15:2e:49","type":"reservation","updated_at":"2023-12-05T15:02:33.252810Z","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "325"
+      - "1993"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:33 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1979,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac7ede22-81e4-4acd-9cf8-63ad9b00bc62
+      - 38131b0c-b379-4895-816b-8d30eef11344
     status: 200 OK
     code: 200
     duration: ""
@@ -1990,21 +2064,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:43.690528Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1899"
+      - "1993"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:33 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2012,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1b2af94-469b-4ac8-9f3e-01ff0b4026d2
+      - 54d4c4bc-7d31-48e0-983e-3b91fcb6e551
     status: 200 OK
     code: 200
     duration: ""
@@ -2023,21 +2097,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ad334fa3-3aea-4693-8d0a-e69774d137af
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:43.690528Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:35.955612Z","gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","hostname":"tf-srv-dazzling-ptolemy","id":"ad334fa3-3aea-4693-8d0a-e69774d137af","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:b6","type":"reservation","updated_at":"2024-02-22T07:33:11.916983Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1899"
+      - "336"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:33 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2045,12 +2119,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba93b9a1-fc71-45eb-8c19-185194b5d45b
+      - cdcd588e-e5b8-43b6-b56e-9a5c7fbef455
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","public_port":2222,"private_ip":"192.168.1.4","private_port":22,"protocol":"tcp"}'
+    body: '{"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","public_port":2222,"private_ip":"192.168.1.4","private_port":22,"protocol":"tcp"}'
     form: {}
     headers:
       Content-Type:
@@ -2061,18 +2135,18 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules
     method: POST
   response:
-    body: '{"created_at":"2023-12-05T15:02:33.876516Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"0140e6b3-f427-441d-9679-94e3e7c633b0","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2023-12-05T15:02:33.876516Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:33:12.183475Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"b8afff61-1474-4dfb-aa85-fbb715bd254e","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2024-02-22T07:33:12.183475Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "282"
+      - "290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:33 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2080,7 +2154,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf3152f0-f082-4689-ad2f-29a2f7b0aaa5
+      - 87cc8094-5ffd-4469-842c-2a967c27dc9f
     status: 200 OK
     code: 200
     duration: ""
@@ -2091,21 +2165,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:43.690528Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1899"
+      - "1993"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:33 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2113,7 +2187,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7d0565b-490b-4c0b-ad54-ea165036e928
+      - a6db2063-ca5b-4e9b-8648-89cb2b3a39b6
     status: 200 OK
     code: 200
     duration: ""
@@ -2124,21 +2198,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/0140e6b3-f427-441d-9679-94e3e7c633b0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/b8afff61-1474-4dfb-aa85-fbb715bd254e
     method: GET
   response:
-    body: '{"created_at":"2023-12-05T15:02:33.876516Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"0140e6b3-f427-441d-9679-94e3e7c633b0","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2023-12-05T15:02:33.876516Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:33:12.183475Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"b8afff61-1474-4dfb-aa85-fbb715bd254e","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2024-02-22T07:33:12.183475Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "282"
+      - "290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:33 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2146,7 +2220,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c8b89140-1788-4e94-918b-3cbb5cf21899
+      - 7a5cf30b-d132-4bf8-b10d-9b592f79517d
     status: 200 OK
     code: 200
     duration: ""
@@ -2157,21 +2231,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3573fcad-2510-45c0-a5c9-331a06002f76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ad334fa3-3aea-4693-8d0a-e69774d137af
     method: GET
   response:
-    body: '{"created_at":"2023-12-05T15:01:53.253763Z","gateway_network_id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","hostname":"tf-srv-elastic-payne","id":"3573fcad-2510-45c0-a5c9-331a06002f76","ip_address":"192.168.1.4","mac_address":"02:00:00:15:2e:49","type":"reservation","updated_at":"2023-12-05T15:02:33.252810Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:35.955612Z","gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","hostname":"tf-srv-dazzling-ptolemy","id":"ad334fa3-3aea-4693-8d0a-e69774d137af","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:b6","type":"reservation","updated_at":"2024-02-22T07:33:11.916983Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "325"
+      - "336"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:36 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2179,7 +2253,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfaf2c8d-9f24-4473-9d46-ffba5b16dde3
+      - dca552c6-fc5a-4518-abd4-03c22e7a1de0
     status: 200 OK
     code: 200
     duration: ""
@@ -2190,21 +2264,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/450eb185-eebf-4501-ad0c-fc592e26e7eb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/21b394bb-412e-4659-b93a-3a6071f45bac
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "562"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:37 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2212,7 +2286,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d365d0ad-6a60-44ea-8c28-7c9aaf6d348a
+      - c7cfef53-d0b2-4055-becc-9e3bf8680393
     status: 200 OK
     code: 200
     duration: ""
@@ -2223,21 +2297,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/b8119cf7-580b-4fa2-bd1a-91c71e90a6b8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/9b38f399-ac05-4bf9-b402-2780dd84ffd2
     method: GET
   response:
-    body: '{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"}'
+    body: '{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "392"
+      - "401"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:37 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2245,7 +2319,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2d36821-4c69-45b2-ac70-b97715f55248
+      - d4930b5f-83b8-465c-9778-e80055cb003b
     status: 200 OK
     code: 200
     duration: ""
@@ -2256,21 +2330,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/57540f72-2de8-4647-8171-9a93e39b8ee6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d12edf3a-6ab9-420c-87de-aabaa2480974
     method: GET
   response:
-    body: '{"created_at":"2023-12-05T15:01:26.408681Z","dhcp_enabled":true,"id":"57540f72-2de8-4647-8171-9a93e39b8ee6","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2023-12-05T15:01:26.408681Z","id":"0bdf46dd-0df4-4c83-b08f-5f2718beb3bc","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:33.422635Z"},{"created_at":"2023-12-05T15:01:26.408681Z","id":"1a72ca7c-9c13-432f-a4ca-836d75b55148","subnet":"fd5f:519c:6d46:c40b::/64","updated_at":"2023-12-05T15:01:33.425618Z"}],"tags":[],"updated_at":"2023-12-05T15:01:40.356999Z","vpc_id":"c55de21b-aadc-4275-a275-955999d7d57c"}'
+    body: '{"created_at":"2024-02-22T07:32:06.861460Z","dhcp_enabled":true,"id":"d12edf3a-6ab9-420c-87de-aabaa2480974","name":"TestAccScalewayDataSourceVPCPublicGatewayDHCPReservation_Static","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.861460Z","id":"021b49c3-09e3-47a7-b703-59f414e1be2d","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:09.121448Z"},{"created_at":"2024-02-22T07:32:06.861460Z","id":"e3ea9c12-4847-4ca9-817a-60c201c2f7b3","subnet":"fd5f:519c:6d46:cb04::/64","updated_at":"2024-02-22T07:32:09.123958Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.459497Z","vpc_id":"ecc51364-65b4-4870-8b19-c6f3e7939b63"}'
     headers:
       Content-Length:
-      - "747"
+      - "764"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:37 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2278,7 +2352,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c9b78fdc-f246-4951-8f58-c06f08620ad0
+      - 81eb77f0-c25d-4d45-a2c8-83501f8d9091
     status: 200 OK
     code: 200
     duration: ""
@@ -2289,21 +2363,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:43.690528Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1899"
+      - "1993"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:37 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2311,7 +2385,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04fc000a-bacd-4a9e-a8e9-749cd32ff6f4
+      - 35e816a9-1cf5-45f4-8d3c-1ee4f7cca7ac
     status: 200 OK
     code: 200
     duration: ""
@@ -2322,21 +2396,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/52531df8-eb41-44b1-a49f-28280d42c32b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35
     method: GET
   response:
-    body: '{"security_group":{"creation_date":"2023-12-05T15:01:26.494563+00:00","description":null,"enable_default_security":true,"id":"52531df8-eb41-44b1-a49f-28280d42c32b","inbound_default_policy":"drop","modification_date":"2023-12-05T15:01:27.427952+00:00","name":"tf-sg-elated-cartwright","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"}],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
+    body: '{"security_group":{"creation_date":"2024-02-22T07:32:02.442517+00:00","description":null,"enable_default_security":true,"id":"d5661f2e-df14-433a-8915-27cf81fcca35","inbound_default_policy":"drop","modification_date":"2024-02-22T07:32:02.974944+00:00","name":"tf-sg-funny-saha","organization":"105bdce1-64c0-48ab-899d-868455867ecf","organization_default":false,"outbound_default_policy":"accept","project":"105bdce1-64c0-48ab-899d-868455867ecf","project_default":false,"servers":[{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"}],"state":"available","stateful":true,"tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "665"
+      - "661"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:37 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2344,7 +2418,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91f572b9-0d6a-4b28-86a2-cebd42d21eb2
+      - 35d090d1-945c-42cd-9694-cb7cd66ec351
     status: 200 OK
     code: 200
     duration: ""
@@ -2355,10 +2429,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/52531df8-eb41-44b1-a49f-28280d42c32b/rules?page=1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
     method: GET
   response:
-    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"534512f5-e348-4518-a031-7dc286c7caae","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:13 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ed049304-3020-4d94-b28a-baa4abe01ca2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1993"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:13 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a77859d1-16b8-464c-97d6-605ab24ef30a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35/rules?page=1
+    method: GET
+  response:
+    body: '{"rules":[{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"58909be7-d17c-4ac8-9eb3-23d5fc58abc5","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"25680235-108b-4bbc-8e25-114303d950bd","ip_range":"0.0.0.0/0","position":2,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"4a31b633-118e-4900-bd52-facf1085fc8d","ip_range":"0.0.0.0/0","position":3,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":25,"dest_port_to":null,"direction":"outbound","editable":false,"id":"e7dd28e8-3747-4c7c-9a4f-35ae3f0ae2cd","ip_range":"::/0","position":4,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":465,"dest_port_to":null,"direction":"outbound","editable":false,"id":"f37d9e7c-8ed7-4e0f-baff-7f5e7ede0baf","ip_range":"::/0","position":5,"protocol":"TCP","zone":"fr-par-1"},{"action":"drop","dest_ip_range":null,"dest_port_from":587,"dest_port_to":null,"direction":"outbound","editable":false,"id":"68054851-54e3-46c9-9cd7-83219751248b","ip_range":"::/0","position":6,"protocol":"TCP","zone":"fr-par-1"},{"action":"accept","dest_ip_range":null,"dest_port_from":22,"dest_port_to":null,"direction":"inbound","editable":true,"id":"5da3cecd-121d-49c3-b77c-8b907329e930","ip_range":"0.0.0.0/0","position":1,"protocol":"TCP","zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "1792"
@@ -2367,9 +2507,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:37 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2377,7 +2517,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b51a29d4-6e0d-48c2-acab-193db844edbd
+      - 53efb2c1-b1b9-44de-bd28-040f05371f10
     status: 200 OK
     code: 200
     duration: ""
@@ -2388,21 +2528,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/115662f0-5d52-4bbe-a0dd-574652ae2ae9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "960"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:37 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2410,7 +2550,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf3dc143-0d0c-4562-8837-3a2efd1ab63d
+      - 67149e5b-32e9-4d19-848c-1e7efe73110c
     status: 200 OK
     code: 200
     duration: ""
@@ -2421,92 +2561,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:43.690528Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1899"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:02:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7b1825a5-026e-4099-a9cd-57dc89af0087
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/115662f0-5d52-4bbe-a0dd-574652ae2ae9
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "960"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:02:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1c710d00-00ce-4cb4-ae22-3416347d1d82
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:01:49.457389+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:29.921486+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3157"
+      - "3182"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:38 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2514,7 +2588,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d31867d4-3a5e-4136-9c14-ad4503534d69
+      - e6d303b3-9755-4196-9858-7f7398244ed6
     status: 200 OK
     code: 200
     duration: ""
@@ -2525,7 +2599,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2537,9 +2611,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:38 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2547,7 +2621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca6f8478-069f-4bc5-8961-58f30a3c10aa
+      - d8134542-8d87-4729-baf7-fde75e5cb840
     status: 200 OK
     code: 200
     duration: ""
@@ -2558,10 +2632,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2570,12 +2644,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:38 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Link:
-      - </servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics?page=1&per_page=50&>;
+      - </servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2583,7 +2657,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b162d98-3444-4cb7-84d5-8b2a7c1e757f
+      - 9200688f-8046-4b9e-a9c8-649491115256
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2596,21 +2670,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3573fcad-2510-45c0-a5c9-331a06002f76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ad334fa3-3aea-4693-8d0a-e69774d137af
     method: GET
   response:
-    body: '{"created_at":"2023-12-05T15:01:53.253763Z","gateway_network_id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","hostname":"tf-srv-elastic-payne","id":"3573fcad-2510-45c0-a5c9-331a06002f76","ip_address":"192.168.1.4","mac_address":"02:00:00:15:2e:49","type":"reservation","updated_at":"2023-12-05T15:02:33.252810Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:35.955612Z","gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","hostname":"tf-srv-dazzling-ptolemy","id":"ad334fa3-3aea-4693-8d0a-e69774d137af","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:b6","type":"reservation","updated_at":"2024-02-22T07:33:11.916983Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "325"
+      - "336"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:38 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2618,7 +2692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6435fff7-a642-4ac3-9815-8236ad1c44dd
+      - 4ac4ec85-dc84-47c5-abca-14accea23121
     status: 200 OK
     code: 200
     duration: ""
@@ -2629,21 +2703,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/0140e6b3-f427-441d-9679-94e3e7c633b0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/b8afff61-1474-4dfb-aa85-fbb715bd254e
     method: GET
   response:
-    body: '{"created_at":"2023-12-05T15:02:33.876516Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"0140e6b3-f427-441d-9679-94e3e7c633b0","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2023-12-05T15:02:33.876516Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:33:12.183475Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"b8afff61-1474-4dfb-aa85-fbb715bd254e","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2024-02-22T07:33:12.183475Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "282"
+      - "290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:38 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2651,7 +2725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5097e8eb-c5f0-413f-b02e-2ff18cf71d4a
+      - dd727556-2ae8-4129-aaca-e8d8eaf79717
     status: 200 OK
     code: 200
     duration: ""
@@ -2662,21 +2736,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3573fcad-2510-45c0-a5c9-331a06002f76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ad334fa3-3aea-4693-8d0a-e69774d137af
     method: GET
   response:
-    body: '{"created_at":"2023-12-05T15:01:53.253763Z","gateway_network_id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","hostname":"tf-srv-elastic-payne","id":"3573fcad-2510-45c0-a5c9-331a06002f76","ip_address":"192.168.1.4","mac_address":"02:00:00:15:2e:49","type":"reservation","updated_at":"2023-12-05T15:02:33.252810Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:35.955612Z","gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","hostname":"tf-srv-dazzling-ptolemy","id":"ad334fa3-3aea-4693-8d0a-e69774d137af","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:b6","type":"reservation","updated_at":"2024-02-22T07:33:11.916983Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "325"
+      - "336"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:38 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2684,7 +2758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b172cc5-514d-4fa1-84cd-4f7366b3f695
+      - 6030a0eb-b2e6-4fb9-850b-0704e708ebe8
     status: 200 OK
     code: 200
     duration: ""
@@ -2695,21 +2769,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3573fcad-2510-45c0-a5c9-331a06002f76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ad334fa3-3aea-4693-8d0a-e69774d137af
     method: GET
   response:
-    body: '{"created_at":"2023-12-05T15:01:53.253763Z","gateway_network_id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","hostname":"tf-srv-elastic-payne","id":"3573fcad-2510-45c0-a5c9-331a06002f76","ip_address":"192.168.1.4","mac_address":"02:00:00:15:2e:49","type":"reservation","updated_at":"2023-12-05T15:02:33.252810Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:35.955612Z","gateway_network_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","hostname":"tf-srv-dazzling-ptolemy","id":"ad334fa3-3aea-4693-8d0a-e69774d137af","ip_address":"192.168.1.4","mac_address":"02:00:00:18:8b:b6","type":"reservation","updated_at":"2024-02-22T07:33:11.916983Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "325"
+      - "336"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:40 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2717,7 +2791,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34fff604-78f3-40c1-9790-279bc1006a6e
+      - 5435b321-93fc-4a73-90c5-2c1f1057c140
     status: 200 OK
     code: 200
     duration: ""
@@ -2728,21 +2802,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/0140e6b3-f427-441d-9679-94e3e7c633b0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/b8afff61-1474-4dfb-aa85-fbb715bd254e
     method: GET
   response:
-    body: '{"created_at":"2023-12-05T15:02:33.876516Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"0140e6b3-f427-441d-9679-94e3e7c633b0","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2023-12-05T15:02:33.876516Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:33:12.183475Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"b8afff61-1474-4dfb-aa85-fbb715bd254e","private_ip":"192.168.1.4","private_port":22,"protocol":"tcp","public_port":2222,"updated_at":"2024-02-22T07:33:12.183475Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "282"
+      - "290"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:44 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2750,7 +2824,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 775a750d-7398-47eb-a715-bbc7e5337171
+      - 8203abb6-9a2e-4656-87d6-18eb52b5a996
     status: 200 OK
     code: 200
     duration: ""
@@ -2761,21 +2835,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:43.690528Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1899"
+      - "1993"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:44 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2783,7 +2857,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a1d9755-7c4a-4db8-a929-f941feebd0b6
+      - a25405d7-2096-4659-bb14-2756d3905421
     status: 200 OK
     code: 200
     duration: ""
@@ -2794,7 +2868,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/0140e6b3-f427-441d-9679-94e3e7c633b0
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/b8afff61-1474-4dfb-aa85-fbb715bd254e
     method: DELETE
   response:
     body: ""
@@ -2804,9 +2878,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:44 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2814,7 +2888,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa1a1b7d-4079-4c9c-87e3-95b48013fd32
+      - 5a980fdb-8e15-4d97-890c-27e67168a101
     status: 204 No Content
     code: 204
     duration: ""
@@ -2825,21 +2899,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:43.690528Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1899"
+      - "1993"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:44 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2847,7 +2921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8f47af8-9769-4ea0-9705-69346e9fc412
+      - fa7de0c2-84aa-455b-8d6a-76fc410f795a
     status: 200 OK
     code: 200
     duration: ""
@@ -2858,21 +2932,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/115662f0-5d52-4bbe-a0dd-574652ae2ae9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "960"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:44 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2880,7 +2954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4aabf57c-2bac-4d63-adb3-c6e54412f3bb
+      - 651e8689-0ec8-42af-873b-632fdc966b8c
     status: 200 OK
     code: 200
     duration: ""
@@ -2891,7 +2965,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/3573fcad-2510-45c0-a5c9-331a06002f76
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ad334fa3-3aea-4693-8d0a-e69774d137af
     method: DELETE
   response:
     body: ""
@@ -2901,9 +2975,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:44 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2911,7 +2985,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f27a11a-bd06-4dd1-8a77-13a43c16108e
+      - 9b279025-01a6-4d7f-88e8-90705b5d2070
     status: 204 No Content
     code: 204
     duration: ""
@@ -2922,21 +2996,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/115662f0-5d52-4bbe-a0dd-574652ae2ae9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "960"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:44 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2944,7 +3018,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c9b5cef-edbe-4fcd-b0f8-555c5fecdde6
+      - 3be9915f-0095-405d-9441-d75647ca7685
     status: 200 OK
     code: 200
     duration: ""
@@ -2955,21 +3029,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/115662f0-5d52-4bbe-a0dd-574652ae2ae9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"ready","updated_at":"2023-12-05T15:01:43.579454Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"ready","updated_at":"2024-02-22T07:32:23.278853Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "960"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:44 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2977,7 +3051,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f43d8715-49b9-49b5-8521-f16b3f3dc88d
+      - 3db8fd6f-4e4d-4aec-8188-019b58569164
     status: 200 OK
     code: 200
     duration: ""
@@ -2988,26 +3062,57 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d?cleanup_dhcp=true
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3a9b551f-0525-472a-86e8-be6bf97e6797
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:01:49.457389+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:32:29.921486+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3157"
+      - "3182"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:44 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3015,7 +3120,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1a18f49-a036-4be1-bcdc-b4bc7dbb5a26
+      - 684804ba-6e04-46a2-a5a5-e92150435f85
     status: 200 OK
     code: 200
     duration: ""
@@ -3026,52 +3131,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/115662f0-5d52-4bbe-a0dd-574652ae2ae9?cleanup_dhcp=true
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:02:44 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1c3409cd-4ced-49db-be5f-7110f11ebeb0
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/115662f0-5d52-4bbe-a0dd-574652ae2ae9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-12-05T15:01:33.809809Z","dhcp":{"address":"192.168.1.1","created_at":"2023-12-05T15:01:26.400Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-12-05T15:01:26.400Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","ipam_config":null,"mac_address":"02:00:00:15:2E:48","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","status":"detaching","updated_at":"2023-12-05T15:02:44.516983Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.091310Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.383937Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"21b394bb-412e-4659-b93a-3a6071f45bac","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.383937Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","ipam_config":null,"mac_address":"02:00:00:18:8B:AE","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","status":"detaching","updated_at":"2024-02-22T07:33:14.715069Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "964"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:44 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3079,7 +3153,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c5dd97b-4ba1-49c9-99f3-9788fb9bb00a
+      - d72b6364-d73e-4756-b690-a59ad265b986
     status: 200 OK
     code: 200
     duration: ""
@@ -3092,10 +3166,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/32196297-5eb8-4800-8c3b-35f057428ec4/action","href_result":"/servers/32196297-5eb8-4800-8c3b-35f057428ec4","id":"a268b080-caa1-403e-9b9f-5e9d6a4810b7","started_at":"2023-12-05T15:02:44.679411+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/04f78869-fd94-417e-945c-c72b0d2041d6/action","href_result":"/servers/04f78869-fd94-417e-945c-c72b0d2041d6","id":"340155f9-82df-4651-b864-f79f07c4c7c7","started_at":"2024-02-22T07:33:14.960131+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -3104,11 +3178,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:44 GMT
+      - Thu, 22 Feb 2024 07:33:15 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/a268b080-caa1-403e-9b9f-5e9d6a4810b7
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/340155f9-82df-4651-b864-f79f07c4c7c7
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3116,7 +3190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cad6945-7ad6-452d-8c2b-2c795a8fbfc8
+      - 404c41da-7d9d-4d7d-a463-0ea4024ac994
     status: 202 Accepted
     code: 202
     duration: ""
@@ -3127,27 +3201,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:02:44.527318+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"stopping","state_detail":"launching
-      poweroff task","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:14.822923+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3140"
+      - "3150"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:45 GMT
+      - Thu, 22 Feb 2024 07:33:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3155,7 +3228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f8e9acb-0eec-4eae-a898-50864173c1b6
+      - a02e7645-9a2e-4837-89db-49f850f0fa9f
     status: 200 OK
     code: 200
     duration: ""
@@ -3166,10 +3239,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/115662f0-5d52-4bbe-a0dd-574652ae2ae9
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/706b1aa7-f9cb-4e98-8841-624d61a0422d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"115662f0-5d52-4bbe-a0dd-574652ae2ae9","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"706b1aa7-f9cb-4e98-8841-624d61a0422d","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3178,9 +3251,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:49 GMT
+      - Thu, 22 Feb 2024 07:33:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3188,7 +3261,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02af9859-b898-4772-9b83-48d497f529fe
+      - 5de488c7-679d-46f7-8bde-9385d3fafba0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3199,21 +3272,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:43.690528Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "939"
+      - "997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:49 GMT
+      - Thu, 22 Feb 2024 07:33:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3221,7 +3294,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4886efe-5dc1-4b21-953d-4fa8f13e8b0d
+      - adebcdf1-75fd-4048-83ba-9cbda112b228
     status: 200 OK
     code: 200
     duration: ""
@@ -3232,10 +3305,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/450eb185-eebf-4501-ad0c-fc592e26e7eb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/21b394bb-412e-4659-b93a-3a6071f45bac
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"21b394bb-412e-4659-b93a-3a6071f45bac","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3244,9 +3317,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:49 GMT
+      - Thu, 22 Feb 2024 07:33:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3254,7 +3327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbfe07fd-6a09-4e9e-9708-25734180afb9
+      - f150638d-f9b3-4702-ae31-bb64f1ee7e6c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3265,21 +3338,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-12-05T15:01:27.369504Z","gateway_networks":[],"id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","ip":{"address":"51.15.233.234","created_at":"2023-12-05T15:01:27.036136Z","gateway_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","id":"b8119cf7-580b-4fa2-bd1a-91c71e90a6b8","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"234-233-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-12-05T15:01:27.036136Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-12-05T15:01:43.690528Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.367520Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "939"
+      - "997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:49 GMT
+      - Thu, 22 Feb 2024 07:33:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3287,7 +3360,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4628628b-39a3-42ee-86c0-95a5001e470c
+      - 8d2792c6-7ed4-4858-a44e-8764a96d91c4
     status: 200 OK
     code: 200
     duration: ""
@@ -3298,7 +3371,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -3308,9 +3381,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:49 GMT
+      - Thu, 22 Feb 2024 07:33:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3318,7 +3391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48cd690b-7242-4db3-9142-d2bd1e3c7138
+      - 82f6aa6e-d840-4418-b12b-674593bf4111
     status: 204 No Content
     code: 204
     duration: ""
@@ -3329,10 +3402,81 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"9d0fddf4-d921-4e8c-8ab4-b3aba6cd65ba","type":"not_found"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.155432Z","gateway_networks":[],"id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","ip":{"address":"51.15.247.228","created_at":"2024-02-22T07:32:02.969270Z","gateway_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","id":"9b38f399-ac05-4bf9-b402-2780dd84ffd2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"228-247-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:02.969270Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"deleting","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:33:19.902961Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "998"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:19 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 74299060-d001-471e-8be9-72e65c824742
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:14.822923+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3150"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ae68a12a-bec8-442c-b53f-25ed9fc6806b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/78e844d5-0d0d-49a4-bd4b-0a025776a95d
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"78e844d5-0d0d-49a4-bd4b-0a025776a95d","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3341,9 +3485,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:49 GMT
+      - Thu, 22 Feb 2024 07:33:24 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3351,7 +3495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc8e3394-f863-4be8-a083-579e5a16a7bc
+      - aa70a752-7d47-4e27-8157-2ef086a045c5
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3362,7 +3506,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/b8119cf7-580b-4fa2-bd1a-91c71e90a6b8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/9b38f399-ac05-4bf9-b402-2780dd84ffd2
     method: DELETE
   response:
     body: ""
@@ -3372,9 +3516,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:50 GMT
+      - Thu, 22 Feb 2024 07:33:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3382,7 +3526,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3ac8dcc-4250-4a91-b55f-800482b282d9
+      - 611c0051-c51b-4f56-a6f3-6adcac2ed88e
     status: 204 No Content
     code: 204
     duration: ""
@@ -3393,27 +3537,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:02:44.527318+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"stopping","state_detail":"launching
-      poweroff task","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:14.822923+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3140"
+      - "3150"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:50 GMT
+      - Thu, 22 Feb 2024 07:33:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3421,7 +3564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7ece367-80fd-4c6c-81bf-abf089634b93
+      - 81bad793-204a-40e9-86f2-5230a77fa237
     status: 200 OK
     code: 200
     duration: ""
@@ -3432,26 +3575,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:02:44.527318+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:14.822923+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3125"
+      - "3150"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:02:55 GMT
+      - Thu, 22 Feb 2024 07:33:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3459,7 +3602,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7688e9e-59c3-4479-aa0b-026aa3d865b5
+      - e94161e7-c54a-46dc-b3e2-82701a57ee84
     status: 200 OK
     code: 200
     duration: ""
@@ -3470,26 +3613,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:02:44.527318+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:14.822923+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3125"
+      - "3150"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:03:00 GMT
+      - Thu, 22 Feb 2024 07:33:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3497,7 +3640,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 210c2cbb-2df0-46b0-95a2-0fb194077e04
+      - 51706298-810d-4871-acad-b0a188b2f83c
     status: 200 OK
     code: 200
     duration: ""
@@ -3508,26 +3651,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:02:44.527318+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:14.822923+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3125"
+      - "3150"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:03:06 GMT
+      - Thu, 22 Feb 2024 07:33:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3535,7 +3678,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9230c5e2-3237-4d51-9f58-e86c80478bce
+      - eaf0615d-ec69-4682-a88e-11b4c58e9852
     status: 200 OK
     code: 200
     duration: ""
@@ -3546,26 +3689,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:02:44.527318+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"802","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:14.822923+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.110.37","private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3125"
+      - "3150"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:03:11 GMT
+      - Thu, 22 Feb 2024 07:33:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3573,7 +3716,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6344da02-60dd-48d6-9b4d-f40aefff4fe0
+      - a0ae817d-5e0c-4012-bd04-f68f92dd2bd9
     status: 200 OK
     code: 200
     duration: ""
@@ -3584,140 +3727,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:02:44.527318+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3125"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:03:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 652e7021-86a5-4ce2-98c7-01153db5a1af
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:02:44.527318+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3125"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:03:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 845ac339-3cab-414f-932f-82d998e53162
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"1302","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:02:44.527318+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.64.130.7","private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3125"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 15:03:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cf2d3890-1f7e-4775-8168-72d211a9353e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:03:30.986974+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:46.854446+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3004"
+      - "3028"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:03:32 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3725,7 +3754,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04064147-2c54-46cc-934b-cd47bfbdb499
+      - 0e973a6b-0123-4e1e-b2ef-47226a4493bc
     status: 200 OK
     code: 200
     duration: ""
@@ -3736,10 +3765,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3748,12 +3777,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:03:32 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Link:
-      - </servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics?page=1&per_page=50&>;
+      - </servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3761,7 +3790,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82fef17e-537d-4d83-98d4-cd0736ac3671
+      - e61dbb65-7814-4970-a4a5-a000929ddd9c
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3774,10 +3803,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics/936b802d-34f7-4781-9018-392ab419baac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-12-05T15:01:51.077787+00:00","id":"936b802d-34f7-4781-9018-392ab419baac","mac_address":"02:00:00:15:2e:49","modification_date":"2023-12-05T15:02:27.277146+00:00","private_network_id":"57540f72-2de8-4647-8171-9a93e39b8ee6","server_id":"32196297-5eb8-4800-8c3b-35f057428ec4","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:35.320655+00:00","id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","mac_address":"02:00:00:18:8b:b6","modification_date":"2024-02-22T07:33:06.558345+00:00","private_network_id":"d12edf3a-6ab9-420c-87de-aabaa2480974","server_id":"04f78869-fd94-417e-945c-c72b0d2041d6","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -3786,9 +3815,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:03:32 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3796,7 +3825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e777c24-1710-4a52-8d3e-6a76cddba700
+      - fae1bc94-c901-436c-aa4c-b75e629edfdb
     status: 200 OK
     code: 200
     duration: ""
@@ -3807,7 +3836,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics/936b802d-34f7-4781-9018-392ab419baac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
     method: DELETE
   response:
     body: ""
@@ -3815,9 +3844,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 15:03:32 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3825,7 +3854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 553e7d95-2343-4fe8-9d46-3a713e00ddcc
+      - db749f9a-c8e4-4f49-a4d4-c8ff93cc7a61
     status: 204 No Content
     code: 204
     duration: ""
@@ -3836,10 +3865,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4/private_nics/936b802d-34f7-4781-9018-392ab419baac
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6/private_nics/c7f80ab3-3130-4caa-b16d-5be81aecfb79
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"936b802d-34f7-4781-9018-392ab419baac","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"c7f80ab3-3130-4caa-b16d-5be81aecfb79","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -3848,9 +3877,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:03:32 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3858,7 +3887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8f10f8d-aa0c-4371-acc0-c89cbcf68d3a
+      - 40a104df-09a2-4371-8cc4-245951d04918
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3869,26 +3898,26 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T15:01:28.272230+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-elastic-payne","id":"32196297-5eb8-4800-8c3b-35f057428ec4","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:d5:a9","maintenances":[],"modification_date":"2023-12-05T15:03:30.986974+00:00","name":"tf-srv-elastic-payne","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"52531df8-eb41-44b1-a49f-28280d42c32b","name":"tf-sg-elated-cartwright"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T15:01:28.272230+00:00","export_uri":null,"id":"12f49b1b-9318-4f80-8665-d804078e40d5","modification_date":"2023-12-05T15:01:28.272230+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"32196297-5eb8-4800-8c3b-35f057428ec4","name":"tf-srv-elastic-payne"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.791550+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-dazzling-ptolemy","id":"04f78869-fd94-417e-945c-c72b0d2041d6","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b9","maintenances":[],"modification_date":"2024-02-22T07:33:46.854446+00:00","name":"tf-srv-dazzling-ptolemy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"d5661f2e-df14-433a-8915-27cf81fcca35","name":"tf-sg-funny-saha"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.791550+00:00","export_uri":null,"id":"f2e13700-9110-4c65-a8cf-c5287a2a51a8","modification_date":"2024-02-22T07:32:07.791550+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"04f78869-fd94-417e-945c-c72b0d2041d6","name":"tf-srv-dazzling-ptolemy"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2643"
+      - "2667"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:03:32 GMT
+      - Thu, 22 Feb 2024 07:33:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3896,7 +3925,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34db9e64-f6db-4075-a4a2-7c4349ec3ba5
+      - 3c40845c-65ae-4a6b-b80c-bf409949dce2
     status: 200 OK
     code: 200
     duration: ""
@@ -3907,7 +3936,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: DELETE
   response:
     body: ""
@@ -3915,9 +3944,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 15:03:33 GMT
+      - Thu, 22 Feb 2024 07:33:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3925,7 +3954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 924d4f84-f3e3-4f0d-93a5-fe901ab93ddb
+      - e1403c33-388e-4793-814f-e8b134ea1373
     status: 204 No Content
     code: 204
     duration: ""
@@ -3936,10 +3965,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/32196297-5eb8-4800-8c3b-35f057428ec4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/04f78869-fd94-417e-945c-c72b0d2041d6
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"32196297-5eb8-4800-8c3b-35f057428ec4","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"04f78869-fd94-417e-945c-c72b0d2041d6","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -3948,9 +3977,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:03:33 GMT
+      - Thu, 22 Feb 2024 07:33:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3958,7 +3987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d49cd16-b930-4292-96dd-9ef59604f4e7
+      - 9a46b474-00d4-4c1c-8a88-37e3d5436637
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3969,7 +3998,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/12f49b1b-9318-4f80-8665-d804078e40d5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f2e13700-9110-4c65-a8cf-c5287a2a51a8
     method: DELETE
   response:
     body: ""
@@ -3977,9 +4006,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 15:03:33 GMT
+      - Thu, 22 Feb 2024 07:33:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3987,7 +4016,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6186214-0ce0-47a4-bcb4-bce7c75ad6d7
+      - 66e029d8-3d13-48da-b92c-e346fb294132
     status: 204 No Content
     code: 204
     duration: ""
@@ -3998,7 +4027,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/52531df8-eb41-44b1-a49f-28280d42c32b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/security_groups/d5661f2e-df14-433a-8915-27cf81fcca35
     method: DELETE
   response:
     body: ""
@@ -4006,9 +4035,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 15:03:33 GMT
+      - Thu, 22 Feb 2024 07:33:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4016,7 +4045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 230f85b1-5ea3-4d8c-8ec3-521b0ed911e1
+      - 1aaa89b9-601e-4c10-a3c8-30b7504af954
     status: 204 No Content
     code: 204
     duration: ""
@@ -4027,7 +4056,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/57540f72-2de8-4647-8171-9a93e39b8ee6
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/d12edf3a-6ab9-420c-87de-aabaa2480974
     method: DELETE
   response:
     body: ""
@@ -4037,9 +4066,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:03:34 GMT
+      - Thu, 22 Feb 2024 07:33:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4047,7 +4076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7230f445-d216-412d-b3f2-6f0c3f69868a
+      - e2845fc0-ff4c-44e0-bb42-de21b1c6d53e
     status: 204 No Content
     code: 204
     duration: ""
@@ -4058,10 +4087,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/450eb185-eebf-4501-ad0c-fc592e26e7eb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/21b394bb-412e-4659-b93a-3a6071f45bac
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"450eb185-eebf-4501-ad0c-fc592e26e7eb","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"21b394bb-412e-4659-b93a-3a6071f45bac","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -4070,9 +4099,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 15:03:34 GMT
+      - Thu, 22 Feb 2024 07:33:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4080,7 +4109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 218dd904-00c2-4f5b-ad4f-4bcc16086171
+      - 27a7c8b2-ad62-4c95-9489-85a04f0b5518
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-image-server-with-block-volume.cassette.yaml
+++ b/scaleway/testdata/instance-image-server-with-block-volume.cassette.yaml
@@ -11,18 +11,18 @@ interactions:
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"492d66d3-b14d-46d3-80c6-3945d5b61b21","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2f1f7a57-c508-4f72-9f7f-536b316f36e1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"5d083890-4354-47ab-b769-8b0de601eb3a","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1183"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:17 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -30,7 +30,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc6efe3d-e6b0-40a1-a610-57ea8f9c40da
+      - b452d41c-a06a-448b-bd6a-e26f8c5f8afa
     status: 200 OK
     code: 200
     duration: ""
@@ -53,12 +53,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:17 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -66,7 +66,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5f519b2-a021-4260-8761-1aa6fcf8fa15
+      - eab04ee6-bdfc-4fc5-9f6d-f26f36519e90
       X-Total-Count:
       - "61"
     status: 200 OK
@@ -91,12 +91,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:17 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -104,14 +104,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c89ef748-aa73-4a4b-890c-e7d7718ca51a
+      - 87fabc99-2f31-47e2-abba-c822c24ed05c
       X-Total-Count:
       - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-vol-keen-hypatia","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"b_ssd","size":21000000000}'
+    body: '{"name":"tf-vol-relaxed-mendeleev","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"b_ssd","size":21000000000}'
     form: {}
     headers:
       Content-Type:
@@ -122,20 +122,20 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:57:17.949755+00:00","export_uri":null,"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","modification_date":"2023-12-05T10:57:17.949755+00:00","name":"tf-vol-keen-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.446019+00:00","export_uri":null,"id":"269fbc40-435e-442e-9795-272bc7053559","modification_date":"2024-02-22T07:32:02.446019+00:00","name":"tf-vol-relaxed-mendeleev","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "441"
+      - "446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:18 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/26746f64-05c8-4f2a-8ac9-ea12eda1aa37
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/269fbc40-435e-442e-9795-272bc7053559
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -143,7 +143,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91191af0-f613-4396-bec8-f404d75a6a7a
+      - d9bf8593-4377-4408-9699-f8e2b62c4cb0
     status: 201 Created
     code: 201
     duration: ""
@@ -154,21 +154,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/26746f64-05c8-4f2a-8ac9-ea12eda1aa37
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/269fbc40-435e-442e-9795-272bc7053559
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:57:17.949755+00:00","export_uri":null,"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","modification_date":"2023-12-05T10:57:17.949755+00:00","name":"tf-vol-keen-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.446019+00:00","export_uri":null,"id":"269fbc40-435e-442e-9795-272bc7053559","modification_date":"2024-02-22T07:32:02.446019+00:00","name":"tf-vol-relaxed-mendeleev","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "441"
+      - "446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:18 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -176,7 +176,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aabce369-6fcb-4096-9f43-1e605f02e185
+      - e2fedda2-21c6-483e-a432-467cc89392d3
     status: 200 OK
     code: 200
     duration: ""
@@ -187,21 +187,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/26746f64-05c8-4f2a-8ac9-ea12eda1aa37
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/269fbc40-435e-442e-9795-272bc7053559
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:57:17.949755+00:00","export_uri":null,"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","modification_date":"2023-12-05T10:57:17.949755+00:00","name":"tf-vol-keen-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.446019+00:00","export_uri":null,"id":"269fbc40-435e-442e-9795-272bc7053559","modification_date":"2024-02-22T07:32:02.446019+00:00","name":"tf-vol-relaxed-mendeleev","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "441"
+      - "446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:18 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -209,12 +209,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1ef9b51-60c3-42bb-b915-587025b304d2
+      - 7910db8d-6a3b-4d3d-a087-9b0849571633
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-ecstatic-einstein","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-srv-kind-fermat","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5d083890-4354-47ab-b769-8b0de601eb3a","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -227,24 +227,24 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:18.215409+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:57:18.215409+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:02.679296+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:02.679296+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2654"
+      - "2658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:18 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -252,12 +252,51 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb55c787-105c-4793-b662-5dd73fb3c0b1
+      - 5f3b1e00-94c3-4b07-bdcf-16fbba80e32c
     status: 201 Created
     code: 201
     duration: ""
 - request:
-    body: '{"name":"tf-snap-clever-swanson","volume_id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:02.679296+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:02.679296+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2658"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - abd7ebed-d30c-42f8-aa46-c52ed497091e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-snap-strange-goldberg","volume_id":"269fbc40-435e-442e-9795-272bc7053559","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -268,18 +307,18 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:18.391366+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_1a72d901-2461-4e37-91a2-4af1cc6febed","href_from":"/snapshots","href_result":"snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed","id":"8abab62c-5f39-4ae4-be70-f81d9795a114","started_at":"2023-12-05T10:57:18.599254+00:00","status":"pending","terminated_at":null}}'
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:02.802694+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_92d0a032-2112-495d-8d8f-82346d8b6aea","href_from":"/snapshots","href_result":"snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea","id":"5b4a9a03-1e78-45e7-ab51-8d81d240461f","started_at":"2024-02-22T07:32:03.079370+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
-      - "836"
+      - "843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:18 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -287,7 +326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 305afad7-acf7-4ea1-a243-2a5dce45b132
+      - 0d98ec9f-c9d2-4b37-aec5-31d632a4f9c1
     status: 201 Created
     code: 201
     duration: ""
@@ -298,27 +337,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:18.215409+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:57:18.215409+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:02.679296+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:02.679296+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2654"
+      - "2658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:18 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -326,7 +365,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b759a282-9349-4d60-9106-173c767e6f1f
+      - 430b25f5-84e5-4d85-a87c-932d26d316ab
     status: 200 OK
     code: 200
     duration: ""
@@ -337,21 +376,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:18.391366+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:02.802694+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "530"
+      - "537"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:19 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -359,46 +398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 168fb926-8219-417e-a2a3-b71e6fbe5baa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:18.215409+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:57:18.215409+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2654"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:57:19 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - faa6c57c-fe02-44da-b049-18ae3a4e15cb
+      - 3b87b5f0-62e1-4237-9c26-d6a7296637de
     status: 200 OK
     code: 200
     duration: ""
@@ -411,10 +411,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/action","href_result":"/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850","id":"5d5b6ecc-acc9-4f89-9161-a7d397d71ae8","started_at":"2023-12-05T10:57:19.649723+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/action","href_result":"/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5","id":"38610964-3c56-489f-af3c-ffcef26c93d9","started_at":"2024-02-22T07:32:03.614013+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -423,11 +423,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:19 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/5d5b6ecc-acc9-4f89-9161-a7d397d71ae8
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/38610964-3c56-489f-af3c-ffcef26c93d9
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -435,7 +435,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5de2d176-6fd7-40b5-942d-4ae594b54978
+      - 782961c1-4cf2-46cf-a336-6b35d544ad09
     status: 202 Accepted
     code: 202
     duration: ""
@@ -446,27 +446,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:19.107857+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:57:18.215409+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:03.390497+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:02.679296+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2676"
+      - "2680"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:20 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -474,7 +474,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c79dd3b-b364-4aec-917a-ab4953b16448
+      - 2f21c506-a27f-4a9a-adfb-4bb6137025d5
     status: 200 OK
     code: 200
     duration: ""
@@ -485,21 +485,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:18.391366+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:02.802694+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "530"
+      - "537"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:24 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -507,7 +507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 352fe509-7d10-49b2-9896-ead512747eaf
+      - 9558c330-e57b-41df-923b-ea362b84d073
     status: 200 OK
     code: 200
     duration: ""
@@ -518,132 +518,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:19.107857+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:57:18.215409+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2786"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:57:25 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 116dd61f-c113-43af-a490-31f00fd84b38
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "527"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:57:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bace0f28-3c1c-40d7-a03b-969bfe460a97
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "527"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:57:29 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 05bc5580-c0ee-451e-a62a-9a8c6c70d04b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:19.107857+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:57:18.215409+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:03.390497+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:02.679296+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2786"
+      - "2788"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:30 GMT
+      - Thu, 22 Feb 2024 07:32:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -651,7 +546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09349046-8208-4ad7-b83c-c38ca8cfefcf
+      - c9698b12-7ab2-4315-a4b1-c015abe2df72
     status: 200 OK
     code: 200
     duration: ""
@@ -662,27 +557,171 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "534"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:13 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d1107f54-4921-47d8-bc19-277c7e645f41
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "534"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:13 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 22f5fd03-f9b0-4063-b336-95b9c60c0745
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:03.390497+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:02.679296+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2788"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bf95181e-903d-4fc3-bbed-6364265b6b9b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:03.390497+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:02.679296+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2788"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:19 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6f7817e6-429a-4372-8dc6-f788404f0dff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:35.309269+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:57:18.215409+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:23.411647+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:02.679296+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2817"
+      - "2819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:35 GMT
+      - Thu, 22 Feb 2024 07:32:24 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -690,7 +729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 739199ea-8c66-42a8-9a91-450ecf697552
+      - 3b761700-3899-4901-abfe-a9136d1555dd
     status: 200 OK
     code: 200
     duration: ""
@@ -701,27 +740,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:35.309269+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:57:18.215409+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:23.411647+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:02.679296+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2817"
+      - "2819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:35 GMT
+      - Thu, 22 Feb 2024 07:32:24 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -729,7 +768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95f7e0d2-52ca-442f-8376-deea0a9a4b0f
+      - 59938ee4-7a30-4d82-9f16-530a97f58640
     status: 200 OK
     code: 200
     duration: ""
@@ -740,7 +779,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -752,9 +791,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:36 GMT
+      - Thu, 22 Feb 2024 07:32:24 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -762,7 +801,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0c35957-cb89-4347-a575-1c8d4e2c560d
+      - 756e4270-509d-482f-91cf-10cb8f5a6ffb
     status: 200 OK
     code: 200
     duration: ""
@@ -773,7 +812,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -785,12 +824,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:36 GMT
+      - Thu, 22 Feb 2024 07:32:24 GMT
       Link:
-      - </servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/private_nics?page=0&per_page=50&>;
+      - </servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -798,7 +837,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 166a08d7-1cb9-40fd-b977-1359d3b289f4
+      - 63b0d905-2220-459a-aaab-5a1f79f64f02
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -811,21 +850,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/26746f64-05c8-4f2a-8ac9-ea12eda1aa37
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/269fbc40-435e-442e-9795-272bc7053559
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:57:17.949755+00:00","export_uri":null,"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-vol-keen-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.446019+00:00","export_uri":null,"id":"269fbc40-435e-442e-9795-272bc7053559","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-vol-relaxed-mendeleev","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "441"
+      - "446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:36 GMT
+      - Thu, 22 Feb 2024 07:32:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -833,7 +872,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 27d6e7a8-a0f7-4495-be5b-af8a9568ca76
+      - 091209cb-d1e1-4965-83ee-2cadb39317cc
     status: 200 OK
     code: 200
     duration: ""
@@ -844,132 +883,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:35.309269+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:57:18.215409+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2817"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:57:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9d17a52a-295d-4bfd-b1e7-b2dd33db9722
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "527"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:57:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eb703d5a-1890-4a13-b296-ce480bf7f576
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/26746f64-05c8-4f2a-8ac9-ea12eda1aa37
-    method: GET
-  response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:57:17.949755+00:00","export_uri":null,"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-vol-keen-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "441"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:57:37 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c75d859f-9478-44e3-b873-6b9097fc4e4e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:35.309269+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:57:18.215409+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:23.411647+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:02.679296+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2817"
+      - "2819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:38 GMT
+      - Thu, 22 Feb 2024 07:32:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -977,7 +911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07f25c7d-b678-4b8e-9bf3-b79b79b0de85
+      - 3c980b66-124f-4a5a-9076-5baad0629b7f
     status: 200 OK
     code: 200
     duration: ""
@@ -988,21 +922,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "527"
+      - "534"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:38 GMT
+      - Thu, 22 Feb 2024 07:32:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1010,7 +944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1424210d-61c2-4448-84f7-1d43f1177354
+      - 25e8f11c-c6b3-4299-8662-aa59e51dbfde
     status: 200 OK
     code: 200
     duration: ""
@@ -1021,7 +955,112 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/269fbc40-435e-442e-9795-272bc7053559
+    method: GET
+  response:
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.446019+00:00","export_uri":null,"id":"269fbc40-435e-442e-9795-272bc7053559","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-vol-relaxed-mendeleev","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "446"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:25 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4b919703-e7f9-4d15-bdab-bd0cce38758f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "534"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:25 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 92571256-67d9-48f9-b1af-02a74801e6cd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:23.411647+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:02.679296+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2819"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:25 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ca336e47-b58c-45e1-bcc4-43b4e7ad18ee
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1033,9 +1072,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:38 GMT
+      - Thu, 22 Feb 2024 07:32:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1043,7 +1082,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d25cf759-279f-4c94-8787-f8df3a42de5e
+      - 209db0cc-6cf5-4826-8951-89a8f9ece4d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1054,7 +1093,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1066,12 +1105,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:38 GMT
+      - Thu, 22 Feb 2024 07:32:26 GMT
       Link:
-      - </servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/private_nics?page=0&per_page=50&>;
+      - </servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1079,7 +1118,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc58429a-83c4-41d8-9ed1-81392497420a
+      - a2217fa5-2497-46b2-bf35-3d9b93b31871
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1092,21 +1131,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/26746f64-05c8-4f2a-8ac9-ea12eda1aa37
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/269fbc40-435e-442e-9795-272bc7053559
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:57:17.949755+00:00","export_uri":null,"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-vol-keen-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.446019+00:00","export_uri":null,"id":"269fbc40-435e-442e-9795-272bc7053559","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-vol-relaxed-mendeleev","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "441"
+      - "446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:40 GMT
+      - Thu, 22 Feb 2024 07:32:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1114,7 +1153,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d327a030-a00e-4771-8bc3-613313023274
+      - 957a4f00-fdcf-4b6c-96cd-63717dc297ba
     status: 200 OK
     code: 200
     duration: ""
@@ -1125,27 +1164,60 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "534"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6e130e96-06a9-46d7-abf5-10b6d97733e4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:35.309269+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:57:18.215409+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:23.411647+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:02.679296+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2817"
+      - "2819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:40 GMT
+      - Thu, 22 Feb 2024 07:32:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1153,7 +1225,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68937c77-2172-473a-8095-51b9d636301b
+      - 299510c3-8a71-405e-b871-8cf30ffafd4b
     status: 200 OK
     code: 200
     duration: ""
@@ -1164,40 +1236,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "527"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:57:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d99588a8-7e4d-4738-85d7-3a582a5f5922
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1209,9 +1248,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:40 GMT
+      - Thu, 22 Feb 2024 07:32:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1219,7 +1258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 518f1e61-f605-4721-bbbf-25b1f9076058
+      - 7d575623-3d20-4952-9dd1-739e8e863901
     status: 200 OK
     code: 200
     duration: ""
@@ -1230,7 +1269,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1242,12 +1281,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:40 GMT
+      - Thu, 22 Feb 2024 07:32:26 GMT
       Link:
-      - </servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/private_nics?page=0&per_page=50&>;
+      - </servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1255,14 +1294,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1470d388-5d5b-45fb-b01c-627e1e2b2941
+      - 12494ab4-c456-4526-b57a-1f29e033bedc
       X-Total-Count:
       - "0"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-snap-compassionate-panini","volume_id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-snap-priceless-banach","volume_id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -1273,19 +1312,19 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot":{"base_volume":{"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:42.913586+00:00","error_details":null,"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","modification_date":"2023-12-05T10:57:42.913586+00:00","name":"tf-snap-compassionate-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_542d3ff6-3c1c-4016-a659-f36df015caa0","href_from":"/snapshots","href_result":"snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0","id":"d4750cca-cfa5-42d5-8f53-dd5dc679bc46","started_at":"2023-12-05T10:57:43.205082+00:00","status":"pending","terminated_at":null}}'
+    body: '{"snapshot":{"base_volume":{"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:27.606769+00:00","error_details":null,"id":"675d3789-bd48-40dc-9848-70779022b8cc","modification_date":"2024-02-22T07:32:27.606769+00:00","name":"tf-snap-priceless-banach","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_675d3789-bd48-40dc-9848-70779022b8cc","href_from":"/snapshots","href_result":"snapshots/675d3789-bd48-40dc-9848-70779022b8cc","id":"81e13945-8187-4a2b-b6d7-a2bc63fbe85c","started_at":"2024-02-22T07:32:27.943896+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
-      - "847"
+      - "843"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:43 GMT
+      - Thu, 22 Feb 2024 07:32:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1293,7 +1332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 817a49c1-64cc-4b4c-96ff-dda28319fe50
+      - 67aa8782-c244-4b0e-ac75-c5b33133d633
     status: 201 Created
     code: 201
     duration: ""
@@ -1304,22 +1343,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:42.913586+00:00","error_details":null,"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","modification_date":"2023-12-05T10:57:42.913586+00:00","name":"tf-snap-compassionate-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:27.606769+00:00","error_details":null,"id":"675d3789-bd48-40dc-9848-70779022b8cc","modification_date":"2024-02-22T07:32:27.606769+00:00","name":"tf-snap-priceless-banach","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "541"
+      - "537"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:43 GMT
+      - Thu, 22 Feb 2024 07:32:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1327,7 +1366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29eb345b-a345-4195-abab-bfc3c439355e
+      - 55c9d0cf-4e73-481f-a03a-db04932d6277
     status: 200 OK
     code: 200
     duration: ""
@@ -1338,22 +1377,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:42.913586+00:00","error_details":null,"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","modification_date":"2023-12-05T10:57:42.913586+00:00","name":"tf-snap-compassionate-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:27.606769+00:00","error_details":null,"id":"675d3789-bd48-40dc-9848-70779022b8cc","modification_date":"2024-02-22T07:32:27.606769+00:00","name":"tf-snap-priceless-banach","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "541"
+      - "537"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:48 GMT
+      - Thu, 22 Feb 2024 07:32:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1361,7 +1400,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - caaf9fac-a799-48e3-80b8-6e6040ee0917
+      - 5d41968b-7f14-4eca-9699-b49d9ea5ed38
     status: 200 OK
     code: 200
     duration: ""
@@ -1372,22 +1411,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:42.913586+00:00","error_details":null,"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","modification_date":"2023-12-05T10:57:42.913586+00:00","name":"tf-snap-compassionate-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:27.606769+00:00","error_details":null,"id":"675d3789-bd48-40dc-9848-70779022b8cc","modification_date":"2024-02-22T07:32:27.606769+00:00","name":"tf-snap-priceless-banach","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "541"
+      - "537"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:53 GMT
+      - Thu, 22 Feb 2024 07:32:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1395,7 +1434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67070b8a-e680-435c-81c0-28caca2d458e
+      - d58b7737-4535-4d04-b140-74367207ecbf
     status: 200 OK
     code: 200
     duration: ""
@@ -1406,22 +1445,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:42.913586+00:00","error_details":null,"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","modification_date":"2023-12-05T10:57:42.913586+00:00","name":"tf-snap-compassionate-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:27.606769+00:00","error_details":null,"id":"675d3789-bd48-40dc-9848-70779022b8cc","modification_date":"2024-02-22T07:32:27.606769+00:00","name":"tf-snap-priceless-banach","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "541"
+      - "537"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:58 GMT
+      - Thu, 22 Feb 2024 07:32:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1429,7 +1468,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9324102-1f09-435f-ab71-c72b32723c9e
+      - 6f263231-dde0-48af-9db7-11e636c15fe0
     status: 200 OK
     code: 200
     duration: ""
@@ -1440,22 +1479,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:42.913586+00:00","error_details":null,"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"tf-snap-compassionate-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:27.606769+00:00","error_details":null,"id":"675d3789-bd48-40dc-9848-70779022b8cc","modification_date":"2024-02-22T07:32:27.606769+00:00","name":"tf-snap-priceless-banach","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "538"
+      - "537"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:03 GMT
+      - Thu, 22 Feb 2024 07:32:48 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1463,7 +1502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0945a373-f9ae-4189-ab26-51e6f29446dd
+      - 31345bbd-86c3-4a21-85d0-642bf6c53dea
     status: 200 OK
     code: 200
     duration: ""
@@ -1474,22 +1513,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:42.913586+00:00","error_details":null,"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"tf-snap-compassionate-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:27.606769+00:00","error_details":null,"id":"675d3789-bd48-40dc-9848-70779022b8cc","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"tf-snap-priceless-banach","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "538"
+      - "534"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:04 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1497,7 +1536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed31bfa3-a61d-4db8-a53c-1f0063bd44b9
+      - afc34182-93be-406d-994e-532ee90f57c7
     status: 200 OK
     code: 200
     duration: ""
@@ -1508,21 +1547,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:27.606769+00:00","error_details":null,"id":"675d3789-bd48-40dc-9848-70779022b8cc","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"tf-snap-priceless-banach","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "527"
+      - "534"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:04 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1530,12 +1570,45 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6091132-ab6b-4af3-a4c9-16f88398ae4f
+      - 1e8b477d-a2fd-449b-9bdc-db50770c2f5a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-image-elastic-mccarthy","root_volume":"542d3ff6-3c1c-4016-a659-f36df015caa0","arch":"x86_64","extra_volumes":{"1":{"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","name":"tf-vol-keen-hypatia","size":21000000000,"volume_type":"b_ssd"}},"project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "534"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 74d560b2-dab1-497f-a895-d3c9116be112
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-image-bold-burnell","root_volume":"675d3789-bd48-40dc-9848-70779022b8cc","arch":"x86_64","extra_volumes":{"1":{"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","name":"tf-vol-relaxed-mendeleev","size":21000000000,"volume_type":"b_ssd"}},"project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false}'
     form: {}
     headers:
       Content-Type:
@@ -1546,20 +1619,20 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
     method: POST
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:04.438491+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","name":"tf-snap-clever-swanson","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","modification_date":"2023-12-05T10:58:04.438491+00:00","name":"tf-image-elastic-mccarthy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","name":"tf-snap-compassionate-panini","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:53.870827+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","name":"tf-snap-strange-goldberg","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"099d7f0d-fe30-4845-9481-2253982b3972","modification_date":"2024-02-22T07:32:53.870827+00:00","name":"tf-image-bold-burnell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"675d3789-bd48-40dc-9848-70779022b8cc","name":"tf-snap-priceless-banach","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "748"
+      - "742"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:04 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1567,7 +1640,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5599a4b-c7ac-4879-9a21-f5fb767c786c
+      - b51035fd-68f7-4d33-88d1-359284aa047e
     status: 201 Created
     code: 201
     duration: ""
@@ -1578,21 +1651,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:04.438491+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","name":"tf-snap-clever-swanson","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","modification_date":"2023-12-05T10:58:04.438491+00:00","name":"tf-image-elastic-mccarthy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","name":"tf-snap-compassionate-panini","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:53.870827+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","name":"tf-snap-strange-goldberg","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"099d7f0d-fe30-4845-9481-2253982b3972","modification_date":"2024-02-22T07:32:53.870827+00:00","name":"tf-image-bold-burnell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"675d3789-bd48-40dc-9848-70779022b8cc","name":"tf-snap-priceless-banach","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "748"
+      - "742"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:04 GMT
+      - Thu, 22 Feb 2024 07:32:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1600,7 +1673,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2d08b3c-1994-4d8f-b639-fe573d056eb9
+      - 54e2669c-4c0b-4b84-86aa-ea2f31955a45
     status: 200 OK
     code: 200
     duration: ""
@@ -1611,21 +1684,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:04.438491+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","name":"tf-snap-clever-swanson","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","modification_date":"2023-12-05T10:58:04.438491+00:00","name":"tf-image-elastic-mccarthy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","name":"tf-snap-compassionate-panini","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:53.870827+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","name":"tf-snap-strange-goldberg","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"099d7f0d-fe30-4845-9481-2253982b3972","modification_date":"2024-02-22T07:32:53.870827+00:00","name":"tf-image-bold-burnell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"675d3789-bd48-40dc-9848-70779022b8cc","name":"tf-snap-priceless-banach","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "748"
+      - "742"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:04 GMT
+      - Thu, 22 Feb 2024 07:32:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1633,7 +1706,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 112def2d-beae-4bd8-9c0d-549a7406f2a7
+      - 49821fc4-6a61-4428-b43c-37b2385f9d6f
     status: 200 OK
     code: 200
     duration: ""
@@ -1644,21 +1717,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/26746f64-05c8-4f2a-8ac9-ea12eda1aa37
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/269fbc40-435e-442e-9795-272bc7053559
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:57:17.949755+00:00","export_uri":null,"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-vol-keen-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.446019+00:00","export_uri":null,"id":"269fbc40-435e-442e-9795-272bc7053559","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-vol-relaxed-mendeleev","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "441"
+      - "446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:04 GMT
+      - Thu, 22 Feb 2024 07:32:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1666,7 +1739,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbda3a20-89c2-4a87-9d3d-9f9d7f9f046d
+      - 0c2245f7-38f7-4f0c-8fcc-8531a70b7daa
     status: 200 OK
     code: 200
     duration: ""
@@ -1677,232 +1750,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:35.309269+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2809"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 290b3562-6c74-4ebf-8109-6f1d350c8061
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "527"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d99d9414-bee1-4310-b742-89e3e40a33c6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:42.913586+00:00","error_details":null,"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"tf-snap-compassionate-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "538"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cf464ae7-cd84-48be-96c5-4744fcb14369
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
-    method: GET
-  response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:04.438491+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","name":"tf-snap-clever-swanson","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","modification_date":"2023-12-05T10:58:04.438491+00:00","name":"tf-image-elastic-mccarthy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","name":"tf-snap-compassionate-panini","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "748"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ebd0c58e-37b2-46b4-a726-70b16413bc7c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/26746f64-05c8-4f2a-8ac9-ea12eda1aa37
-    method: GET
-  response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:57:17.949755+00:00","export_uri":null,"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-vol-keen-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "441"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5816044f-a609-4765-80ef-212b64357e00
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "527"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 767a53b7-0027-41d0-a004-7043984dc359
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:35.309269+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:23.411647+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2809"
+      - "2811"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:07 GMT
+      - Thu, 22 Feb 2024 07:32:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1910,7 +1778,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b6e25f1-048c-40bf-9794-c931e025c90f
+      - 541d4488-8d63-4ccf-9662-32b9dbf6ac73
     status: 200 OK
     code: 200
     duration: ""
@@ -1921,7 +1789,212 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "534"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:54 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d9b5d2ae-4516-44c8-8579-0407b7b6ce29
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:27.606769+00:00","error_details":null,"id":"675d3789-bd48-40dc-9848-70779022b8cc","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"tf-snap-priceless-banach","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "534"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:54 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6d70b148-9e68-4ba2-ab76-ac59a0b70ba4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
+    method: GET
+  response:
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:53.870827+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","name":"tf-snap-strange-goldberg","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"099d7f0d-fe30-4845-9481-2253982b3972","modification_date":"2024-02-22T07:32:53.870827+00:00","name":"tf-image-bold-burnell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"675d3789-bd48-40dc-9848-70779022b8cc","name":"tf-snap-priceless-banach","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "742"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:54 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7b11bb26-75d6-4570-b77d-f0631b01c69d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/269fbc40-435e-442e-9795-272bc7053559
+    method: GET
+  response:
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.446019+00:00","export_uri":null,"id":"269fbc40-435e-442e-9795-272bc7053559","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-vol-relaxed-mendeleev","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "446"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:55 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a0514720-e764-4e4b-bad6-83b94e7e12e9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "534"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:55 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fbe8f080-46de-4cf4-9c7f-dbd3f5c375ac
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:23.411647+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2811"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:55 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fb41a680-2e1a-4447-badf-499295db08f5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1933,9 +2006,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:07 GMT
+      - Thu, 22 Feb 2024 07:32:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1943,7 +2016,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ac4fcdb-983d-4421-a409-22585ad325a7
+      - 6fb9dde7-6351-4120-99d6-3061a7ef3645
     status: 200 OK
     code: 200
     duration: ""
@@ -1954,7 +2027,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1966,12 +2039,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:07 GMT
+      - Thu, 22 Feb 2024 07:32:55 GMT
       Link:
-      - </servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/private_nics?page=0&per_page=50&>;
+      - </servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1979,7 +2052,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e035825-dae2-436e-80f0-48f30b9c3fbc
+      - 013d4446-d0ed-45d1-a0d6-4c0ec01974f6
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1992,22 +2065,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:42.913586+00:00","error_details":null,"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"tf-snap-compassionate-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:27.606769+00:00","error_details":null,"id":"675d3789-bd48-40dc-9848-70779022b8cc","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"tf-snap-priceless-banach","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "538"
+      - "534"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:07 GMT
+      - Thu, 22 Feb 2024 07:32:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2015,7 +2088,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9dedd51-3ffe-43f3-8743-9e3095dd310a
+      - ada63c72-d4d8-4ed8-865d-d06f91b1ba3f
     status: 200 OK
     code: 200
     duration: ""
@@ -2026,21 +2099,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:04.438491+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","name":"tf-snap-clever-swanson","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","modification_date":"2023-12-05T10:58:04.438491+00:00","name":"tf-image-elastic-mccarthy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","name":"tf-snap-compassionate-panini","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:53.870827+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","name":"tf-snap-strange-goldberg","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"099d7f0d-fe30-4845-9481-2253982b3972","modification_date":"2024-02-22T07:32:53.870827+00:00","name":"tf-image-bold-burnell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"675d3789-bd48-40dc-9848-70779022b8cc","name":"tf-snap-priceless-banach","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "748"
+      - "742"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:08 GMT
+      - Thu, 22 Feb 2024 07:32:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2048,7 +2121,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7243d906-1c34-49e3-981c-2713b0646781
+      - 5f2cb610-3108-4b8e-a1aa-104120b00142
     status: 200 OK
     code: 200
     duration: ""
@@ -2059,21 +2132,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/26746f64-05c8-4f2a-8ac9-ea12eda1aa37
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/269fbc40-435e-442e-9795-272bc7053559
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:57:17.949755+00:00","export_uri":null,"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-vol-keen-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.446019+00:00","export_uri":null,"id":"269fbc40-435e-442e-9795-272bc7053559","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-vol-relaxed-mendeleev","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "441"
+      - "446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:10 GMT
+      - Thu, 22 Feb 2024 07:32:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2081,7 +2154,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 123cbeb3-03a8-4690-9843-260aabde9f86
+      - 4a0a93b7-89d3-456f-a7db-3d13b26435ec
     status: 200 OK
     code: 200
     duration: ""
@@ -2092,21 +2165,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "527"
+      - "534"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:10 GMT
+      - Thu, 22 Feb 2024 07:32:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2114,7 +2187,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5b93376-f7ab-44da-b919-f65f21f61024
+      - c3d7e726-b689-439d-99e2-b79e476eb671
     status: 200 OK
     code: 200
     duration: ""
@@ -2125,27 +2198,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:35.309269+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:23.411647+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2809"
+      - "2811"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:10 GMT
+      - Thu, 22 Feb 2024 07:32:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2153,7 +2226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffb086a3-214f-423a-ac29-d46174d266c3
+      - 13fec4a6-eab1-41e0-895f-e0315636b653
     status: 200 OK
     code: 200
     duration: ""
@@ -2164,7 +2237,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2176,9 +2249,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:10 GMT
+      - Thu, 22 Feb 2024 07:32:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2186,7 +2259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8ab4aa1-c240-46f9-9014-1bdc04a70343
+      - 366e705e-56c8-4c7b-a3e5-783b7cf42b83
     status: 200 OK
     code: 200
     duration: ""
@@ -2197,7 +2270,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -2209,12 +2282,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:10 GMT
+      - Thu, 22 Feb 2024 07:32:56 GMT
       Link:
-      - </servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/private_nics?page=0&per_page=50&>;
+      - </servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2222,7 +2295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cba786c2-6a5b-4b34-b90e-ecbdeea728a5
+      - 8430fc17-fb36-4ae6-bdd2-eb7235c228f3
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -2235,22 +2308,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:42.913586+00:00","error_details":null,"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"tf-snap-compassionate-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:27.606769+00:00","error_details":null,"id":"675d3789-bd48-40dc-9848-70779022b8cc","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"tf-snap-priceless-banach","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "538"
+      - "534"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:10 GMT
+      - Thu, 22 Feb 2024 07:32:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2258,7 +2331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c48a62ff-57d9-499d-baee-b612c3ded96a
+      - 3a50ec05-01f0-4257-bb8d-5b16702ecea5
     status: 200 OK
     code: 200
     duration: ""
@@ -2269,21 +2342,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:04.438491+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","name":"tf-snap-clever-swanson","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","modification_date":"2023-12-05T10:58:04.438491+00:00","name":"tf-image-elastic-mccarthy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","name":"tf-snap-compassionate-panini","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:53.870827+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","name":"tf-snap-strange-goldberg","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"099d7f0d-fe30-4845-9481-2253982b3972","modification_date":"2024-02-22T07:32:53.870827+00:00","name":"tf-image-bold-burnell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"675d3789-bd48-40dc-9848-70779022b8cc","name":"tf-snap-priceless-banach","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "748"
+      - "742"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:10 GMT
+      - Thu, 22 Feb 2024 07:32:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2291,12 +2364,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1acb3d5f-9fdf-4deb-ad6f-90807b003e38
+      - 5ab80771-0574-4c89-86b6-844d95e4cdfd
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-vol-great-chaplygin","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"b_ssd","size":22000000000}'
+    body: '{"name":"tf-vol-objective-ishizaka","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"b_ssd","size":22000000000}'
     form: {}
     headers:
       Content-Type:
@@ -2307,20 +2380,20 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:58:13.175513+00:00","export_uri":null,"id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","modification_date":"2023-12-05T10:58:13.175513+00:00","name":"tf-vol-great-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:57.228191+00:00","export_uri":null,"id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","modification_date":"2024-02-22T07:32:57.228191+00:00","name":"tf-vol-objective-ishizaka","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "444"
+      - "447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:13 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/acbd6426-6e87-4d31-a8d1-9dbe8628ac62
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6f90dd97-31e1-4c23-97b7-7b7f044178bf
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2328,7 +2401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 596491c7-424c-4eb8-9bfe-d1dd73e8de44
+      - 6e328230-e569-4b0b-8e0a-11c48281969c
     status: 201 Created
     code: 201
     duration: ""
@@ -2339,21 +2412,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/acbd6426-6e87-4d31-a8d1-9dbe8628ac62
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6f90dd97-31e1-4c23-97b7-7b7f044178bf
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:58:13.175513+00:00","export_uri":null,"id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","modification_date":"2023-12-05T10:58:13.175513+00:00","name":"tf-vol-great-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:57.228191+00:00","export_uri":null,"id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","modification_date":"2024-02-22T07:32:57.228191+00:00","name":"tf-vol-objective-ishizaka","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "444"
+      - "447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:13 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2361,7 +2434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81ae52b9-1c20-4a43-b819-c62e3511df4a
+      - 47930ef5-5524-47dc-869a-24b342b7ab10
     status: 200 OK
     code: 200
     duration: ""
@@ -2372,21 +2445,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/acbd6426-6e87-4d31-a8d1-9dbe8628ac62
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6f90dd97-31e1-4c23-97b7-7b7f044178bf
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:58:13.175513+00:00","export_uri":null,"id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","modification_date":"2023-12-05T10:58:13.175513+00:00","name":"tf-vol-great-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:57.228191+00:00","export_uri":null,"id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","modification_date":"2024-02-22T07:32:57.228191+00:00","name":"tf-vol-objective-ishizaka","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "444"
+      - "447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:13 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2394,12 +2467,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a95c0392-53bb-4593-b553-6416636486f9
+      - 98058ae2-cc6d-46e6-9415-93861ca59cba
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-snap-stoic-ishizaka","volume_id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-snap-gallant-blackwell","volume_id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -2410,18 +2483,18 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot":{"base_volume":{"id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","name":"tf-vol-great-chaplygin"},"creation_date":"2023-12-05T10:58:13.765941+00:00","error_details":null,"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","modification_date":"2023-12-05T10:58:13.765941+00:00","name":"tf-snap-stoic-ishizaka","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_2b8a6fba-9cff-4bb7-a535-2c778ed1139c","href_from":"/snapshots","href_result":"snapshots/2b8a6fba-9cff-4bb7-a535-2c778ed1139c","id":"1411c273-33c1-4bd9-8e33-f779dfdb4712","started_at":"2023-12-05T10:58:13.985562+00:00","status":"pending","terminated_at":null}}'
+    body: '{"snapshot":{"base_volume":{"id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","name":"tf-vol-objective-ishizaka"},"creation_date":"2024-02-22T07:32:57.551215+00:00","error_details":null,"id":"b44c2da9-5a3f-4028-982e-d344bc6af652","modification_date":"2024-02-22T07:32:57.551215+00:00","name":"tf-snap-gallant-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_b44c2da9-5a3f-4028-982e-d344bc6af652","href_from":"/snapshots","href_result":"snapshots/b44c2da9-5a3f-4028-982e-d344bc6af652","id":"bdcb95e2-a597-437f-a7a1-a3998803678c","started_at":"2024-02-22T07:32:57.794470+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
-      - "839"
+      - "845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:14 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2429,7 +2502,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78c2befb-7cd5-4d5a-8e64-36c6443988ef
+      - 85106439-7c4c-4f47-bf82-8cc465e532d4
     status: 201 Created
     code: 201
     duration: ""
@@ -2440,21 +2513,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b8a6fba-9cff-4bb7-a535-2c778ed1139c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b44c2da9-5a3f-4028-982e-d344bc6af652
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","name":"tf-vol-great-chaplygin"},"creation_date":"2023-12-05T10:58:13.765941+00:00","error_details":null,"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","modification_date":"2023-12-05T10:58:13.765941+00:00","name":"tf-snap-stoic-ishizaka","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","name":"tf-vol-objective-ishizaka"},"creation_date":"2024-02-22T07:32:57.551215+00:00","error_details":null,"id":"b44c2da9-5a3f-4028-982e-d344bc6af652","modification_date":"2024-02-22T07:32:57.551215+00:00","name":"tf-snap-gallant-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "533"
+      - "539"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:14 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2462,7 +2535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 962c792b-ad69-4821-8cb2-4073bb449f20
+      - 377a4686-ad97-4c12-b013-81043ebc0936
     status: 200 OK
     code: 200
     duration: ""
@@ -2473,21 +2546,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b8a6fba-9cff-4bb7-a535-2c778ed1139c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b44c2da9-5a3f-4028-982e-d344bc6af652
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","name":"tf-vol-great-chaplygin"},"creation_date":"2023-12-05T10:58:13.765941+00:00","error_details":null,"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","modification_date":"2023-12-05T10:58:19.165822+00:00","name":"tf-snap-stoic-ishizaka","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","name":"tf-vol-objective-ishizaka"},"creation_date":"2024-02-22T07:32:57.551215+00:00","error_details":null,"id":"b44c2da9-5a3f-4028-982e-d344bc6af652","modification_date":"2024-02-22T07:33:02.294940+00:00","name":"tf-snap-gallant-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "530"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:19 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2495,7 +2568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e766999a-c5a1-40ca-bfc1-89bd52b6448d
+      - af7992bb-3826-4f2b-9a55-7a2991d3cc70
     status: 200 OK
     code: 200
     duration: ""
@@ -2506,21 +2579,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b8a6fba-9cff-4bb7-a535-2c778ed1139c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b44c2da9-5a3f-4028-982e-d344bc6af652
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","name":"tf-vol-great-chaplygin"},"creation_date":"2023-12-05T10:58:13.765941+00:00","error_details":null,"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","modification_date":"2023-12-05T10:58:19.165822+00:00","name":"tf-snap-stoic-ishizaka","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","name":"tf-vol-objective-ishizaka"},"creation_date":"2024-02-22T07:32:57.551215+00:00","error_details":null,"id":"b44c2da9-5a3f-4028-982e-d344bc6af652","modification_date":"2024-02-22T07:33:02.294940+00:00","name":"tf-snap-gallant-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "530"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:19 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2528,7 +2601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 218f32d5-4a87-4680-b578-977452885cd7
+      - 42081583-9401-4214-b1b0-e3b0af57f0c7
     status: 200 OK
     code: 200
     duration: ""
@@ -2539,21 +2612,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:04.438491+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","name":"tf-snap-clever-swanson","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","modification_date":"2023-12-05T10:58:04.438491+00:00","name":"tf-image-elastic-mccarthy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","name":"tf-snap-compassionate-panini","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:53.870827+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","name":"tf-snap-strange-goldberg","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"099d7f0d-fe30-4845-9481-2253982b3972","modification_date":"2024-02-22T07:32:53.870827+00:00","name":"tf-image-bold-burnell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"675d3789-bd48-40dc-9848-70779022b8cc","name":"tf-snap-priceless-banach","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "748"
+      - "742"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:19 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2561,7 +2634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8334bbbd-e6ba-4351-bc09-4fcd23446e5b
+      - 61516b6d-7900-4ff8-bcb4-3e9862fb66f8
     status: 200 OK
     code: 200
     duration: ""
@@ -2572,21 +2645,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b8a6fba-9cff-4bb7-a535-2c778ed1139c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b44c2da9-5a3f-4028-982e-d344bc6af652
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","name":"tf-vol-great-chaplygin"},"creation_date":"2023-12-05T10:58:13.765941+00:00","error_details":null,"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","modification_date":"2023-12-05T10:58:19.165822+00:00","name":"tf-snap-stoic-ishizaka","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","name":"tf-vol-objective-ishizaka"},"creation_date":"2024-02-22T07:32:57.551215+00:00","error_details":null,"id":"b44c2da9-5a3f-4028-982e-d344bc6af652","modification_date":"2024-02-22T07:33:02.294940+00:00","name":"tf-snap-gallant-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "530"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:20 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2594,7 +2667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c76930b-fd83-4b39-b176-10f74240bf4b
+      - a6162ad3-5577-42eb-82af-61d01300df6a
     status: 200 OK
     code: 200
     duration: ""
@@ -2605,21 +2678,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:04.438491+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","name":"tf-snap-clever-swanson","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","modification_date":"2023-12-05T10:58:04.438491+00:00","name":"tf-image-elastic-mccarthy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","name":"tf-snap-compassionate-panini","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:53.870827+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","name":"tf-snap-strange-goldberg","size":21000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"099d7f0d-fe30-4845-9481-2253982b3972","modification_date":"2024-02-22T07:32:53.870827+00:00","name":"tf-image-bold-burnell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"675d3789-bd48-40dc-9848-70779022b8cc","name":"tf-snap-priceless-banach","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "748"
+      - "742"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:20 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2627,12 +2700,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 942167d5-989b-4ded-a91f-c2833e2c9dec
+      - 143a836f-d5e7-4080-a878-d57f527d77e0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-image-elastic-mccarthy","arch":"x86_64","extra_volumes":{"1":{"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c"}},"tags":[]}'
+    body: '{"name":"tf-image-bold-burnell","arch":"x86_64","extra_volumes":{"1":{"id":"b44c2da9-5a3f-4028-982e-d344bc6af652"}},"tags":[]}'
     form: {}
     headers:
       Content-Type:
@@ -2640,21 +2713,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
     method: PATCH
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:04.438491+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","name":"tf-snap-stoic-ishizaka","size":22000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","modification_date":"2023-12-05T10:58:04.438491+00:00","name":"tf-image-elastic-mccarthy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","name":"tf-snap-compassionate-panini","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:53.870827+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"b44c2da9-5a3f-4028-982e-d344bc6af652","name":"tf-snap-gallant-blackwell","size":22000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"099d7f0d-fe30-4845-9481-2253982b3972","modification_date":"2024-02-22T07:32:53.870827+00:00","name":"tf-image-bold-burnell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"675d3789-bd48-40dc-9848-70779022b8cc","name":"tf-snap-priceless-banach","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "748"
+      - "743"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:20 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2662,7 +2735,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6122d776-c75e-46e9-aa0f-26676a8a99fc
+      - 4d327812-8468-43c7-ad50-1b7a2a4d5aa9
     status: 200 OK
     code: 200
     duration: ""
@@ -2673,21 +2746,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:04.438491+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","name":"tf-snap-stoic-ishizaka","size":22000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","modification_date":"2023-12-05T10:58:04.438491+00:00","name":"tf-image-elastic-mccarthy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","name":"tf-snap-compassionate-panini","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:53.870827+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"b44c2da9-5a3f-4028-982e-d344bc6af652","name":"tf-snap-gallant-blackwell","size":22000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"099d7f0d-fe30-4845-9481-2253982b3972","modification_date":"2024-02-22T07:32:53.870827+00:00","name":"tf-image-bold-burnell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"675d3789-bd48-40dc-9848-70779022b8cc","name":"tf-snap-priceless-banach","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "748"
+      - "743"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:20 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2695,7 +2768,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4374bcbb-26cc-4b90-b4ec-391f1ec0d9de
+      - 5ee5a596-c4fa-445e-81f1-78d1649cee94
     status: 200 OK
     code: 200
     duration: ""
@@ -2706,21 +2779,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:04.438491+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","name":"tf-snap-stoic-ishizaka","size":22000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","modification_date":"2023-12-05T10:58:04.438491+00:00","name":"tf-image-elastic-mccarthy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","name":"tf-snap-compassionate-panini","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:53.870827+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"b44c2da9-5a3f-4028-982e-d344bc6af652","name":"tf-snap-gallant-blackwell","size":22000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"099d7f0d-fe30-4845-9481-2253982b3972","modification_date":"2024-02-22T07:32:53.870827+00:00","name":"tf-image-bold-burnell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"675d3789-bd48-40dc-9848-70779022b8cc","name":"tf-snap-priceless-banach","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "748"
+      - "743"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:20 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2728,7 +2801,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfd0fc84-0652-418a-8484-dcd97d6ac755
+      - 2dbf2f52-4a44-48b5-8e76-15928154f060
     status: 200 OK
     code: 200
     duration: ""
@@ -2739,21 +2812,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/26746f64-05c8-4f2a-8ac9-ea12eda1aa37
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/269fbc40-435e-442e-9795-272bc7053559
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:57:17.949755+00:00","export_uri":null,"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-vol-keen-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.446019+00:00","export_uri":null,"id":"269fbc40-435e-442e-9795-272bc7053559","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-vol-relaxed-mendeleev","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "441"
+      - "446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:20 GMT
+      - Thu, 22 Feb 2024 07:33:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2761,7 +2834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6752f604-bcb7-46ce-a299-e69d3698a33c
+      - 4764cc53-b4e6-4681-a1fa-7cf5f5bbf9ab
     status: 200 OK
     code: 200
     duration: ""
@@ -2772,21 +2845,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/acbd6426-6e87-4d31-a8d1-9dbe8628ac62
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6f90dd97-31e1-4c23-97b7-7b7f044178bf
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:58:13.175513+00:00","export_uri":null,"id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","modification_date":"2023-12-05T10:58:19.165822+00:00","name":"tf-vol-great-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:57.228191+00:00","export_uri":null,"id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","modification_date":"2024-02-22T07:33:02.294940+00:00","name":"tf-vol-objective-ishizaka","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "444"
+      - "447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:20 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2794,7 +2867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b8a8a8c-0a7a-4a7d-b159-5817f8a09619
+      - 295c261a-815e-4fb2-aa52-3c5c4da6b0dc
     status: 200 OK
     code: 200
     duration: ""
@@ -2805,331 +2878,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:35.309269+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2809"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 90a31185-8b34-4f83-936b-cbbcccc85ac3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "527"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1a248b6b-0d9a-4114-97e6-4abc71810312
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b8a6fba-9cff-4bb7-a535-2c778ed1139c
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","name":"tf-vol-great-chaplygin"},"creation_date":"2023-12-05T10:58:13.765941+00:00","error_details":null,"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","modification_date":"2023-12-05T10:58:19.165822+00:00","name":"tf-snap-stoic-ishizaka","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "530"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 898efe7f-b47c-4f5f-9a8f-ded15a740278
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:42.913586+00:00","error_details":null,"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"tf-snap-compassionate-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "538"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0741baed-4a91-4461-9021-7e56aece91ad
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
-    method: GET
-  response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:04.438491+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","name":"tf-snap-stoic-ishizaka","size":22000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","modification_date":"2023-12-05T10:58:04.438491+00:00","name":"tf-image-elastic-mccarthy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","name":"tf-snap-compassionate-panini","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "748"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:21 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 636c850d-cfd9-409a-a314-cbd0ef27e94a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/26746f64-05c8-4f2a-8ac9-ea12eda1aa37
-    method: GET
-  response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:57:17.949755+00:00","export_uri":null,"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-vol-keen-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "441"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b6a722c6-e919-4867-8679-30a8fdb51daa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/acbd6426-6e87-4d31-a8d1-9dbe8628ac62
-    method: GET
-  response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:58:13.175513+00:00","export_uri":null,"id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","modification_date":"2023-12-05T10:58:19.165822+00:00","name":"tf-vol-great-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "444"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:23 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - de839f18-59b1-4170-8b9a-dd22563bbe8b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "527"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f1674bdc-e44f-4abc-81fc-1f6131b6d9e1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b8a6fba-9cff-4bb7-a535-2c778ed1139c
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","name":"tf-vol-great-chaplygin"},"creation_date":"2023-12-05T10:58:13.765941+00:00","error_details":null,"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","modification_date":"2023-12-05T10:58:19.165822+00:00","name":"tf-snap-stoic-ishizaka","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "530"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:24 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c6fab52c-3eb1-4844-bd4f-99c35411a498
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:35.309269+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:23.411647+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2809"
+      - "2811"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:24 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3137,7 +2906,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09805f03-e865-4745-bbed-030b0cd102f8
+      - c5e28cdb-41aa-4640-8d2f-98f1d2304bd1
     status: 200 OK
     code: 200
     duration: ""
@@ -3148,7 +2917,311 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "534"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 38973d42-11c0-4cf2-94ee-f31b8d1c7edc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b44c2da9-5a3f-4028-982e-d344bc6af652
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","name":"tf-vol-objective-ishizaka"},"creation_date":"2024-02-22T07:32:57.551215+00:00","error_details":null,"id":"b44c2da9-5a3f-4028-982e-d344bc6af652","modification_date":"2024-02-22T07:33:02.294940+00:00","name":"tf-snap-gallant-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "536"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 004d4019-5971-4266-8dba-2a8a2e52d367
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:27.606769+00:00","error_details":null,"id":"675d3789-bd48-40dc-9848-70779022b8cc","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"tf-snap-priceless-banach","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "534"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f70977c9-0980-4f15-be2c-5bd27e276b7a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
+    method: GET
+  response:
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:53.870827+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"b44c2da9-5a3f-4028-982e-d344bc6af652","name":"tf-snap-gallant-blackwell","size":22000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"099d7f0d-fe30-4845-9481-2253982b3972","modification_date":"2024-02-22T07:32:53.870827+00:00","name":"tf-image-bold-burnell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"675d3789-bd48-40dc-9848-70779022b8cc","name":"tf-snap-priceless-banach","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "743"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 35aa73d3-1cf9-4807-a95d-1d3566204684
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6f90dd97-31e1-4c23-97b7-7b7f044178bf
+    method: GET
+  response:
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:57.228191+00:00","export_uri":null,"id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","modification_date":"2024-02-22T07:33:02.294940+00:00","name":"tf-vol-objective-ishizaka","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "447"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 06d70f41-7d4e-4a43-854a-85ed6605b2fc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/269fbc40-435e-442e-9795-272bc7053559
+    method: GET
+  response:
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.446019+00:00","export_uri":null,"id":"269fbc40-435e-442e-9795-272bc7053559","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-vol-relaxed-mendeleev","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "446"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eb170278-5635-4ef7-9177-df4ab661c975
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:23.411647+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2811"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c95d5390-7f4f-49c8-bbf5-6e905135c130
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b44c2da9-5a3f-4028-982e-d344bc6af652
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","name":"tf-vol-objective-ishizaka"},"creation_date":"2024-02-22T07:32:57.551215+00:00","error_details":null,"id":"b44c2da9-5a3f-4028-982e-d344bc6af652","modification_date":"2024-02-22T07:33:02.294940+00:00","name":"tf-snap-gallant-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "536"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 92c96cec-efe6-448b-82dc-02ea1fdd2306
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "534"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1bc01274-1c28-4889-852c-2b5cb9ea982a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -3160,9 +3233,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:24 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3170,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67f9c109-faeb-484d-b5af-3f50411d7063
+      - 5817b2df-a438-4231-b1c7-e0bc01b5975a
     status: 200 OK
     code: 200
     duration: ""
@@ -3181,7 +3254,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -3193,12 +3266,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:24 GMT
+      - Thu, 22 Feb 2024 07:33:05 GMT
       Link:
-      - </servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/private_nics?page=0&per_page=50&>;
+      - </servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3206,7 +3279,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2c9bd0c-0589-4176-a0bc-3cd8898462bd
+      - c7dcd706-2b92-426a-a73f-4386a3d7a2b7
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -3219,22 +3292,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:42.913586+00:00","error_details":null,"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"tf-snap-compassionate-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:27.606769+00:00","error_details":null,"id":"675d3789-bd48-40dc-9848-70779022b8cc","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"tf-snap-priceless-banach","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "538"
+      - "534"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:24 GMT
+      - Thu, 22 Feb 2024 07:33:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3242,7 +3315,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11838696-e93b-4770-9fa0-775a8b7ac1ae
+      - 1a4c28e2-0312-4825-95e7-b521b8f4c3ef
     status: 200 OK
     code: 200
     duration: ""
@@ -3253,21 +3326,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:04.438491+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","name":"tf-snap-stoic-ishizaka","size":22000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","modification_date":"2023-12-05T10:58:04.438491+00:00","name":"tf-image-elastic-mccarthy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","name":"tf-snap-compassionate-panini","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:53.870827+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"b44c2da9-5a3f-4028-982e-d344bc6af652","name":"tf-snap-gallant-blackwell","size":22000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"099d7f0d-fe30-4845-9481-2253982b3972","modification_date":"2024-02-22T07:32:53.870827+00:00","name":"tf-image-bold-burnell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"675d3789-bd48-40dc-9848-70779022b8cc","name":"tf-snap-priceless-banach","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "748"
+      - "743"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:24 GMT
+      - Thu, 22 Feb 2024 07:33:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3275,7 +3348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17a47007-6516-462c-872d-0212d12ac3d3
+      - 09e02bdc-6dbe-4b63-9bef-56c64ff43ecd
     status: 200 OK
     code: 200
     duration: ""
@@ -3286,21 +3359,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","name":"tf-vol-keen-hypatia"},"creation_date":"2023-12-05T10:57:18.391366+00:00","error_details":null,"id":"1a72d901-2461-4e37-91a2-4af1cc6febed","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-snap-clever-swanson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"269fbc40-435e-442e-9795-272bc7053559","name":"tf-vol-relaxed-mendeleev"},"creation_date":"2024-02-22T07:32:02.802694+00:00","error_details":null,"id":"92d0a032-2112-495d-8d8f-82346d8b6aea","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-snap-strange-goldberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "527"
+      - "534"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3308,7 +3381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55dffb91-91ee-4ca7-adbc-e3b7275db911
+      - cb8ae6bd-7255-43f1-9500-127bf236cd8b
     status: 200 OK
     code: 200
     duration: ""
@@ -3319,21 +3392,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:04.438491+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","name":"tf-snap-stoic-ishizaka","size":22000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","modification_date":"2023-12-05T10:58:04.438491+00:00","name":"tf-image-elastic-mccarthy","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","name":"tf-snap-compassionate-panini","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:53.870827+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"b44c2da9-5a3f-4028-982e-d344bc6af652","name":"tf-snap-gallant-blackwell","size":22000000000,"volume_type":"b_ssd"}},"from_server":null,"id":"099d7f0d-fe30-4845-9481-2253982b3972","modification_date":"2024-02-22T07:32:53.870827+00:00","name":"tf-image-bold-burnell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"675d3789-bd48-40dc-9848-70779022b8cc","name":"tf-snap-priceless-banach","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "748"
+      - "743"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3341,7 +3414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d9f0451f-788a-4864-8a97-c3a5ed6be4e5
+      - f54d60b5-75f5-4b60-932d-5c7a2a567f52
     status: 200 OK
     code: 200
     duration: ""
@@ -3352,7 +3425,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
     method: DELETE
   response:
     body: ""
@@ -3360,9 +3433,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3370,7 +3443,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd02a3ba-8eab-419f-b6aa-95998a3cc373
+      - 8c55d826-6ee7-4a5b-8adf-24d39580aa3d
     status: 204 No Content
     code: 204
     duration: ""
@@ -3381,10 +3454,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"1a72d901-2461-4e37-91a2-4af1cc6febed","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"92d0a032-2112-495d-8d8f-82346d8b6aea","type":"not_found"}'
     headers:
       Content-Length:
       - "145"
@@ -3393,9 +3466,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3403,7 +3476,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bffd934-6847-4fd3-bc34-89029864ecb1
+      - 0b8519be-0603-41f5-b962-e8876fe2b026
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3414,50 +3487,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bd8811e7-2a66-41a3-ab06-0dae011eec8b
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/26746f64-05c8-4f2a-8ac9-ea12eda1aa37
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/269fbc40-435e-442e-9795-272bc7053559
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:57:17.949755+00:00","export_uri":null,"id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","modification_date":"2023-12-05T10:57:25.112688+00:00","name":"tf-vol-keen-hypatia","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.446019+00:00","export_uri":null,"id":"269fbc40-435e-442e-9795-272bc7053559","modification_date":"2024-02-22T07:32:08.590155+00:00","name":"tf-vol-relaxed-mendeleev","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":21000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "441"
+      - "446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3465,7 +3509,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5a8a356-491d-4127-8db4-81bd4841d6c3
+      - 04a95592-2abf-4a46-9841-60b7cfb39e89
     status: 200 OK
     code: 200
     duration: ""
@@ -3476,10 +3520,39 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Thu, 22 Feb 2024 07:33:06 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 74f4152c-3974-419e-a187-7a98fbf1c295
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_image","resource_id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_image","resource_id":"099d7f0d-fe30-4845-9481-2253982b3972","type":"not_found"}'
     headers:
       Content-Length:
       - "142"
@@ -3488,9 +3561,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3498,7 +3571,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fce36fb9-c158-490d-ab92-78d154c79835
+      - 017fdb9e-babb-4894-87f3-e3e9f9de6689
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3509,21 +3582,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b8a6fba-9cff-4bb7-a535-2c778ed1139c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b44c2da9-5a3f-4028-982e-d344bc6af652
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","name":"tf-vol-great-chaplygin"},"creation_date":"2023-12-05T10:58:13.765941+00:00","error_details":null,"id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","modification_date":"2023-12-05T10:58:19.165822+00:00","name":"tf-snap-stoic-ishizaka","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","name":"tf-vol-objective-ishizaka"},"creation_date":"2024-02-22T07:32:57.551215+00:00","error_details":null,"id":"b44c2da9-5a3f-4028-982e-d344bc6af652","modification_date":"2024-02-22T07:33:02.294940+00:00","name":"tf-snap-gallant-blackwell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "530"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3531,7 +3604,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37ccffbb-8e93-4955-824e-d5f3bae4f23f
+      - cf0154dd-2896-4feb-8b26-e07b6b531da8
     status: 200 OK
     code: 200
     duration: ""
@@ -3542,22 +3615,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:42.913586+00:00","error_details":null,"id":"542d3ff6-3c1c-4016-a659-f36df015caa0","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"tf-snap-compassionate-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:27.606769+00:00","error_details":null,"id":"675d3789-bd48-40dc-9848-70779022b8cc","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"tf-snap-priceless-banach","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "538"
+      - "534"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3565,7 +3638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59f1099b-ddc1-4f65-9709-1fd571081c15
+      - 71aa0d71-2e0f-4ed4-88ed-9dcad9bd1716
     status: 200 OK
     code: 200
     duration: ""
@@ -3576,7 +3649,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/26746f64-05c8-4f2a-8ac9-ea12eda1aa37
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/269fbc40-435e-442e-9795-272bc7053559
     method: DELETE
   response:
     body: ""
@@ -3584,9 +3657,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3594,7 +3667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 450adb0d-7f64-4c12-9e8a-3318b8704bc5
+      - ebd9d7d3-ce00-4ef7-9ad6-eddb09c838ee
     status: 204 No Content
     code: 204
     duration: ""
@@ -3605,7 +3678,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b8a6fba-9cff-4bb7-a535-2c778ed1139c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b44c2da9-5a3f-4028-982e-d344bc6af652
     method: DELETE
   response:
     body: ""
@@ -3613,9 +3686,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3623,7 +3696,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b37d3fa-e04d-4c3c-ab93-10b3f81f36b0
+      - 7634b370-17ab-49c9-a66d-b4e3b9577d68
     status: 204 No Content
     code: 204
     duration: ""
@@ -3634,10 +3707,39 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b8a6fba-9cff-4bb7-a535-2c778ed1139c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Thu, 22 Feb 2024 07:33:06 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c8d6fcac-c676-4341-b815-31c64d922566
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b44c2da9-5a3f-4028-982e-d344bc6af652
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"b44c2da9-5a3f-4028-982e-d344bc6af652","type":"not_found"}'
     headers:
       Content-Length:
       - "145"
@@ -3646,9 +3748,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3656,7 +3758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebb34969-f47f-48f7-b70a-303adf8bf4e2
+      - f2824912-9bf0-4ac0-b509-22273a1f232e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3667,39 +3769,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d40f3fad-4081-4767-866d-b1218ce98eb1
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"542d3ff6-3c1c-4016-a659-f36df015caa0","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"675d3789-bd48-40dc-9848-70779022b8cc","type":"not_found"}'
     headers:
       Content-Length:
       - "145"
@@ -3708,9 +3781,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3718,7 +3791,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c9496b2-01ba-4bc0-84ce-129382382d4c
+      - d38810c2-9e0d-489f-ac2b-ae1807556c74
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3729,21 +3802,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/acbd6426-6e87-4d31-a8d1-9dbe8628ac62
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6f90dd97-31e1-4c23-97b7-7b7f044178bf
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-12-05T10:58:13.175513+00:00","export_uri":null,"id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","modification_date":"2023-12-05T10:58:19.165822+00:00","name":"tf-vol-great-chaplygin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:57.228191+00:00","export_uri":null,"id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","modification_date":"2024-02-22T07:33:02.294940+00:00","name":"tf-vol-objective-ishizaka","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":22000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "444"
+      - "447"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3751,7 +3824,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6ef83f4-156e-4661-92f8-bdae44cb7573
+      - 069321ff-3e7c-4110-af98-07410522ed2d
     status: 200 OK
     code: 200
     duration: ""
@@ -3762,7 +3835,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/acbd6426-6e87-4d31-a8d1-9dbe8628ac62
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6f90dd97-31e1-4c23-97b7-7b7f044178bf
     method: DELETE
   response:
     body: ""
@@ -3770,9 +3843,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3780,7 +3853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26d48d24-2a57-49cb-9474-014e669fe9d2
+      - 8e33c07b-9c48-4560-9cb3-e7177981fda0
     status: 204 No Content
     code: 204
     duration: ""
@@ -3791,27 +3864,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:57:35.309269+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:32:23.411647+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2809"
+      - "2811"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:28 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3819,7 +3892,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e30e7bfc-a0e9-46c1-a132-be90bd7b63b1
+      - 458c4ada-2085-4bf7-93b0-a79bea4bef85
     status: 200 OK
     code: 200
     duration: ""
@@ -3832,10 +3905,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850/action","href_result":"/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850","id":"a91cd3b5-31cb-484f-897e-1209068dce4a","started_at":"2023-12-05T10:58:29.112474+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5/action","href_result":"/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5","id":"95291f42-4799-46d2-b0ca-5f70fa8f70c3","started_at":"2024-02-22T07:33:07.237662+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -3844,11 +3917,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:29 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/a91cd3b5-31cb-484f-897e-1209068dce4a
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/95291f42-4799-46d2-b0ca-5f70fa8f70c3
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3856,7 +3929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d44a8c3b-a1c1-4d03-ab38-c858bcd73061
+      - 5bf1dcec-00ed-4871-a796-c6ca7b775d77
     status: 202 Accepted
     code: 202
     duration: ""
@@ -3867,27 +3940,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:58:28.984404+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:33:06.639565+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2777"
+      - "2779"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:29 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3895,7 +3968,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d80641e2-67f8-4b10-bc39-15dad84694f8
+      - b09e8cae-ad04-4993-9f45-7304fb86f3d7
     status: 200 OK
     code: 200
     duration: ""
@@ -3906,27 +3979,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:58:28.984404+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:33:06.639565+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2777"
+      - "2779"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:35 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3934,7 +4007,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af2979f8-34ec-436f-9b2d-23b0d696df02
+      - 615ad09c-50c2-4424-9c5f-8d56abb532d8
     status: 200 OK
     code: 200
     duration: ""
@@ -3945,27 +4018,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:58:28.984404+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:33:06.639565+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2777"
+      - "2779"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:40 GMT
+      - Thu, 22 Feb 2024 07:33:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3973,7 +4046,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62b7bc96-d763-40fc-8447-0e112c0c4240
+      - bce493b4-b44d-4a0a-9851-48795da2ca67
     status: 200 OK
     code: 200
     duration: ""
@@ -3984,27 +4057,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:58:28.984404+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:33:06.639565+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2777"
+      - "2779"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:45 GMT
+      - Thu, 22 Feb 2024 07:33:23 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4012,7 +4085,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fad2271e-a296-4669-9e16-1f3ed494b47d
+      - 2bd58c08-353e-49ad-86c5-83239df50d82
     status: 200 OK
     code: 200
     duration: ""
@@ -4023,27 +4096,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:58:28.984404+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:33:06.639565+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2777"
+      - "2779"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:50 GMT
+      - Thu, 22 Feb 2024 07:33:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4051,7 +4124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29635dce-b01a-44d9-92bc-5aa78bb6b47a
+      - 45c9321e-1ee3-4252-8a53-f831db4dce8e
     status: 200 OK
     code: 200
     duration: ""
@@ -4062,27 +4135,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:58:28.984404+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:33:06.639565+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2777"
+      - "2779"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:55 GMT
+      - Thu, 22 Feb 2024 07:33:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4090,7 +4163,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07cc5686-0e14-432d-9335-f68b27d2e8d0
+      - 969fead3-4b6f-4a42-a885-66040239ee60
     status: 200 OK
     code: 200
     duration: ""
@@ -4101,27 +4174,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"39","hypervisor_id":"1401","node_id":"19","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:58:28.984404+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.69.132.37","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:33:06.639565+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.70.40.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2777"
+      - "2779"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:01 GMT
+      - Thu, 22 Feb 2024 07:33:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4129,7 +4202,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71c5c4db-621f-4e7e-9278-abcf65005ab4
+      - 3cf4c22c-7875-42ac-a481-9f631d9b9b05
     status: 200 OK
     code: 200
     duration: ""
@@ -4140,27 +4213,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:59:03.449577+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:33:41.881475+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2654"
+      - "2658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:06 GMT
+      - Thu, 22 Feb 2024 07:33:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4168,7 +4241,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 896e6ea4-57be-4ab1-8e92-52d3474ab6ba
+      - 257e4a9c-5388-44f8-af61-770af376cd33
     status: 200 OK
     code: 200
     duration: ""
@@ -4179,27 +4252,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.215409+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-ecstatic-einstein","id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:f9","maintenances":[],"modification_date":"2023-12-05T10:59:03.449577+00:00","name":"tf-srv-ecstatic-einstein","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.215409+00:00","export_uri":null,"id":"f70d4dd9-a997-4bd6-b245-9a695bc80cec","modification_date":"2023-12-05T10:58:02.548666+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","name":"tf-srv-ecstatic-einstein"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.679296+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-kind-fermat","id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:9f","maintenances":[],"modification_date":"2024-02-22T07:33:41.881475+00:00","name":"tf-srv-kind-fermat","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.679296+00:00","export_uri":null,"id":"7ef08fe5-505f-442d-9105-7a7d917bdfc3","modification_date":"2024-02-22T07:32:51.213624+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","name":"tf-srv-kind-fermat"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2654"
+      - "2658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:06 GMT
+      - Thu, 22 Feb 2024 07:33:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4207,7 +4280,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c62cc9a4-dcbf-4531-bc8d-d80e321d5aa5
+      - 1c7eedaa-25d5-49cf-821c-767f036da4b5
     status: 200 OK
     code: 200
     duration: ""
@@ -4218,7 +4291,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: DELETE
   response:
     body: ""
@@ -4226,9 +4299,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:59:07 GMT
+      - Thu, 22 Feb 2024 07:33:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4236,7 +4309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5b66106-3063-4d42-8542-91ffed9e5032
+      - 59eb0fcb-a39c-42f7-ba7f-8ee699ebd921
     status: 204 No Content
     code: 204
     duration: ""
@@ -4247,10 +4320,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -4259,9 +4332,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:07 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4269,7 +4342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 23341b89-99ae-42c9-ba8b-03cf6343ee87
+      - 5251bc24-d422-423f-bb14-ee4c720800bd
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4280,7 +4353,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f70d4dd9-a997-4bd6-b245-9a695bc80cec
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/7ef08fe5-505f-442d-9105-7a7d917bdfc3
     method: DELETE
   response:
     body: ""
@@ -4288,9 +4361,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:59:07 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4298,7 +4371,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 035954e0-a339-43fa-8d59-8929d7d44411
+      - ddd21396-bf8f-43f1-86ec-969ca30ea423
     status: 204 No Content
     code: 204
     duration: ""
@@ -4309,10 +4382,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/e2759695-25c8-4450-9698-eb9ec66dcb5a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/099d7f0d-fe30-4845-9481-2253982b3972
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_image","resource_id":"e2759695-25c8-4450-9698-eb9ec66dcb5a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_image","resource_id":"099d7f0d-fe30-4845-9481-2253982b3972","type":"not_found"}'
     headers:
       Content-Length:
       - "142"
@@ -4321,9 +4394,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:07 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4331,7 +4404,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e014bad-70a0-4728-a836-131e0b88e5de
+      - fb3fe507-31d3-48bc-bc33-03b130818567
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4342,10 +4415,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/1a72d901-2461-4e37-91a2-4af1cc6febed
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/92d0a032-2112-495d-8d8f-82346d8b6aea
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"1a72d901-2461-4e37-91a2-4af1cc6febed","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"92d0a032-2112-495d-8d8f-82346d8b6aea","type":"not_found"}'
     headers:
       Content-Length:
       - "145"
@@ -4354,9 +4427,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:07 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4364,7 +4437,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b26a23bc-368b-4e07-be59-3bac9f94e0a3
+      - 1a607ae9-3b8b-4bee-a319-56c4a77714be
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4375,10 +4448,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/2b8a6fba-9cff-4bb7-a535-2c778ed1139c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/b44c2da9-5a3f-4028-982e-d344bc6af652
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"2b8a6fba-9cff-4bb7-a535-2c778ed1139c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"b44c2da9-5a3f-4028-982e-d344bc6af652","type":"not_found"}'
     headers:
       Content-Length:
       - "145"
@@ -4387,9 +4460,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:07 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4397,7 +4470,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2feda686-626c-4988-804a-11158985537c
+      - 7db18798-7d5c-4aa8-a603-a329b4b4cb24
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4408,10 +4481,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/542d3ff6-3c1c-4016-a659-f36df015caa0
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/675d3789-bd48-40dc-9848-70779022b8cc
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"542d3ff6-3c1c-4016-a659-f36df015caa0","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"675d3789-bd48-40dc-9848-70779022b8cc","type":"not_found"}'
     headers:
       Content-Length:
       - "145"
@@ -4420,9 +4493,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:07 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4430,7 +4503,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b3f0149-5818-45d5-a7e9-b968490bc351
+      - adf086ea-46cd-4762-a6e9-0638d4648537
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4441,10 +4514,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/acbd6426-6e87-4d31-a8d1-9dbe8628ac62
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/269fbc40-435e-442e-9795-272bc7053559
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"acbd6426-6e87-4d31-a8d1-9dbe8628ac62","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"269fbc40-435e-442e-9795-272bc7053559","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -4453,9 +4526,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:07 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4463,7 +4536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51210f41-44b2-4682-8e13-c73e40fe32db
+      - d67d4925-0931-46b3-b51d-6a5257711f12
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4474,10 +4547,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/26746f64-05c8-4f2a-8ac9-ea12eda1aa37
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6f90dd97-31e1-4c23-97b7-7b7f044178bf
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"26746f64-05c8-4f2a-8ac9-ea12eda1aa37","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"6f90dd97-31e1-4c23-97b7-7b7f044178bf","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -4486,9 +4559,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:07 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4496,7 +4569,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88963193-6e98-4c8c-82a9-41a932fa9975
+      - 1cb278b8-9e39-49ea-b3f3-99061568213d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4507,10 +4580,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4e107064-6cf3-4f3b-a511-ecb1fdcaf850
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3baccc3f-7b29-47c1-abd1-34fee7c923d5
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"4e107064-6cf3-4f3b-a511-ecb1fdcaf850","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"3baccc3f-7b29-47c1-abd1-34fee7c923d5","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -4519,9 +4592,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:07 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4529,7 +4602,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - de7d4dad-0b74-420b-a482-359850cfe355
+      - 86d2e07d-ab6a-4208-b057-a03e1e116d5f
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-image-server-with-local-volume.cassette.yaml
+++ b/scaleway/testdata/instance-image-server-with-local-volume.cassette.yaml
@@ -11,18 +11,18 @@ interactions:
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"492d66d3-b14d-46d3-80c6-3945d5b61b21","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2f1f7a57-c508-4f72-9f7f-536b316f36e1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"5d083890-4354-47ab-b769-8b0de601eb3a","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1183"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:17 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -30,7 +30,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ac60032-1e67-44a8-b77c-05727e85bb1f
+      - bf140cd6-399d-4ff8-9e0e-b9d9ee4de876
     status: 200 OK
     code: 200
     duration: ""
@@ -53,12 +53,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:17 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -66,7 +66,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a05e3912-c1b4-4895-8c51-c7c647fe1db1
+      - f6d0ef2c-4852-465f-ae3a-446c10e836be
       X-Total-Count:
       - "61"
     status: 200 OK
@@ -91,12 +91,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:17 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -104,14 +104,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69ccff51-c95f-405c-8c2a-df6d1cca93be
+      - f5843362-dd45-4283-bdc5-28c48b2e65fe
       X-Total-Count:
       - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-crazy-panini","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","volumes":{"0":{"boot":false,"size":15000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-srv-eager-babbage","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5d083890-4354-47ab-b769-8b0de601eb3a","volumes":{"0":{"boot":false,"size":15000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -124,24 +124,24 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:18.048917+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:18.048917+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:02.666702+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:02.666702+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2639"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:18 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -149,7 +149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdc25a4f-842f-48c4-9872-3db2ec01c227
+      - 919b5877-0b56-44f6-be80-954f0ab30939
     status: 201 Created
     code: 201
     duration: ""
@@ -160,27 +160,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:18.048917+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:18.048917+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:02.666702+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:02.666702+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2639"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:18 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -188,7 +188,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 552edfc5-5c7f-4a64-99b4-e106c4467c6c
+      - 99db7aff-90ea-419d-868a-96c1b9f21a6c
     status: 200 OK
     code: 200
     duration: ""
@@ -199,27 +199,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:18.048917+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:18.048917+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:02.666702+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:02.666702+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2639"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:18 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -227,7 +227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1b830ce-6ff8-4cfb-b816-5a70181f1be7
+      - 85cc37d1-47ec-45c0-87c5-4c7c05a7ec41
     status: 200 OK
     code: 200
     duration: ""
@@ -240,10 +240,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/action","href_result":"/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096","id":"6bce2992-44c8-41e9-a72f-b9dd6f8dcdf0","started_at":"2023-12-05T10:57:19.127219+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/action","href_result":"/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381","id":"a02c91f7-2430-4c85-b25f-80468a993f50","started_at":"2024-02-22T07:32:03.811082+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -252,11 +252,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:19 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6bce2992-44c8-41e9-a72f-b9dd6f8dcdf0
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/a02c91f7-2430-4c85-b25f-80468a993f50
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -264,7 +264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df4ae9e1-05fb-42c8-96cc-40048d522564
+      - 0ef40437-09d1-4ef7-b4cd-b3ce67a8e4ad
     status: 202 Accepted
     code: 202
     duration: ""
@@ -275,27 +275,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:18.974109+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:18.048917+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:03.579646+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:02.666702+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2661"
+      - "2686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:19 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -303,7 +303,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a0f914b-a47c-49b6-acf9-1b3f843ea751
+      - 3ef935e1-beac-4708-ab8c-0135423695fc
     status: 200 OK
     code: 200
     duration: ""
@@ -314,27 +314,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:18.974109+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:18.048917+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:03.579646+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:02.666702+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2769"
+      - "2686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:24 GMT
+      - Thu, 22 Feb 2024 07:32:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -342,7 +342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 094382fd-302c-411c-80a9-1fcc7e92137e
+      - e36b1add-2922-4c49-8f82-10a9c8192a9e
     status: 200 OK
     code: 200
     duration: ""
@@ -353,27 +353,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:18.974109+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:18.048917+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:03.579646+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:02.666702+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2769"
+      - "2686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:29 GMT
+      - Thu, 22 Feb 2024 07:32:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -381,7 +381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ebd971a-2091-4482-807b-0d4ca49703c1
+      - 3fd3f1dc-af34-4918-9a0d-db9cf0603d8c
     status: 200 OK
     code: 200
     duration: ""
@@ -392,27 +392,144 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:03.579646+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:02.666702+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2686"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:19 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - af6c3ceb-d954-4499-9faf-95f0d8bfbfdd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:03.579646+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:02.666702+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2795"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:24 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1be26688-6162-40d1-9d85-009dfe4c6bbe
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:03.579646+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:02.666702+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2795"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3e45cf0b-8d55-47e2-9d74-e6b025770078
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:33.734255+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:18.048917+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:33.179231+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:02.666702+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2800"
+      - "2826"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:35 GMT
+      - Thu, 22 Feb 2024 07:32:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -420,7 +537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2d8c1ac-a589-4368-8406-26cc461be611
+      - 3ad9753b-941e-44f9-93ec-a6d5f761ee37
     status: 200 OK
     code: 200
     duration: ""
@@ -431,27 +548,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:33.734255+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:18.048917+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:33.179231+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:02.666702+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2800"
+      - "2826"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:35 GMT
+      - Thu, 22 Feb 2024 07:32:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -459,7 +576,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9a6f9e0-b439-467e-b05d-325bbf325d10
+      - ebc83900-11fa-4912-bee8-9b5dd8f86628
     status: 200 OK
     code: 200
     duration: ""
@@ -470,7 +587,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -482,9 +599,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:35 GMT
+      - Thu, 22 Feb 2024 07:32:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -492,7 +609,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 710484d8-9d28-44ff-86ac-a4d2fdaa5c20
+      - c5b59726-7796-46cc-9e50-ea13ad267800
     status: 200 OK
     code: 200
     duration: ""
@@ -503,7 +620,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -515,12 +632,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:35 GMT
+      - Thu, 22 Feb 2024 07:32:35 GMT
       Link:
-      - </servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/private_nics?page=0&per_page=50&>;
+      - </servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -528,14 +645,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3690a54-c7a9-4077-a850-f41fbdd1aa8f
+      - ac2e920d-b977-460c-b476-9a5cf7979133
       X-Total-Count:
       - "0"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-snap-dazzling-moore","volume_id":"0d704327-abfa-45d9-877e-9a551b76428e","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-snap-hopeful-heisenberg","volume_id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -546,19 +663,19 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:35.677063+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_9c4aab65-5dc9-459e-8477-de3925c432ef","href_from":"/snapshots","href_result":"snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef","id":"beef391e-62b0-4471-b8a3-f1d5c3ca173c","started_at":"2023-12-05T10:57:35.956824+00:00","status":"pending","terminated_at":null}}'
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:36.058170+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","href_from":"/snapshots","href_result":"snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","id":"44ee02fd-2e69-4e09-a9fc-de1abab62096","started_at":"2024-02-22T07:32:36.463013+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
-      - "841"
+      - "845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:36 GMT
+      - Thu, 22 Feb 2024 07:32:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -566,7 +683,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1df36b3-e33f-4715-9f3f-dfd74bb15655
+      - b9e01c5d-c7c0-472d-84a2-abf5b87ccfd7
     status: 201 Created
     code: 201
     duration: ""
@@ -577,22 +694,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:35.677063+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:36.058170+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "535"
+      - "539"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:36 GMT
+      - Thu, 22 Feb 2024 07:32:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -600,7 +717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec8d6143-c397-4235-9356-3d7f1c03858f
+      - 1abeb251-2ea3-43d3-9505-f559b7cf9f3a
     status: 200 OK
     code: 200
     duration: ""
@@ -611,22 +728,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:35.677063+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:36.058170+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "535"
+      - "539"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:41 GMT
+      - Thu, 22 Feb 2024 07:32:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -634,7 +751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 278ef5d6-5f11-4d0f-a85f-03a32540eabe
+      - c3e63144-a61d-43ed-a951-2a5cb5ec3d58
     status: 200 OK
     code: 200
     duration: ""
@@ -645,22 +762,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:35.677063+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:36.058170+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "535"
+      - "539"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:46 GMT
+      - Thu, 22 Feb 2024 07:32:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -668,7 +785,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5488334-0da3-443c-8a76-7d08e99b6a99
+      - 3685155e-c61b-4ba3-aa6a-53faad9c2121
     status: 200 OK
     code: 200
     duration: ""
@@ -679,22 +796,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:35.677063+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:36.058170+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "535"
+      - "539"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:51 GMT
+      - Thu, 22 Feb 2024 07:32:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -702,7 +819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 812c5263-7b26-48e2-8d2a-7e88d3a505af
+      - 7b080284-2235-47c1-a001-c4e15654ab26
     status: 200 OK
     code: 200
     duration: ""
@@ -713,22 +830,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "532"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:56 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -736,7 +853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b336ad22-0b43-480e-bf4d-ea65fb538c91
+      - 961e4e7f-c68c-4767-818f-c4490bac8002
     status: 200 OK
     code: 200
     duration: ""
@@ -747,22 +864,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "532"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:56 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -770,7 +887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0bcd35c9-757b-4de8-abc4-cdbc28daec38
+      - 61a99aec-9325-4039-83c9-ffcad810e71c
     status: 200 OK
     code: 200
     duration: ""
@@ -781,100 +898,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:33.734255+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2792"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:57:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 880d6982-f3c4-4de1-b17f-e3b0cb44d1b8
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "532"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:57:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cc6afe3b-e4c1-49c0-853b-73158d14a339
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:33.734255+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:33.179231+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2792"
+      - "2818"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:58 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -882,7 +926,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c65167c3-3b54-490c-a79f-de80bea5fce4
+      - 1fb4b818-4f08-43bb-a232-d62d7f48eab3
     status: 200 OK
     code: 200
     duration: ""
@@ -893,7 +937,80 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "536"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b5f5030e-dfcd-40fe-bb69-f3d44673f4a5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:33.179231+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2818"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e937ee67-0a3b-457d-ad6d-28f0b027dc08
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -905,9 +1022,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:58 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -915,7 +1032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53596428-0a69-4e73-ab28-2d24d30dba61
+      - 6002ad72-3add-4670-8460-676317844d20
     status: 200 OK
     code: 200
     duration: ""
@@ -926,7 +1043,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -938,12 +1055,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:58 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Link:
-      - </servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/private_nics?page=0&per_page=50&>;
+      - </servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -951,7 +1068,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 95f79516-1964-4f9e-bf94-43ecfc7888e3
+      - b0a34229-986e-4ba9-a37b-7df85a073f87
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -964,22 +1081,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "532"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:58 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -987,7 +1104,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48cd0de7-27bb-4bf5-8228-32ead7b4a6f5
+      - e56f37f4-81a3-425d-b9d6-b354ed5f1fb1
     status: 200 OK
     code: 200
     duration: ""
@@ -998,27 +1115,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:33.734255+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:33.179231+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2792"
+      - "2818"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:00 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1026,7 +1143,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b484e25-8d67-43b7-b753-3b7c353daf5a
+      - 316cd88c-277d-43b5-ba51-33a974bf219f
     status: 200 OK
     code: 200
     duration: ""
@@ -1037,7 +1154,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1049,9 +1166,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:00 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1059,7 +1176,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7df9f53c-6878-4ecd-b152-60a5277aa992
+      - 479a1ee0-9ced-40e0-bdec-bab5f22f852f
     status: 200 OK
     code: 200
     duration: ""
@@ -1070,7 +1187,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1082,12 +1199,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:00 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Link:
-      - </servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/private_nics?page=0&per_page=50&>;
+      - </servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1095,7 +1212,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 570eed3e-0b96-4d60-8e5d-34424e33c2ec
+      - a7acf457-1131-452a-b755-954e89007350
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1108,22 +1225,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "532"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:00 GMT
+      - Thu, 22 Feb 2024 07:32:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1131,7 +1248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8508e91e-06a8-414c-a3a6-b6973170f215
+      - 31c7729d-7e5b-48cb-9881-ac65fbeb9ec0
     status: 200 OK
     code: 200
     duration: ""
@@ -1145,18 +1262,18 @@ interactions:
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"492d66d3-b14d-46d3-80c6-3945d5b61b21","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2f1f7a57-c508-4f72-9f7f-536b316f36e1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"5d083890-4354-47ab-b769-8b0de601eb3a","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1183"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:02 GMT
+      - Thu, 22 Feb 2024 07:32:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1164,7 +1281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 327f4ff4-21b8-4641-a929-3eb03d76debb
+      - 004930ac-115c-408b-9853-51c3485faba9
     status: 200 OK
     code: 200
     duration: ""
@@ -1187,12 +1304,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:03 GMT
+      - Thu, 22 Feb 2024 07:32:59 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1200,7 +1317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8204fd65-3053-493d-a104-a09ede6d2b6e
+      - eb4f22e8-37e9-4709-8082-a59b24e18572
       X-Total-Count:
       - "61"
     status: 200 OK
@@ -1225,12 +1342,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:03 GMT
+      - Thu, 22 Feb 2024 07:32:59 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1238,14 +1355,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80452b96-cf2e-450b-bc53-43c789f9e15e
+      - fadabf8d-469c-4a93-898b-0c1e80f0b7c3
       X-Total-Count:
       - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-loving-satoshi","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","volumes":{"0":{"boot":false,"size":10000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-srv-happy-poitras","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5d083890-4354-47ab-b769-8b0de601eb3a","volumes":{"0":{"boot":false,"size":10000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -1258,24 +1375,24 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:03.531577+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:03.531577+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:32:59.845577+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:32:59.845577+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2645"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:04 GMT
+      - Thu, 22 Feb 2024 07:33:00 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1283,7 +1400,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5a882fd-4262-4352-855b-abc820dc880b
+      - 55688d2a-e878-4a1a-85a3-45dbeadbf27b
     status: 201 Created
     code: 201
     duration: ""
@@ -1294,27 +1411,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:03.531577+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:03.531577+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:32:59.845577+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:32:59.845577+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2645"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:04 GMT
+      - Thu, 22 Feb 2024 07:33:00 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1322,7 +1439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3025fd04-503e-4631-98f9-6198939469ac
+      - d2fe5a47-2e95-4dd5-94c2-44cd69a81c35
     status: 200 OK
     code: 200
     duration: ""
@@ -1333,27 +1450,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:03.531577+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:03.531577+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:32:59.845577+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:32:59.845577+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2645"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:04 GMT
+      - Thu, 22 Feb 2024 07:33:00 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1361,7 +1478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02902494-6837-4625-9cb7-3e9d563c8b5a
+      - 34568e59-5e4d-4251-939a-19971ebaee8c
     status: 200 OK
     code: 200
     duration: ""
@@ -1374,10 +1491,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/action","href_result":"/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b","id":"f453346e-54a8-46ac-a449-de3d62ab4a06","started_at":"2023-12-05T10:58:04.436256+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/action","href_result":"/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda","id":"5b6214f2-b153-48b9-978e-38a0f2619ac0","started_at":"2024-02-22T07:33:00.730698+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -1386,11 +1503,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:04 GMT
+      - Thu, 22 Feb 2024 07:33:00 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/f453346e-54a8-46ac-a449-de3d62ab4a06
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/5b6214f2-b153-48b9-978e-38a0f2619ac0
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1398,7 +1515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a58fdc0-0059-45a0-8bb6-0b0a2e8a19f7
+      - a096e8d8-3e6e-4c3f-837b-52328f5b7c03
     status: 202 Accepted
     code: 202
     duration: ""
@@ -1409,27 +1526,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:04.279223+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:03.531577+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:00.602246+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:32:59.845577+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2667"
+      - "2686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:04 GMT
+      - Thu, 22 Feb 2024 07:33:01 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1437,7 +1554,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac516c51-e271-4d55-b0d5-ae8370f6b4ec
+      - 2dd88857-b8a9-4ff0-917c-6202ce99939f
     status: 200 OK
     code: 200
     duration: ""
@@ -1448,27 +1565,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:04.279223+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:03.531577+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:00.602246+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:32:59.845577+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2776"
+      - "2795"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:09 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1476,7 +1593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7184c9da-8faf-4828-b765-91292af51cde
+      - 3dcab5d4-7020-4123-9b3d-dff1c8988937
     status: 200 OK
     code: 200
     duration: ""
@@ -1487,27 +1604,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:04.279223+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:03.531577+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:00.602246+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:32:59.845577+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2776"
+      - "2795"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:15 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1515,7 +1632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a64b0c5c-4124-4035-86a0-770d68cf46a5
+      - ef0fa052-1a1e-43aa-861d-bc7d60344f12
     status: 200 OK
     code: 200
     duration: ""
@@ -1526,66 +1643,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:04.279223+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:03.531577+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2776"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:20 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0919d381-e4db-4751-926d-ca2971535594
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:21.900222+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:03.531577+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:12.589310+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:32:59.845577+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2807"
+      - "2826"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:25 GMT
+      - Thu, 22 Feb 2024 07:33:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1593,7 +1671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fbd0b13-65b6-4fe5-b5ad-4bbe86cf93bc
+      - 1992ee4e-be43-4011-862d-c3e28c762ab7
     status: 200 OK
     code: 200
     duration: ""
@@ -1604,27 +1682,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:21.900222+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:03.531577+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:12.589310+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:32:59.845577+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2807"
+      - "2826"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:25 GMT
+      - Thu, 22 Feb 2024 07:33:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1632,7 +1710,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e99a972a-9eda-4b7a-ac80-d2baa02881dc
+      - 114fd656-d39d-44e2-b732-9bca36c7a843
     status: 200 OK
     code: 200
     duration: ""
@@ -1643,7 +1721,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1655,9 +1733,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:25 GMT
+      - Thu, 22 Feb 2024 07:33:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1665,7 +1743,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c678027-e53d-4333-a691-e919184d94c9
+      - 6c903003-806a-47dd-92f4-3162ce6160eb
     status: 200 OK
     code: 200
     duration: ""
@@ -1676,7 +1754,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1688,12 +1766,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:25 GMT
+      - Thu, 22 Feb 2024 07:33:17 GMT
       Link:
-      - </servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/private_nics?page=0&per_page=50&>;
+      - </servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1701,14 +1779,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60bab739-9576-4fc3-bf75-8c2fd0a60a8f
+      - 6e862725-d593-4b81-baf2-bed0382126b5
       X-Total-Count:
       - "0"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-snap-laughing-goldwasser","volume_id":"be1064c6-4b60-4504-97de-33288701d5cd","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-snap-infallible-jackson","volume_id":"2a9a05ad-b2c6-420f-a623-cd310972500d","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -1719,19 +1797,19 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot":{"base_volume":{"id":"be1064c6-4b60-4504-97de-33288701d5cd","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:58:26.176900+00:00","error_details":null,"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","modification_date":"2023-12-05T10:58:26.176900+00:00","name":"tf-snap-laughing-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","href_from":"/snapshots","href_result":"snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","id":"e9b083ac-b031-431c-b41f-c88c167241f9","started_at":"2023-12-05T10:58:26.455226+00:00","status":"pending","terminated_at":null}}'
+    body: '{"snapshot":{"base_volume":{"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:33:17.207036+00:00","error_details":null,"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","modification_date":"2024-02-22T07:33:17.207036+00:00","name":"tf-snap-infallible-jackson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_acc92b70-a228-494a-bd8d-14ce43c3a05b","href_from":"/snapshots","href_result":"snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b","id":"987e546a-bb6e-46ed-a7c5-0711554cab87","started_at":"2024-02-22T07:33:17.799649+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
-      - "846"
+      - "845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:26 GMT
+      - Thu, 22 Feb 2024 07:33:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1739,7 +1817,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00caae7c-de20-4651-96ce-24aa8c2340a6
+      - 8d434168-c7b1-4fee-a699-77e20e9a82a0
     status: 201 Created
     code: 201
     duration: ""
@@ -1750,22 +1828,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"be1064c6-4b60-4504-97de-33288701d5cd","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:58:26.176900+00:00","error_details":null,"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","modification_date":"2023-12-05T10:58:26.176900+00:00","name":"tf-snap-laughing-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:33:17.207036+00:00","error_details":null,"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","modification_date":"2024-02-22T07:33:17.207036+00:00","name":"tf-snap-infallible-jackson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "540"
+      - "539"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:26 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1773,7 +1851,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d755fd10-c999-4f28-abbe-9855c7007dd6
+      - faba1e68-6b19-4cba-b52b-7c23148410dc
     status: 200 OK
     code: 200
     duration: ""
@@ -1784,22 +1862,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"be1064c6-4b60-4504-97de-33288701d5cd","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:58:26.176900+00:00","error_details":null,"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","modification_date":"2023-12-05T10:58:26.176900+00:00","name":"tf-snap-laughing-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:33:17.207036+00:00","error_details":null,"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","modification_date":"2024-02-22T07:33:17.207036+00:00","name":"tf-snap-infallible-jackson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "540"
+      - "539"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:31 GMT
+      - Thu, 22 Feb 2024 07:33:23 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1807,7 +1885,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0171d565-acb2-424f-9020-7b4461301a74
+      - 9f9290d3-8447-42f2-8e8a-af9a929bf75b
     status: 200 OK
     code: 200
     duration: ""
@@ -1818,22 +1896,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"be1064c6-4b60-4504-97de-33288701d5cd","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:58:26.176900+00:00","error_details":null,"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","modification_date":"2023-12-05T10:58:26.176900+00:00","name":"tf-snap-laughing-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:33:17.207036+00:00","error_details":null,"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","modification_date":"2024-02-22T07:33:17.207036+00:00","name":"tf-snap-infallible-jackson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "540"
+      - "539"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:36 GMT
+      - Thu, 22 Feb 2024 07:33:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1841,7 +1919,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64c2062d-e20d-4e18-8a5d-b555358c6a15
+      - 60feb768-de3d-47c4-9b33-d29c5cdbd857
     status: 200 OK
     code: 200
     duration: ""
@@ -1852,22 +1930,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"be1064c6-4b60-4504-97de-33288701d5cd","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:58:26.176900+00:00","error_details":null,"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","modification_date":"2023-12-05T10:58:26.176900+00:00","name":"tf-snap-laughing-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:33:17.207036+00:00","error_details":null,"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","modification_date":"2024-02-22T07:33:17.207036+00:00","name":"tf-snap-infallible-jackson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "540"
+      - "539"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:42 GMT
+      - Thu, 22 Feb 2024 07:33:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1875,7 +1953,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d562323-7fdd-471e-8bd3-341ba97aa243
+      - c922fb6c-2c69-4135-9f75-7fb98789cb4f
     status: 200 OK
     code: 200
     duration: ""
@@ -1886,22 +1964,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"be1064c6-4b60-4504-97de-33288701d5cd","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:58:26.176900+00:00","error_details":null,"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"tf-snap-laughing-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:33:17.207036+00:00","error_details":null,"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"tf-snap-infallible-jackson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "537"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:47 GMT
+      - Thu, 22 Feb 2024 07:33:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1909,7 +1987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91b09ba8-7ff4-426b-a3e6-5a56794a676e
+      - fc1e5e2a-7730-4607-b9d3-261a1889b00b
     status: 200 OK
     code: 200
     duration: ""
@@ -1920,22 +1998,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"be1064c6-4b60-4504-97de-33288701d5cd","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:58:26.176900+00:00","error_details":null,"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"tf-snap-laughing-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:33:17.207036+00:00","error_details":null,"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"tf-snap-infallible-jackson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "537"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:47 GMT
+      - Thu, 22 Feb 2024 07:33:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1943,7 +2021,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f477fd0e-822b-4892-a304-9f8a876d6293
+      - f1736d48-5292-4ec6-a580-b0fe7f6ab18f
     status: 200 OK
     code: 200
     duration: ""
@@ -1954,66 +2032,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:33.734255+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2792"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4dab1cd1-43a3-402e-a38c-f1d172cf64b9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:21.900222+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:33.179231+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2807"
+      - "2818"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:47 GMT
+      - Thu, 22 Feb 2024 07:33:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2021,7 +2060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6468073-fd3a-4ae3-ac14-a96b14312316
+      - 17dd32b4-e71d-4f06-ae6b-0504fcd4b7f7
     status: 200 OK
     code: 200
     duration: ""
@@ -2032,95 +2071,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "532"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 40a8fb1a-d92d-4fbf-96e3-cad08dc6549b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"be1064c6-4b60-4504-97de-33288701d5cd","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:58:26.176900+00:00","error_details":null,"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"tf-snap-laughing-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "537"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 14c00f19-8b20-4ac1-9853-bfa2775d241a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:33.734255+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:12.589310+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2792"
+      - "2818"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:49 GMT
+      - Thu, 22 Feb 2024 07:33:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2128,7 +2099,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e651b93-b3f1-4a20-9274-6371945008a3
+      - 7c20a075-a8c8-428e-8421-ff0437c85ad8
     status: 200 OK
     code: 200
     duration: ""
@@ -2139,27 +2110,95 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "536"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:39 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 97229cde-26ee-4929-af54-618869acab7e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:33:17.207036+00:00","error_details":null,"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"tf-snap-infallible-jackson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "536"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:39 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 02449161-9fe8-46f6-98ea-93bbc9e59882
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:21.900222+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:33.179231+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2807"
+      - "2818"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:49 GMT
+      - Thu, 22 Feb 2024 07:33:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2167,7 +2206,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f6f2441-a47d-43fa-b676-aac7290e7036
+      - cce8953a-27d1-4eff-9faa-ca14155118ff
     status: 200 OK
     code: 200
     duration: ""
@@ -2178,7 +2217,46 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:12.589310+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2818"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:39 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b0d72d43-4f54-4cc4-aca8-356d9749a007
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2190,9 +2268,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:49 GMT
+      - Thu, 22 Feb 2024 07:33:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2200,7 +2278,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae437528-e7dd-4819-9a38-c423e41db287
+      - 18f2bc68-4769-4f7c-871e-98cdea01701d
     status: 200 OK
     code: 200
     duration: ""
@@ -2211,7 +2289,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2223,9 +2301,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:49 GMT
+      - Thu, 22 Feb 2024 07:33:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2233,7 +2311,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10929ae6-f705-4320-b164-e22aa5775322
+      - 02a20518-8b6c-4e67-9955-0e94ecb2dfc0
     status: 200 OK
     code: 200
     duration: ""
@@ -2244,7 +2322,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -2256,12 +2334,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:49 GMT
+      - Thu, 22 Feb 2024 07:33:39 GMT
       Link:
-      - </servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/private_nics?page=0&per_page=50&>;
+      - </servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2269,7 +2347,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13c795b8-c5b3-4dfa-a045-a2ce96289fea
+      - 59d37a5a-9d4f-4a53-8b03-dc38512eaeb4
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -2282,7 +2360,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -2294,12 +2372,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:49 GMT
+      - Thu, 22 Feb 2024 07:33:39 GMT
       Link:
-      - </servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/private_nics?page=0&per_page=50&>;
+      - </servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2307,7 +2385,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c89c4d2-e83e-4c43-8bc9-4c2bd80441f2
+      - 852a27ba-876b-409e-9709-a9932867d064
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -2320,22 +2398,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "532"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:49 GMT
+      - Thu, 22 Feb 2024 07:33:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2343,7 +2421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d18cbb73-4de8-4303-860c-99829ab367f2
+      - 9e45aaf0-aca0-497a-9cd5-4e3be6c0828f
     status: 200 OK
     code: 200
     duration: ""
@@ -2354,22 +2432,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"be1064c6-4b60-4504-97de-33288701d5cd","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:58:26.176900+00:00","error_details":null,"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"tf-snap-laughing-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:33:17.207036+00:00","error_details":null,"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"tf-snap-infallible-jackson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "537"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:49 GMT
+      - Thu, 22 Feb 2024 07:33:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2377,7 +2455,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 030b533c-11b9-4b57-9679-cd257e4a4662
+      - 28f056f0-cf8f-42dc-a075-bc25039cabfc
     status: 200 OK
     code: 200
     duration: ""
@@ -2388,27 +2466,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:21.900222+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:33.179231+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2807"
+      - "2818"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:51 GMT
+      - Thu, 22 Feb 2024 07:33:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2416,7 +2494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc3d7802-f511-4b5b-9605-61a1bbdfd0be
+      - 39040aaa-8a7a-4a29-84a6-789694bd0e79
     status: 200 OK
     code: 200
     duration: ""
@@ -2427,7 +2505,46 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:12.589310+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2818"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:40 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 80ce406b-4bdc-43fd-9dcf-0e590d671612
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2439,9 +2556,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:52 GMT
+      - Thu, 22 Feb 2024 07:33:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2449,7 +2566,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4c45d27-8617-4538-af90-e4a3412a4186
+      - 57693040-62aa-4fc9-ae99-cf9ec71201e9
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,118 +2577,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/private_nics
-    method: GET
-  response:
-    body: '{"private_nics":[]}'
-    headers:
-      Content-Length:
-      - "20"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:52 GMT
-      Link:
-      - </servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/private_nics?page=0&per_page=50&>;
-        rel="last"
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fa816ba2-31e5-416c-8cc9-c0feac03a20e
-      X-Total-Count:
-      - "0"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"be1064c6-4b60-4504-97de-33288701d5cd","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:58:26.176900+00:00","error_details":null,"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"tf-snap-laughing-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "537"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e5b95bf2-4e88-4ee1-bf7a-02c35e26dc0f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:33.734255+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2792"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2e7a8670-0148-4b17-aed3-b6153df98587
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2583,9 +2589,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:52 GMT
+      - Thu, 22 Feb 2024 07:33:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2593,7 +2599,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 055f4248-76d0-480b-82a8-23e18507d9cf
+      - 7b633fab-ee31-4385-b2e0-086389c89343
     status: 200 OK
     code: 200
     duration: ""
@@ -2604,7 +2610,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -2616,12 +2622,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:52 GMT
+      - Thu, 22 Feb 2024 07:33:40 GMT
       Link:
-      - </servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/private_nics?page=0&per_page=50&>;
+      - </servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2629,7 +2635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6332ef81-b66c-462e-9b6f-7c52b8d5b41c
+      - 7c67e6b4-8a1e-413f-b948-cd1f709402f6
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -2642,22 +2648,24 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/private_nics
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"private_nics":[]}'
     headers:
       Content-Length:
-      - "532"
+      - "20"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:52 GMT
+      - Thu, 22 Feb 2024 07:33:40 GMT
+      Link:
+      - </servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/private_nics?page=0&per_page=50&>;
+        rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2665,7 +2673,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18c73809-3044-498d-a1eb-05c83dd73e01
+      - 5c3c38af-2e8d-4a04-9a81-397cf182f107
+      X-Total-Count:
+      - "0"
     status: 200 OK
     code: 200
     duration: ""
@@ -2676,22 +2686,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"be1064c6-4b60-4504-97de-33288701d5cd","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:58:26.176900+00:00","error_details":null,"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"tf-snap-laughing-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:33:17.207036+00:00","error_details":null,"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"tf-snap-infallible-jackson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "537"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:55 GMT
+      - Thu, 22 Feb 2024 07:33:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2699,12 +2709,80 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0fd4d23-6389-40b7-aa58-ed62bd88a24f
+      - e3db4f1d-19e5-48e6-904e-3af6343d8e0c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-image-trusting-poitras","root_volume":"9c4aab65-5dc9-459e-8477-de3925c432ef","arch":"x86_64","extra_volumes":{"1":{"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","name":"Ubuntu
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "536"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:40 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 737d7181-f7fb-4dce-9889-ceb434a81c58
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:33:17.207036+00:00","error_details":null,"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"tf-snap-infallible-jackson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "536"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:41 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 30186752-6f05-48ed-a251-1e47c4f5f63c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-image-competent-morse","root_volume":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","arch":"x86_64","extra_volumes":{"1":{"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","name":"Ubuntu
       20.04 Focal Fossa","size":10000000000,"volume_type":"l_ssd"}},"project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false}'
     form: {}
     headers:
@@ -2716,20 +2794,20 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
     method: POST
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:55.309004+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","name":"tf-snap-laughing-goldwasser","size":10000000000,"volume_type":"l_ssd"}},"from_server":null,"id":"da69ba55-9ae3-4e6a-9282-43735cf60235","modification_date":"2023-12-05T10:58:55.309004+00:00","name":"tf-image-trusting-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","name":"tf-snap-dazzling-moore","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:33:41.496663+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","name":"tf-snap-infallible-jackson","size":10000000000,"volume_type":"l_ssd"}},"from_server":null,"id":"92b374f9-678c-483c-9aea-7266fc0bf4ad","modification_date":"2024-02-22T07:33:41.496663+00:00","name":"tf-image-competent-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","name":"tf-snap-hopeful-heisenberg","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "747"
+      - "749"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:55 GMT
+      - Thu, 22 Feb 2024 07:33:41 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/da69ba55-9ae3-4e6a-9282-43735cf60235
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/92b374f9-678c-483c-9aea-7266fc0bf4ad
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2737,7 +2815,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78b9e7f4-2287-48e8-a535-9a9472725bfc
+      - 10e979d9-b4ca-4d9b-90bd-73bac0c2fde6
     status: 201 Created
     code: 201
     duration: ""
@@ -2748,21 +2826,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/da69ba55-9ae3-4e6a-9282-43735cf60235
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/92b374f9-678c-483c-9aea-7266fc0bf4ad
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:55.309004+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","name":"tf-snap-laughing-goldwasser","size":10000000000,"volume_type":"l_ssd"}},"from_server":null,"id":"da69ba55-9ae3-4e6a-9282-43735cf60235","modification_date":"2023-12-05T10:58:55.309004+00:00","name":"tf-image-trusting-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","name":"tf-snap-dazzling-moore","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:33:41.496663+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","name":"tf-snap-infallible-jackson","size":10000000000,"volume_type":"l_ssd"}},"from_server":null,"id":"92b374f9-678c-483c-9aea-7266fc0bf4ad","modification_date":"2024-02-22T07:33:41.496663+00:00","name":"tf-image-competent-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","name":"tf-snap-hopeful-heisenberg","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "747"
+      - "749"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:55 GMT
+      - Thu, 22 Feb 2024 07:33:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2770,7 +2848,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c85b84a-8474-437e-864c-f9b0134de1d9
+      - b5bb5d8b-a2d7-4f95-ab4c-5210f87d6e39
     status: 200 OK
     code: 200
     duration: ""
@@ -2781,21 +2859,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/da69ba55-9ae3-4e6a-9282-43735cf60235
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/92b374f9-678c-483c-9aea-7266fc0bf4ad
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:55.309004+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","name":"tf-snap-laughing-goldwasser","size":10000000000,"volume_type":"l_ssd"}},"from_server":null,"id":"da69ba55-9ae3-4e6a-9282-43735cf60235","modification_date":"2023-12-05T10:58:55.309004+00:00","name":"tf-image-trusting-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","name":"tf-snap-dazzling-moore","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:33:41.496663+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","name":"tf-snap-infallible-jackson","size":10000000000,"volume_type":"l_ssd"}},"from_server":null,"id":"92b374f9-678c-483c-9aea-7266fc0bf4ad","modification_date":"2024-02-22T07:33:41.496663+00:00","name":"tf-image-competent-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","name":"tf-snap-hopeful-heisenberg","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "747"
+      - "749"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:55 GMT
+      - Thu, 22 Feb 2024 07:33:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2803,7 +2881,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea861c10-15b0-46e1-8d17-fd8a6d7e8954
+      - 020401ff-6cd8-460a-8523-653cb52ccfd9
     status: 200 OK
     code: 200
     duration: ""
@@ -2814,66 +2892,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:33.734255+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2792"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a86ccccb-1e2f-4db0-b57b-900d92ffb358
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:21.900222+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:33.179231+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2799"
+      - "2818"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:56 GMT
+      - Thu, 22 Feb 2024 07:33:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2881,7 +2920,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f159bad9-660f-472b-ac12-8566e126aed6
+      - e4c9f2a9-9d80-4ad1-a718-d14702f19b0d
     status: 200 OK
     code: 200
     duration: ""
@@ -2892,128 +2931,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "532"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 56c87554-609f-44ef-88b8-dae758265a26
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"be1064c6-4b60-4504-97de-33288701d5cd","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:58:26.176900+00:00","error_details":null,"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"tf-snap-laughing-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "537"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e4a0edf6-a9c3-4a27-ab0c-373407168c12
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/da69ba55-9ae3-4e6a-9282-43735cf60235
-    method: GET
-  response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:55.309004+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","name":"tf-snap-laughing-goldwasser","size":10000000000,"volume_type":"l_ssd"}},"from_server":null,"id":"da69ba55-9ae3-4e6a-9282-43735cf60235","modification_date":"2023-12-05T10:58:55.309004+00:00","name":"tf-image-trusting-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","name":"tf-snap-dazzling-moore","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "747"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 82316108-aa76-4973-a0cc-23ae4c57603c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:21.900222+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:12.589310+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2799"
+      - "2818"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:58 GMT
+      - Thu, 22 Feb 2024 07:33:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3021,7 +2959,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 945b1f30-a098-4b09-b418-b38538ad0b00
+      - 5bc6609c-cbf1-4b49-9df8-384f1e7805be
     status: 200 OK
     code: 200
     duration: ""
@@ -3032,27 +2970,128 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "536"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0872d75b-2c42-4777-9cd6-e42e1655e07c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:33:17.207036+00:00","error_details":null,"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"tf-snap-infallible-jackson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "536"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6aa37256-cd3b-488d-a1e7-3c91604431e0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/92b374f9-678c-483c-9aea-7266fc0bf4ad
+    method: GET
+  response:
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:33:41.496663+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","name":"tf-snap-infallible-jackson","size":10000000000,"volume_type":"l_ssd"}},"from_server":null,"id":"92b374f9-678c-483c-9aea-7266fc0bf4ad","modification_date":"2024-02-22T07:33:41.496663+00:00","name":"tf-image-competent-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","name":"tf-snap-hopeful-heisenberg","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "749"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8fdeca61-68c2-473b-a64e-8eca2a2f034c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:33.734255+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:33.179231+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2792"
+      - "2818"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:58 GMT
+      - Thu, 22 Feb 2024 07:33:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3060,7 +3099,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d65a7fc4-2a38-4c37-95c3-42eba48aa2c7
+      - b354dbff-8592-4016-b15d-4eeb43b92f9b
     status: 200 OK
     code: 200
     duration: ""
@@ -3071,7 +3110,46 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:12.589310+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2818"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 52965287-57b4-46e9-9cea-d7cb645ebcce
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -3083,9 +3161,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:58 GMT
+      - Thu, 22 Feb 2024 07:33:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3093,7 +3171,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82b97520-4c7f-46b9-b7a4-1b9d5800a069
+      - 55115e68-cfe0-4adb-ab6d-33f50f5e42ba
     status: 200 OK
     code: 200
     duration: ""
@@ -3104,7 +3182,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -3116,9 +3194,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:58 GMT
+      - Thu, 22 Feb 2024 07:33:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3126,7 +3204,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 458abe08-3f88-45da-8462-19c2a5d762b9
+      - 17412e30-a833-4b37-82a8-b5d0a0da8fd1
     status: 200 OK
     code: 200
     duration: ""
@@ -3137,7 +3215,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -3149,12 +3227,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:58 GMT
+      - Thu, 22 Feb 2024 07:33:43 GMT
       Link:
-      - </servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/private_nics?page=0&per_page=50&>;
+      - </servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3162,7 +3240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75287798-04d6-471e-aa77-6558b8a0f8e9
+      - 0fb178aa-9984-49a5-9fee-f5a691de70a7
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -3175,7 +3253,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -3187,12 +3265,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:58 GMT
+      - Thu, 22 Feb 2024 07:33:43 GMT
       Link:
-      - </servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/private_nics?page=0&per_page=50&>;
+      - </servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3200,7 +3278,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 30fea731-a8bc-45fc-984c-a5014c05daef
+      - 4f8a64c1-0de2-411c-91f4-4bdf6560520a
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -3213,22 +3291,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "532"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:59 GMT
+      - Thu, 22 Feb 2024 07:33:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3236,7 +3314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57481956-72c6-4b29-9606-edbbfdb03ee7
+      - 0457cefb-0768-46f7-8c38-c64f97b32d54
     status: 200 OK
     code: 200
     duration: ""
@@ -3247,22 +3325,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"be1064c6-4b60-4504-97de-33288701d5cd","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:58:26.176900+00:00","error_details":null,"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"tf-snap-laughing-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:33:17.207036+00:00","error_details":null,"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"tf-snap-infallible-jackson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "537"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:59 GMT
+      - Thu, 22 Feb 2024 07:33:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3270,7 +3348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1de1fa7e-faec-4831-8e22-c6d8ac958c19
+      - 2e5ba811-db59-473f-b55e-d1aeeb069e83
     status: 200 OK
     code: 200
     duration: ""
@@ -3281,21 +3359,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/da69ba55-9ae3-4e6a-9282-43735cf60235
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/92b374f9-678c-483c-9aea-7266fc0bf4ad
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:55.309004+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","name":"tf-snap-laughing-goldwasser","size":10000000000,"volume_type":"l_ssd"}},"from_server":null,"id":"da69ba55-9ae3-4e6a-9282-43735cf60235","modification_date":"2023-12-05T10:58:55.309004+00:00","name":"tf-image-trusting-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","name":"tf-snap-dazzling-moore","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:33:41.496663+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","name":"tf-snap-infallible-jackson","size":10000000000,"volume_type":"l_ssd"}},"from_server":null,"id":"92b374f9-678c-483c-9aea-7266fc0bf4ad","modification_date":"2024-02-22T07:33:41.496663+00:00","name":"tf-image-competent-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","name":"tf-snap-hopeful-heisenberg","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "747"
+      - "749"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:59 GMT
+      - Thu, 22 Feb 2024 07:33:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3303,7 +3381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f84023a7-8ae6-4429-b40d-faf91aaab108
+      - 05e7bbb9-8d96-4415-85d2-3cfde1f06e8f
     status: 200 OK
     code: 200
     duration: ""
@@ -3314,21 +3392,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/da69ba55-9ae3-4e6a-9282-43735cf60235
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/92b374f9-678c-483c-9aea-7266fc0bf4ad
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:55.309004+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","name":"tf-snap-laughing-goldwasser","size":10000000000,"volume_type":"l_ssd"}},"from_server":null,"id":"da69ba55-9ae3-4e6a-9282-43735cf60235","modification_date":"2023-12-05T10:58:55.309004+00:00","name":"tf-image-trusting-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","name":"tf-snap-dazzling-moore","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:33:41.496663+00:00","default_bootscript":null,"extra_volumes":{"1":{"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","name":"tf-snap-infallible-jackson","size":10000000000,"volume_type":"l_ssd"}},"from_server":null,"id":"92b374f9-678c-483c-9aea-7266fc0bf4ad","modification_date":"2024-02-22T07:33:41.496663+00:00","name":"tf-image-competent-morse","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","name":"tf-snap-hopeful-heisenberg","size":15000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "747"
+      - "749"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:02 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3336,7 +3414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f02dbf86-1ff6-4f1a-8517-0ca8ad3e4ecd
+      - 6ea5cdc0-c980-453e-b566-5268f33ad111
     status: 200 OK
     code: 200
     duration: ""
@@ -3347,7 +3425,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/da69ba55-9ae3-4e6a-9282-43735cf60235
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/92b374f9-678c-483c-9aea-7266fc0bf4ad
     method: DELETE
   response:
     body: ""
@@ -3355,9 +3433,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:59:02 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3365,7 +3443,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5cc33890-058f-4ed9-a845-841826138789
+      - a62f7953-0533-44ae-8b20-ea32367ace8a
     status: 204 No Content
     code: 204
     duration: ""
@@ -3376,10 +3454,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/da69ba55-9ae3-4e6a-9282-43735cf60235
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/92b374f9-678c-483c-9aea-7266fc0bf4ad
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_image","resource_id":"da69ba55-9ae3-4e6a-9282-43735cf60235","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_image","resource_id":"92b374f9-678c-483c-9aea-7266fc0bf4ad","type":"not_found"}'
     headers:
       Content-Length:
       - "142"
@@ -3388,9 +3466,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:03 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3398,7 +3476,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b230592b-eb05-4dfc-bdba-c39dd3a29376
+      - fe6957b0-42a4-4186-ac10-2eb383269390
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3409,22 +3487,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"be1064c6-4b60-4504-97de-33288701d5cd","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:58:26.176900+00:00","error_details":null,"id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"tf-snap-laughing-goldwasser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:36.058170+00:00","error_details":null,"id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"tf-snap-hopeful-heisenberg","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "537"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:03 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3432,7 +3510,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f02f40a1-742d-4903-b131-c56e1e6796f1
+      - d1c03a38-d4bc-44b5-ab02-62661cbc1155
     status: 200 OK
     code: 200
     duration: ""
@@ -3443,22 +3521,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0d704327-abfa-45d9-877e-9a551b76428e","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:35.677063+00:00","error_details":null,"id":"9c4aab65-5dc9-459e-8477-de3925c432ef","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"tf-snap-dazzling-moore","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:33:17.207036+00:00","error_details":null,"id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"tf-snap-infallible-jackson","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "532"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:03 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3466,7 +3544,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d306fff-422a-4d00-a4f9-4aee16765daf
+      - 603af927-c123-4c60-99d3-60d261df27a6
     status: 200 OK
     code: 200
     duration: ""
@@ -3477,7 +3555,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
     method: DELETE
   response:
     body: ""
@@ -3485,9 +3563,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:59:03 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3495,7 +3573,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b5aa5ed-d2a3-4959-a24a-80a48f133970
+      - 694dd237-97fb-4543-8c49-df6ab08f5cf5
     status: 204 No Content
     code: 204
     duration: ""
@@ -3506,40 +3584,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "145"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:59:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 53135257-a5a7-425e-a284-378531de83a7
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
     method: DELETE
   response:
     body: ""
@@ -3547,9 +3592,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:59:03 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3557,7 +3602,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4bb4a50-1489-4f0e-9472-66f359cf4867
+      - 054069f8-9f7d-4937-9a0f-be15245cc1fc
     status: 204 No Content
     code: 204
     duration: ""
@@ -3568,10 +3613,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"9c4aab65-5dc9-459e-8477-de3925c432ef","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","type":"not_found"}'
     headers:
       Content-Length:
       - "145"
@@ -3580,9 +3625,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:03 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3590,7 +3635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e58233db-2e48-48ca-89d4-ff6737eb3294
+      - a0514c82-fd70-43c1-b429-417e965d3ac3
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3601,27 +3646,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:58:21.900222+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","type":"not_found"}'
     headers:
       Content-Length:
-      - "2799"
+      - "145"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:03 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3629,7 +3668,46 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afc013a6-aab4-4fa1-8e93-7d7abd7d6c44
+      - 25747635-10d2-47d5-84a8-5abcadd0075e
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:12.589310+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2818"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f44e4936-710f-49d2-8373-c4fdb33bedf2
     status: 200 OK
     code: 200
     duration: ""
@@ -3640,27 +3718,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:57:33.734255+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:32:33.179231+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2792"
+      - "2818"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:03 GMT
+      - Thu, 22 Feb 2024 07:33:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3668,7 +3746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 785516d9-7d46-46ee-bd29-b17405daefe8
+      - 96345f6d-cd85-47ea-baf3-99f87761ff67
     status: 200 OK
     code: 200
     duration: ""
@@ -3681,10 +3759,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096/action","href_result":"/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096","id":"926f620a-12d1-4e4c-ae10-686d34b7e4de","started_at":"2023-12-05T10:59:03.598742+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381/action","href_result":"/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381","id":"d2d36f5e-4554-4600-b3c4-6313485acbc1","started_at":"2024-02-22T07:33:45.014296+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -3693,11 +3771,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:03 GMT
+      - Thu, 22 Feb 2024 07:33:45 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/926f620a-12d1-4e4c-ae10-686d34b7e4de
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/d2d36f5e-4554-4600-b3c4-6313485acbc1
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3705,48 +3783,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44dec690-6b11-46c2-b822-2de85e186fdb
+      - dea80c30-f500-4a50-adc1-62b7e0ae369b
     status: 202 Accepted
     code: 202
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:59:03.458391+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2760"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:59:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ed8d1f9f-26a7-45ee-b1d4-c7f3bd0e4cdd
-    status: 200 OK
-    code: 200
     duration: ""
 - request:
     body: '{"action":"poweroff"}'
@@ -3757,10 +3796,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b/action","href_result":"/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b","id":"255c1128-98e9-4059-9a0b-b8daaf0aba17","started_at":"2023-12-05T10:59:03.821213+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda/action","href_result":"/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda","id":"6aa936db-2977-4551-ba46-13ff510066df","started_at":"2024-02-22T07:33:45.024609+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -3769,11 +3808,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:04 GMT
+      - Thu, 22 Feb 2024 07:33:45 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/255c1128-98e9-4059-9a0b-b8daaf0aba17
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6aa936db-2977-4551-ba46-13ff510066df
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3781,7 +3820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd24383b-5e89-44e5-93f4-f3bd75a56385
+      - e22972e9-fe45-4bff-be83-6412b4730fa4
     status: 202 Accepted
     code: 202
     duration: ""
@@ -3792,27 +3831,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:59:03.378035+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:33:44.882905+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:04 GMT
+      - Thu, 22 Feb 2024 07:33:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3820,7 +3859,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b890826e-7b32-46e0-901b-a27d051776ae
+      - 4012afbd-9b12-47d5-83da-88af9b7c5142
     status: 200 OK
     code: 200
     duration: ""
@@ -3831,27 +3870,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:59:03.458391+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:44.879408+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2760"
+      - "2786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:09 GMT
+      - Thu, 22 Feb 2024 07:33:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3859,7 +3898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eaa91056-5db4-4f84-a9fe-0e3cf33a624b
+      - ea0b43ec-7f5b-4df6-86a8-346f1b7cd9bb
     status: 200 OK
     code: 200
     duration: ""
@@ -3870,27 +3909,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:59:03.378035+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:33:44.882905+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:09 GMT
+      - Thu, 22 Feb 2024 07:33:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3898,7 +3937,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64382803-bc04-4078-b2df-3f4eebf1391b
+      - ee8f7e27-c67d-47cd-ad00-2bfcb7754cda
     status: 200 OK
     code: 200
     duration: ""
@@ -3909,27 +3948,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:59:03.458391+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:44.879408+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2760"
+      - "2786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:14 GMT
+      - Thu, 22 Feb 2024 07:33:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3937,7 +3976,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6eb97f4d-016a-4b19-a61b-e7e05124bbd8
+      - eda35c3b-347b-409b-b661-8286e1b16037
     status: 200 OK
     code: 200
     duration: ""
@@ -3948,27 +3987,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:59:03.378035+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:33:44.882905+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:14 GMT
+      - Thu, 22 Feb 2024 07:33:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3976,7 +4015,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f728a577-8381-4f71-a786-d702f509941b
+      - 26a5ccdd-e782-41db-840d-b072a7a3af9b
     status: 200 OK
     code: 200
     duration: ""
@@ -3987,27 +4026,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:59:03.458391+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:44.879408+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2760"
+      - "2786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:19 GMT
+      - Thu, 22 Feb 2024 07:33:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4015,7 +4054,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a28b7eff-1d68-47d2-97bb-4cc2b89a6034
+      - a36af60f-a28b-44af-9879-60759784b297
     status: 200 OK
     code: 200
     duration: ""
@@ -4026,27 +4065,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:59:03.378035+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:33:44.882905+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:20 GMT
+      - Thu, 22 Feb 2024 07:34:00 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4054,7 +4093,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1ab98ca-0c4d-4fbb-8fd3-f28ea0470baf
+      - d586519a-69cb-4ca5-a225-8acb700711cd
     status: 200 OK
     code: 200
     duration: ""
@@ -4065,27 +4104,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"801","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:59:03.458391+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.72.120.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:44.879408+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2760"
+      - "2786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:24 GMT
+      - Thu, 22 Feb 2024 07:34:00 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4093,7 +4132,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bad35863-d341-4e2c-90db-d4b47132e127
+      - 312547e4-38de-4a64-9e7f-59f0e56300ed
     status: 200 OK
     code: 200
     duration: ""
@@ -4104,27 +4143,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:59:03.378035+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"15","hypervisor_id":"1801","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:33:44.882905+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.68.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:25 GMT
+      - Thu, 22 Feb 2024 07:34:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4132,7 +4171,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70fd6de2-3323-4b6e-82bd-d347b095bfb2
+      - cf6afa46-7cfd-4950-8ef4-ca9cf5aa189d
     status: 200 OK
     code: 200
     duration: ""
@@ -4143,27 +4182,105 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:44.879408+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2786"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:34:05 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 77e3f609-cf4f-40cb-b0d7-718c53bd2b9c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:44.879408+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2786"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:34:11 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5c0f7af1-9de3-40c7-af53-95a4cf3ac025
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:59:29.902829+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:34:07.607154+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2639"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:30 GMT
+      - Thu, 22 Feb 2024 07:34:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4171,7 +4288,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f339554d-26ab-4c9e-9814-6f3f8115097c
+      - e66e37c3-9202-4060-ae2c-8fad681a6c51
     status: 200 OK
     code: 200
     duration: ""
@@ -4182,27 +4299,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.048917+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-crazy-panini","id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:f7","maintenances":[],"modification_date":"2023-12-05T10:59:29.902829+00:00","name":"tf-srv-crazy-panini","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.048917+00:00","export_uri":null,"id":"0d704327-abfa-45d9-877e-9a551b76428e","modification_date":"2023-12-05T10:57:53.495159+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","name":"tf-srv-crazy-panini"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.666702+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-eager-babbage","id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a5","maintenances":[],"modification_date":"2024-02-22T07:34:07.607154+00:00","name":"tf-srv-eager-babbage","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.666702+00:00","export_uri":null,"id":"0f964033-f525-4963-b9ae-b9fff06f3aa4","modification_date":"2024-02-22T07:32:53.167242+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","name":"tf-srv-eager-babbage"},"size":15000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2639"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:30 GMT
+      - Thu, 22 Feb 2024 07:34:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4210,7 +4327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e98a28df-4165-4fd7-8135-1288368746e4
+      - d021ddd2-d58a-42a2-83d7-93a36dcacf61
     status: 200 OK
     code: 200
     duration: ""
@@ -4221,46 +4338,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:59:03.378035+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2767"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:59:30 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4c7a9b64-2014-46d4-afaa-0ef68f91f371
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: DELETE
   response:
     body: ""
@@ -4268,9 +4346,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:59:30 GMT
+      - Thu, 22 Feb 2024 07:34:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4278,7 +4356,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09b7c143-3a10-44af-b4b8-372f11c1895b
+      - 01e8cc44-46bb-4229-b995-70b7a47ac399
     status: 204 No Content
     code: 204
     duration: ""
@@ -4289,10 +4367,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -4301,9 +4379,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:30 GMT
+      - Thu, 22 Feb 2024 07:34:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4311,7 +4389,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fe046d7-1b26-494c-ad96-e897ddd3b601
+      - ca84e4c2-9b2d-4d48-808b-3fc327ecd94d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4322,7 +4400,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0d704327-abfa-45d9-877e-9a551b76428e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0f964033-f525-4963-b9ae-b9fff06f3aa4
     method: DELETE
   response:
     body: ""
@@ -4330,9 +4408,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:59:30 GMT
+      - Thu, 22 Feb 2024 07:34:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4340,7 +4418,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07ff5609-4ea0-4251-a997-a950b43f6b8f
+      - f4d6bd0f-66e7-46f5-9198-519487d371a6
     status: 204 No Content
     code: 204
     duration: ""
@@ -4351,27 +4429,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:59:03.378035+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"801","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:33:44.879408+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.120.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:35 GMT
+      - Thu, 22 Feb 2024 07:34:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4379,7 +4457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb8a8cfc-54ba-4bbb-b976-9d0c57fa3f14
+      - 9b5d4dbc-0580-46ee-8a02-d75536850152
     status: 200 OK
     code: 200
     duration: ""
@@ -4390,66 +4468,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1301","node_id":"48","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:59:03.378035+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.48.95","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2767"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:59:40 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 34948de6-3904-4cc9-9919-e45ffa7522db
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:59:43.508832+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:34:20.504779+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2645"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:46 GMT
+      - Thu, 22 Feb 2024 07:34:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4457,7 +4496,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87ad1017-7a66-4da2-911b-6cd00292e53e
+      - 0116c858-1861-4ef9-acdc-b5e26c6ab403
     status: 200 OK
     code: 200
     duration: ""
@@ -4468,27 +4507,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:58:03.531577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-loving-satoshi","id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:cb:0b","maintenances":[],"modification_date":"2023-12-05T10:59:43.508832+00:00","name":"tf-srv-loving-satoshi","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:58:03.531577+00:00","export_uri":null,"id":"be1064c6-4b60-4504-97de-33288701d5cd","modification_date":"2023-12-05T10:58:44.964122+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","name":"tf-srv-loving-satoshi"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:59.845577+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-happy-poitras","id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:c9","maintenances":[],"modification_date":"2024-02-22T07:34:20.504779+00:00","name":"tf-srv-happy-poitras","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:59.845577+00:00","export_uri":null,"id":"2a9a05ad-b2c6-420f-a623-cd310972500d","modification_date":"2024-02-22T07:33:35.965877+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","name":"tf-srv-happy-poitras"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2645"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:46 GMT
+      - Thu, 22 Feb 2024 07:34:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4496,7 +4535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea45bfba-999a-4303-bf29-b69705312fb0
+      - 6fea6e1a-3394-49e5-982d-117715f2b710
     status: 200 OK
     code: 200
     duration: ""
@@ -4507,7 +4546,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: DELETE
   response:
     body: ""
@@ -4515,9 +4554,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:59:46 GMT
+      - Thu, 22 Feb 2024 07:34:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4525,7 +4564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ef021b1-6f74-43f0-8918-1be70d50577c
+      - b9c7a028-0242-4a44-863b-6709d86548b2
     status: 204 No Content
     code: 204
     duration: ""
@@ -4536,10 +4575,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -4548,9 +4587,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:46 GMT
+      - Thu, 22 Feb 2024 07:34:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4558,7 +4597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfe436fd-383c-4420-9f59-b95fb67e82fc
+      - 499403bb-f5f7-499d-ac65-b873112e1436
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4569,7 +4608,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/be1064c6-4b60-4504-97de-33288701d5cd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2a9a05ad-b2c6-420f-a623-cd310972500d
     method: DELETE
   response:
     body: ""
@@ -4577,9 +4616,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:59:46 GMT
+      - Thu, 22 Feb 2024 07:34:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4587,7 +4626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fa68b93-f88a-4206-9623-a11400b3163f
+      - 35549825-8e36-4cb5-b3ab-25da21f4e3b8
     status: 204 No Content
     code: 204
     duration: ""
@@ -4598,10 +4637,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/da69ba55-9ae3-4e6a-9282-43735cf60235
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/92b374f9-678c-483c-9aea-7266fc0bf4ad
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_image","resource_id":"da69ba55-9ae3-4e6a-9282-43735cf60235","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_image","resource_id":"92b374f9-678c-483c-9aea-7266fc0bf4ad","type":"not_found"}'
     headers:
       Content-Length:
       - "142"
@@ -4610,9 +4649,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:46 GMT
+      - Thu, 22 Feb 2024 07:34:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4620,7 +4659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f1883c3-741b-465a-bfe3-7118a4a66666
+      - b77f82b7-e7da-49d3-87cd-25947a11b4e2
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4631,10 +4670,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/9c4aab65-5dc9-459e-8477-de3925c432ef
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/acc92b70-a228-494a-bd8d-14ce43c3a05b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"9c4aab65-5dc9-459e-8477-de3925c432ef","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"acc92b70-a228-494a-bd8d-14ce43c3a05b","type":"not_found"}'
     headers:
       Content-Length:
       - "145"
@@ -4643,9 +4682,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:46 GMT
+      - Thu, 22 Feb 2024 07:34:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4653,7 +4692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32029de0-3b5e-432e-8055-1ca42c49d412
+      - ea7eff84-3401-4958-852f-2a8048dc7f2e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4664,10 +4703,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"eac3cfd0-fc14-400a-a637-0f3ab3f5ca0b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"aea8ddb7-a1c7-4d23-b1db-96cb25e9c7bf","type":"not_found"}'
     headers:
       Content-Length:
       - "145"
@@ -4676,9 +4715,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:46 GMT
+      - Thu, 22 Feb 2024 07:34:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4686,7 +4725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 56bb6ee1-443b-4826-bf4b-c5284b69fa0d
+      - 48d51dc5-a17c-4670-9b8a-bce3fe09ea58
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4697,10 +4736,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2bc74f25-d995-4647-8ff0-4434451bbd3b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/905a43a9-6be7-40ee-90cc-6aa266e2edda
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"2bc74f25-d995-4647-8ff0-4434451bbd3b","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"905a43a9-6be7-40ee-90cc-6aa266e2edda","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -4709,9 +4748,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:46 GMT
+      - Thu, 22 Feb 2024 07:34:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4719,7 +4758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2db3637-51ce-47e6-9bf5-4127c9a1d8da
+      - cc477d81-e1a8-49e4-9664-cf4d67a7d9d1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4730,10 +4769,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e3926706-a9b7-41cc-8dd3-f6bceec2e096
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d9c7ce53-05da-44d9-98e0-6a5f48b5e381
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e3926706-a9b7-41cc-8dd3-f6bceec2e096","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"d9c7ce53-05da-44d9-98e0-6a5f48b5e381","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -4742,9 +4781,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:46 GMT
+      - Thu, 22 Feb 2024 07:34:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4752,7 +4791,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7ec6a53-7325-4258-953a-b2203fe36644
+      - 8dad6307-2b5d-4d81-ac11-612fbc68599c
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-image-server.cassette.yaml
+++ b/scaleway/testdata/instance-image-server.cassette.yaml
@@ -11,18 +11,18 @@ interactions:
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"492d66d3-b14d-46d3-80c6-3945d5b61b21","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2f1f7a57-c508-4f72-9f7f-536b316f36e1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"5d083890-4354-47ab-b769-8b0de601eb3a","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1183"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:18 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -30,7 +30,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce5ee6d4-bdcb-4f17-9389-c054e16b3f29
+      - 48fcaf41-786b-4cd1-8603-acc89e255451
     status: 200 OK
     code: 200
     duration: ""
@@ -53,12 +53,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:18 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -66,7 +66,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 462b1158-f09d-42cd-a69b-11738dc3003b
+      - 5fbb79dd-b111-4588-abba-2c2c24358f0e
       X-Total-Count:
       - "61"
     status: 200 OK
@@ -91,12 +91,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:18 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -104,14 +104,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f3bf091-87f5-4473-93ef-a436ed883795
+      - c6ddec71-ae81-4ab3-ac35-d62971e1f8d5
       X-Total-Count:
       - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-adoring-bouman","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-srv-hardcore-heyrovsky","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5d083890-4354-47ab-b769-8b0de601eb3a","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -124,24 +124,24 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:18.688395+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:18.688395+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:03.021118+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:03.021118+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2645"
+      - "2679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:19 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -149,7 +149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49cc2a78-6c8c-4dfd-9fce-0d9cf502813f
+      - 18cbe58f-0021-4c03-98c1-be4ae45b09ae
     status: 201 Created
     code: 201
     duration: ""
@@ -160,27 +160,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:18.688395+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:18.688395+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:03.021118+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:03.021118+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2645"
+      - "2679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:19 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -188,7 +188,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a29dbc5-46eb-488f-a7ad-146b779eda77
+      - 83ab1da2-7138-4f6b-a56b-11dbc2d3d226
     status: 200 OK
     code: 200
     duration: ""
@@ -199,27 +199,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:18.688395+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:18.688395+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:03.021118+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:03.021118+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2645"
+      - "2679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:19 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -227,7 +227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 053a476f-f5c0-4f19-9133-c2020b18b274
+      - 3d0a90c2-9282-42a0-aa95-c14b9c20d334
     status: 200 OK
     code: 200
     duration: ""
@@ -240,10 +240,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/action","href_result":"/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a","id":"ba1f81ac-6253-4e7e-9873-342dc0d2fc66","started_at":"2023-12-05T10:57:19.557072+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/action","href_result":"/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","id":"621f3447-42c1-4a0d-9287-9c06eb005390","started_at":"2024-02-22T07:32:04.812571+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -252,11 +252,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:19 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/ba1f81ac-6253-4e7e-9873-342dc0d2fc66
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/621f3447-42c1-4a0d-9287-9c06eb005390
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -264,7 +264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77e93ec5-8ee6-47c6-b1dd-50a50d0b7be2
+      - 1c7a57f3-aec5-44b0-b8d3-31cae7333edb
     status: 202 Accepted
     code: 202
     duration: ""
@@ -275,27 +275,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:19.377049+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:18.688395+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:04.097543+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:03.021118+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2667"
+      - "2701"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:20 GMT
+      - Thu, 22 Feb 2024 07:32:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -303,7 +303,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5730e57-62b8-4a3e-aade-7150da98cc56
+      - 45b756f4-9f9b-44bb-897a-8f90a6eef852
     status: 200 OK
     code: 200
     duration: ""
@@ -314,27 +314,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:19.377049+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:18.688395+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:04.097543+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:03.021118+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2667"
+      - "2809"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:25 GMT
+      - Thu, 22 Feb 2024 07:32:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -342,7 +342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c663f898-1426-4e25-b9cf-47778db3cdd6
+      - 14e613f5-0351-4982-a865-e217bf98aa08
     status: 200 OK
     code: 200
     duration: ""
@@ -353,27 +353,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:19.377049+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:18.688395+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:04.097543+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:03.021118+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2776"
+      - "2809"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:30 GMT
+      - Thu, 22 Feb 2024 07:32:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -381,7 +381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df554d24-3374-406f-badf-4ed13dd58e3f
+      - 49fae62a-b68c-49fe-a620-a8ec29f79f15
     status: 200 OK
     code: 200
     duration: ""
@@ -392,27 +392,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:19.377049+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:18.688395+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:04.097543+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:03.021118+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2776"
+      - "2809"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:35 GMT
+      - Thu, 22 Feb 2024 07:32:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -420,7 +420,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eaabe64d-d5fe-45b8-a4a7-fd163bb4dd06
+      - c37e4ed9-edd0-4e03-8ddf-235a47c91357
     status: 200 OK
     code: 200
     duration: ""
@@ -431,27 +431,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:36.875738+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:18.688395+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:23.008638+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:03.021118+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2807"
+      - "2840"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:40 GMT
+      - Thu, 22 Feb 2024 07:32:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -459,7 +459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1240860-f14a-449b-8634-517f339a12f3
+      - 65c1bbc6-0967-46ec-b3ab-e443bf4b90a1
     status: 200 OK
     code: 200
     duration: ""
@@ -470,27 +470,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:36.875738+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:18.688395+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:23.008638+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:03.021118+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2807"
+      - "2840"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:41 GMT
+      - Thu, 22 Feb 2024 07:32:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -498,7 +498,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e1ec3fa-e6c7-45f7-9c18-91eb6718d5de
+      - 9714b8ef-a853-4b63-bfe8-11b484a36b81
     status: 200 OK
     code: 200
     duration: ""
@@ -509,7 +509,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -521,9 +521,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:41 GMT
+      - Thu, 22 Feb 2024 07:32:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -531,7 +531,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 392101f7-7cb8-451a-95c3-f6cfe5b91662
+      - 49c86c2f-1067-4353-b97b-a4c69e24de8f
     status: 200 OK
     code: 200
     duration: ""
@@ -542,7 +542,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -554,12 +554,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:41 GMT
+      - Thu, 22 Feb 2024 07:32:26 GMT
       Link:
-      - </servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/private_nics?page=0&per_page=50&>;
+      - </servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -567,14 +567,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f403567f-8abb-4b21-b890-7374259584bb
+      - b2f0ec61-0670-4364-8f85-2d72cfdca7f7
       X-Total-Count:
       - "0"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-snap-optimistic-chatterjee","volume_id":"216afa50-07ae-4537-8510-03ed8f00e9b7","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-snap-determined-greider","volume_id":"0dcf622a-e575-4429-a444-2eb3067011c2","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -585,19 +585,19 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot":{"base_volume":{"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:41.535022+00:00","error_details":null,"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","modification_date":"2023-12-05T10:57:41.535022+00:00","name":"tf-snap-optimistic-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_0b4789d3-2c63-4b41-a774-9bae410cd377","href_from":"/snapshots","href_result":"snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377","id":"cb79fd25-65a1-4d67-8d5b-5110789605ec","started_at":"2023-12-05T10:57:41.925051+00:00","status":"pending","terminated_at":null}}'
+    body: '{"snapshot":{"base_volume":{"id":"0dcf622a-e575-4429-a444-2eb3067011c2","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:26.109280+00:00","error_details":null,"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","modification_date":"2024-02-22T07:32:26.109280+00:00","name":"tf-snap-determined-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_78abf11c-ef48-481d-8d4b-4a0ce6d0158f","href_from":"/snapshots","href_result":"snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f","id":"5801d199-8c73-49fe-bf12-89b25feae07c","started_at":"2024-02-22T07:32:26.442629+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
-      - "848"
+      - "845"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:57:42 GMT
+      - Thu, 22 Feb 2024 07:32:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -605,7 +605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54728ceb-940b-4151-95fa-928423c9cd3b
+      - b6dbec6f-6b96-4966-be10-739d4f1f00df
     status: 201 Created
     code: 201
     duration: ""
@@ -616,147 +616,11 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:41.535022+00:00","error_details":null,"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","modification_date":"2023-12-05T10:57:41.535022+00:00","name":"tf-snap-optimistic-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "542"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:57:42 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1106f6bd-df9c-46c9-9a2c-93afd18de6ac
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:41.535022+00:00","error_details":null,"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","modification_date":"2023-12-05T10:57:41.535022+00:00","name":"tf-snap-optimistic-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "542"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:57:47 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8fa794da-e4c7-4cf5-aefa-51fe07c21ec3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:41.535022+00:00","error_details":null,"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","modification_date":"2023-12-05T10:57:41.535022+00:00","name":"tf-snap-optimistic-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "542"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:57:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1dea94b5-8526-4f7e-be6e-5f546e1e9347
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:41.535022+00:00","error_details":null,"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","modification_date":"2023-12-05T10:57:41.535022+00:00","name":"tf-snap-optimistic-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "542"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:57:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 76107e3b-7e5b-480b-b682-c280d839a298
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:41.535022+00:00","error_details":null,"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"tf-snap-optimistic-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0dcf622a-e575-4429-a444-2eb3067011c2","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:26.109280+00:00","error_details":null,"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","modification_date":"2024-02-22T07:32:26.109280+00:00","name":"tf-snap-determined-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "539"
@@ -765,9 +629,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:02 GMT
+      - Thu, 22 Feb 2024 07:32:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -775,7 +639,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2688977-fb69-470f-8b80-575606d7ebfe
+      - 4aa70c1d-94d2-41e8-8e4d-acb02ee1dea0
     status: 200 OK
     code: 200
     duration: ""
@@ -786,11 +650,11 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:41.535022+00:00","error_details":null,"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"tf-snap-optimistic-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0dcf622a-e575-4429-a444-2eb3067011c2","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:26.109280+00:00","error_details":null,"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","modification_date":"2024-02-22T07:32:26.109280+00:00","name":"tf-snap-determined-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "539"
@@ -799,9 +663,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:03 GMT
+      - Thu, 22 Feb 2024 07:32:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -809,12 +673,148 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 287b525f-5675-4596-afa0-e10a7d631693
+      - 68b656e7-052e-4dcc-9e46-f67ba9fd1743
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-image-thirsty-niel","root_volume":"0b4789d3-2c63-4b41-a774-9bae410cd377","arch":"x86_64","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["test_remove_tags"],"public":false}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"0dcf622a-e575-4429-a444-2eb3067011c2","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:26.109280+00:00","error_details":null,"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","modification_date":"2024-02-22T07:32:26.109280+00:00","name":"tf-snap-determined-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "539"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:36 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b609b911-d435-4db4-a542-c37346aa32e0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"0dcf622a-e575-4429-a444-2eb3067011c2","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:26.109280+00:00","error_details":null,"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","modification_date":"2024-02-22T07:32:26.109280+00:00","name":"tf-snap-determined-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "539"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:41 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 865257e1-abec-4b22-9c7b-b2ac139f1238
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"0dcf622a-e575-4429-a444-2eb3067011c2","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:26.109280+00:00","error_details":null,"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"tf-snap-determined-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "536"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:47 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bec99198-f040-4c71-9b98-370ca75f55b2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"0dcf622a-e575-4429-a444-2eb3067011c2","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:26.109280+00:00","error_details":null,"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"tf-snap-determined-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "536"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:47 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 25d6e80c-d3c3-4834-9e28-29bc017dfdf6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-image-elegant-clarke","root_volume":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","arch":"x86_64","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["test_remove_tags"],"public":false}'
     form: {}
     headers:
       Content-Type:
@@ -825,20 +825,20 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images
     method: POST
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:03.274793+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","modification_date":"2023-12-05T10:58:03.274793+00:00","name":"tf-image-thirsty-niel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","name":"tf-snap-optimistic-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:47.199189+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"2d8a28a9-9555-4802-ab09-19bbd642622b","modification_date":"2024-02-22T07:32:47.199189+00:00","name":"tf-image-elegant-clarke","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","name":"tf-snap-determined-greider","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "633"
+      - "632"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:03 GMT
+      - Thu, 22 Feb 2024 07:32:47 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -846,7 +846,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 908da192-e8d5-45eb-a943-a2115674b33f
+      - d9baca61-753c-4db8-8611-7d3cf9a95c3f
     status: 201 Created
     code: 201
     duration: ""
@@ -857,21 +857,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:03.274793+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","modification_date":"2023-12-05T10:58:03.274793+00:00","name":"tf-image-thirsty-niel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","name":"tf-snap-optimistic-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:47.199189+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"2d8a28a9-9555-4802-ab09-19bbd642622b","modification_date":"2024-02-22T07:32:47.199189+00:00","name":"tf-image-elegant-clarke","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","name":"tf-snap-determined-greider","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "633"
+      - "632"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:03 GMT
+      - Thu, 22 Feb 2024 07:32:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -879,7 +879,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60bea123-c625-42cc-86ee-08e7d22fba64
+      - f11d1133-a3ab-4143-ab93-8b93b8f6102d
     status: 200 OK
     code: 200
     duration: ""
@@ -890,21 +890,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:03.274793+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","modification_date":"2023-12-05T10:58:03.274793+00:00","name":"tf-image-thirsty-niel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","name":"tf-snap-optimistic-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:47.199189+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"2d8a28a9-9555-4802-ab09-19bbd642622b","modification_date":"2024-02-22T07:32:47.199189+00:00","name":"tf-image-elegant-clarke","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","name":"tf-snap-determined-greider","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "633"
+      - "632"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:03 GMT
+      - Thu, 22 Feb 2024 07:32:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -912,7 +912,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 796d972e-6218-4590-9be5-6b7fbd4b5f28
+      - dfe62c71-b497-4a26-a56a-cdf45b0f0f17
     status: 200 OK
     code: 200
     duration: ""
@@ -923,133 +923,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:36.875738+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2799"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0df77e09-440d-411c-ba4a-3d165436cd7f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:41.535022+00:00","error_details":null,"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"tf-snap-optimistic-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "539"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c00fe5cb-7093-48cb-a9f1-59352741c4da
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
-    method: GET
-  response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:03.274793+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","modification_date":"2023-12-05T10:58:03.274793+00:00","name":"tf-image-thirsty-niel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","name":"tf-snap-optimistic-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "633"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aac54633-7c7d-4e47-a6c9-36beafeaaf8c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:36.875738+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:23.008638+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2799"
+      - "2832"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:05 GMT
+      - Thu, 22 Feb 2024 07:32:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1057,7 +951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca5c3382-d247-404e-8c37-956d71abbc12
+      - 511cab6d-3b67-4806-8361-9c001cfebb51
     status: 200 OK
     code: 200
     duration: ""
@@ -1068,7 +962,113 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"0dcf622a-e575-4429-a444-2eb3067011c2","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:26.109280+00:00","error_details":null,"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"tf-snap-determined-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "536"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:47 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 013c763d-d774-43c0-819b-f7202e814706
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
+    method: GET
+  response:
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:47.199189+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"2d8a28a9-9555-4802-ab09-19bbd642622b","modification_date":"2024-02-22T07:32:47.199189+00:00","name":"tf-image-elegant-clarke","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","name":"tf-snap-determined-greider","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "632"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:47 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7c9f0cb9-11a3-4a10-95f2-b73a99adc2ab
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:23.008638+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2832"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:48 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 31d0364d-aa87-4294-8101-f607b8a104c3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1080,9 +1080,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:05 GMT
+      - Thu, 22 Feb 2024 07:32:48 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1090,7 +1090,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1a828f3-7be1-4c69-b6f2-39bc1a8e6d1f
+      - 09615885-3f0e-453f-99bf-26ed67eb44d2
     status: 200 OK
     code: 200
     duration: ""
@@ -1101,7 +1101,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1113,12 +1113,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:05 GMT
+      - Thu, 22 Feb 2024 07:32:48 GMT
       Link:
-      - </servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/private_nics?page=0&per_page=50&>;
+      - </servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1126,7 +1126,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02926ad8-6980-4a11-8afb-74f86a8d9f17
+      - 6739b62c-4f16-432c-b163-a04759d35f50
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1139,22 +1139,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:41.535022+00:00","error_details":null,"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"tf-snap-optimistic-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0dcf622a-e575-4429-a444-2eb3067011c2","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:26.109280+00:00","error_details":null,"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"tf-snap-determined-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "539"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:06 GMT
+      - Thu, 22 Feb 2024 07:32:48 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1162,7 +1162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3c9dcc6-3087-48a2-9389-5ecc394af67d
+      - e42c9732-6238-4cf4-8f72-5e7dc69d4086
     status: 200 OK
     code: 200
     duration: ""
@@ -1173,21 +1173,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:03.274793+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","modification_date":"2023-12-05T10:58:03.274793+00:00","name":"tf-image-thirsty-niel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","name":"tf-snap-optimistic-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:47.199189+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"2d8a28a9-9555-4802-ab09-19bbd642622b","modification_date":"2024-02-22T07:32:47.199189+00:00","name":"tf-image-elegant-clarke","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","name":"tf-snap-determined-greider","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "633"
+      - "632"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:06 GMT
+      - Thu, 22 Feb 2024 07:32:48 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1195,7 +1195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b13c71e0-56df-44fb-ace8-77cd76682364
+      - a316482a-bcca-410f-a166-7157e192131a
     status: 200 OK
     code: 200
     duration: ""
@@ -1206,27 +1206,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:36.875738+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:23.008638+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2799"
+      - "2832"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:07 GMT
+      - Thu, 22 Feb 2024 07:32:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1234,7 +1234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79c208e0-2ae2-42a2-bdb7-12bfb86af6e0
+      - 4d342868-5e0a-4761-bc71-fe0557c181c8
     status: 200 OK
     code: 200
     duration: ""
@@ -1245,7 +1245,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1257,9 +1257,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:08 GMT
+      - Thu, 22 Feb 2024 07:32:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1267,7 +1267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25a505a6-6e37-40c2-a723-f218651eef93
+      - 98f5dcc5-d360-48bb-815a-5b419ef738ce
     status: 200 OK
     code: 200
     duration: ""
@@ -1278,7 +1278,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1290,12 +1290,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:08 GMT
+      - Thu, 22 Feb 2024 07:32:49 GMT
       Link:
-      - </servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/private_nics?page=0&per_page=50&>;
+      - </servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1303,7 +1303,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 202fb9cf-654b-4a38-a0ec-05300e923bea
+      - a207eb9b-0921-413f-9423-c9e42e4442aa
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1316,22 +1316,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:41.535022+00:00","error_details":null,"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"tf-snap-optimistic-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0dcf622a-e575-4429-a444-2eb3067011c2","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:26.109280+00:00","error_details":null,"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"tf-snap-determined-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "539"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:08 GMT
+      - Thu, 22 Feb 2024 07:32:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1339,7 +1339,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32175b06-56d8-48ca-8488-2f847e481906
+      - e5658804-4c89-45aa-b1c0-339109c7b21e
     status: 200 OK
     code: 200
     duration: ""
@@ -1350,21 +1350,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:03.274793+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","modification_date":"2023-12-05T10:58:03.274793+00:00","name":"tf-image-thirsty-niel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","name":"tf-snap-optimistic-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:47.199189+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"2d8a28a9-9555-4802-ab09-19bbd642622b","modification_date":"2024-02-22T07:32:47.199189+00:00","name":"tf-image-elegant-clarke","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","name":"tf-snap-determined-greider","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "633"
+      - "632"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:08 GMT
+      - Thu, 22 Feb 2024 07:32:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1372,7 +1372,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9a93ae2-d6fd-4371-8541-a6fbabecf57a
+      - be08c77b-3049-4a94-90d1-95747f888867
     status: 200 OK
     code: 200
     duration: ""
@@ -1383,21 +1383,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:03.274793+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","modification_date":"2023-12-05T10:58:03.274793+00:00","name":"tf-image-thirsty-niel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","name":"tf-snap-optimistic-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:47.199189+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"2d8a28a9-9555-4802-ab09-19bbd642622b","modification_date":"2024-02-22T07:32:47.199189+00:00","name":"tf-image-elegant-clarke","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","name":"tf-snap-determined-greider","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "633"
+      - "632"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:09 GMT
+      - Thu, 22 Feb 2024 07:32:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1405,7 +1405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52a39d03-f26b-4c3f-b35f-30da4cbb83a3
+      - 9bfd9cf5-aa89-450f-9566-55e594bf4d8a
     status: 200 OK
     code: 200
     duration: ""
@@ -1416,21 +1416,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:03.274793+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","modification_date":"2023-12-05T10:58:03.274793+00:00","name":"tf-image-thirsty-niel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","name":"tf-snap-optimistic-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:47.199189+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"2d8a28a9-9555-4802-ab09-19bbd642622b","modification_date":"2024-02-22T07:32:47.199189+00:00","name":"tf-image-elegant-clarke","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","name":"tf-snap-determined-greider","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":["test_remove_tags"],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "633"
+      - "632"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:10 GMT
+      - Thu, 22 Feb 2024 07:32:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1438,12 +1438,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c1e23d4-ad52-4e67-9703-ae4afe40ac35
+      - 524d2054-c942-42a1-be03-d984d58972ec
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-image-thirsty-niel","arch":"x86_64","tags":[]}'
+    body: '{"name":"tf-image-elegant-clarke","arch":"x86_64","tags":[]}'
     form: {}
     headers:
       Content-Type:
@@ -1451,21 +1451,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
     method: PATCH
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:03.274793+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","modification_date":"2023-12-05T10:58:10.088508+00:00","name":"tf-image-thirsty-niel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","name":"tf-snap-optimistic-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:47.199189+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"2d8a28a9-9555-4802-ab09-19bbd642622b","modification_date":"2024-02-22T07:32:50.654292+00:00","name":"tf-image-elegant-clarke","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","name":"tf-snap-determined-greider","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "615"
+      - "614"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:10 GMT
+      - Thu, 22 Feb 2024 07:32:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1473,7 +1473,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2792490-789b-4113-b1dc-00f4245abba4
+      - 425aaca8-d52e-400a-a696-54c1c656ae3d
     status: 200 OK
     code: 200
     duration: ""
@@ -1484,21 +1484,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:03.274793+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","modification_date":"2023-12-05T10:58:10.088508+00:00","name":"tf-image-thirsty-niel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","name":"tf-snap-optimistic-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:47.199189+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"2d8a28a9-9555-4802-ab09-19bbd642622b","modification_date":"2024-02-22T07:32:50.654292+00:00","name":"tf-image-elegant-clarke","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","name":"tf-snap-determined-greider","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "615"
+      - "614"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:10 GMT
+      - Thu, 22 Feb 2024 07:32:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1506,7 +1506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 51514462-cc7e-43c3-b6b4-0e7aa2060772
+      - 4eec5e67-557c-4d43-bfe3-b541abf3affa
     status: 200 OK
     code: 200
     duration: ""
@@ -1517,21 +1517,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:03.274793+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","modification_date":"2023-12-05T10:58:10.088508+00:00","name":"tf-image-thirsty-niel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","name":"tf-snap-optimistic-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:47.199189+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"2d8a28a9-9555-4802-ab09-19bbd642622b","modification_date":"2024-02-22T07:32:50.654292+00:00","name":"tf-image-elegant-clarke","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","name":"tf-snap-determined-greider","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "615"
+      - "614"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:10 GMT
+      - Thu, 22 Feb 2024 07:32:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1539,7 +1539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c1a090d-7259-4a7a-a8f5-a49be34e3a14
+      - a55953be-91b0-4dfb-b63b-90b5c3e712f5
     status: 200 OK
     code: 200
     duration: ""
@@ -1550,133 +1550,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:36.875738+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2799"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - dc6b215f-46ed-413a-a0ae-a6f39c34eeaa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
-    method: GET
-  response:
-    body: '{"snapshot":{"base_volume":{"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:41.535022+00:00","error_details":null,"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"tf-snap-optimistic-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "539"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0e591a67-baee-417a-a790-105c8e0a0390
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
-    method: GET
-  response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:03.274793+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","modification_date":"2023-12-05T10:58:10.088508+00:00","name":"tf-image-thirsty-niel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","name":"tf-snap-optimistic-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "615"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 05 Dec 2023 10:58:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e5081c0a-7c42-4f20-9eed-2afb14d4e7e2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:36.875738+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:23.008638+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2799"
+      - "2832"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:12 GMT
+      - Thu, 22 Feb 2024 07:32:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1684,7 +1578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 001e8b78-2155-4952-b943-af21a7156f6a
+      - 9f045b6c-70e1-4df5-863a-35d3436827ad
     status: 200 OK
     code: 200
     duration: ""
@@ -1695,7 +1589,113 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
+    method: GET
+  response:
+    body: '{"snapshot":{"base_volume":{"id":"0dcf622a-e575-4429-a444-2eb3067011c2","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:26.109280+00:00","error_details":null,"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"tf-snap-determined-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "536"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 844bc7ba-de27-4427-b0ea-6cbc1a7b6e91
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
+    method: GET
+  response:
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:47.199189+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"2d8a28a9-9555-4802-ab09-19bbd642622b","modification_date":"2024-02-22T07:32:50.654292+00:00","name":"tf-image-elegant-clarke","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","name":"tf-snap-determined-greider","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "614"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0e6c1b9e-80cf-4146-a857-e0a2c96c4110
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:23.008638+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2832"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fd0cdc43-57a0-4f3c-ac85-9e934a982a75
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1707,9 +1707,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:12 GMT
+      - Thu, 22 Feb 2024 07:32:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1717,7 +1717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 560aa0f6-cb36-4b42-8b0a-10af9d3bb803
+      - be5737bd-190b-4bd6-8123-d0cffa8ac38f
     status: 200 OK
     code: 200
     duration: ""
@@ -1728,7 +1728,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1740,12 +1740,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:12 GMT
+      - Thu, 22 Feb 2024 07:32:52 GMT
       Link:
-      - </servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/private_nics?page=0&per_page=50&>;
+      - </servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1753,7 +1753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf192205-21b8-42b6-9c77-b2e2f403f3cb
+      - abf093be-242d-4918-8a3c-c8f200f40cfc
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1766,22 +1766,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:41.535022+00:00","error_details":null,"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"tf-snap-optimistic-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0dcf622a-e575-4429-a444-2eb3067011c2","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:26.109280+00:00","error_details":null,"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"tf-snap-determined-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "539"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:12 GMT
+      - Thu, 22 Feb 2024 07:32:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1789,7 +1789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f95a1ee4-a97e-47af-a239-84e9c23b15d7
+      - 6abc6b0e-c1ef-48d4-bd0e-2725cc42e97e
     status: 200 OK
     code: 200
     duration: ""
@@ -1800,21 +1800,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:03.274793+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","modification_date":"2023-12-05T10:58:10.088508+00:00","name":"tf-image-thirsty-niel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","name":"tf-snap-optimistic-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:47.199189+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"2d8a28a9-9555-4802-ab09-19bbd642622b","modification_date":"2024-02-22T07:32:50.654292+00:00","name":"tf-image-elegant-clarke","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","name":"tf-snap-determined-greider","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "615"
+      - "614"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:12 GMT
+      - Thu, 22 Feb 2024 07:32:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1822,7 +1822,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b3a7729-a597-405f-83be-55d0021c38e4
+      - 567e3146-411c-442e-a65a-78c742151008
     status: 200 OK
     code: 200
     duration: ""
@@ -1833,21 +1833,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
     method: GET
   response:
-    body: '{"image":{"arch":"x86_64","creation_date":"2023-12-05T10:58:03.274793+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","modification_date":"2023-12-05T10:58:10.088508+00:00","name":"tf-image-thirsty-niel","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","name":"tf-snap-optimistic-chatterjee","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"image":{"arch":"x86_64","creation_date":"2024-02-22T07:32:47.199189+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"2d8a28a9-9555-4802-ab09-19bbd642622b","modification_date":"2024-02-22T07:32:50.654292+00:00","name":"tf-image-elegant-clarke","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","public":false,"root_volume":{"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","name":"tf-snap-determined-greider","size":20000000000,"volume_type":"l_ssd"},"state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "615"
+      - "614"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:15 GMT
+      - Thu, 22 Feb 2024 07:32:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1855,7 +1855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6993fa0b-d0fb-4726-b1d9-529ac95e38e9
+      - 2951009e-1340-4ed3-b56a-a5a6ad7173f5
     status: 200 OK
     code: 200
     duration: ""
@@ -1866,7 +1866,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
     method: DELETE
   response:
     body: ""
@@ -1874,9 +1874,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:58:15 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1884,7 +1884,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d872ea63-d746-4109-90b3-3b4d506014e6
+      - 655cdc15-a55a-441e-8c5b-6e91e1a0a748
     status: 204 No Content
     code: 204
     duration: ""
@@ -1895,10 +1895,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_image","resource_id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_image","resource_id":"2d8a28a9-9555-4802-ab09-19bbd642622b","type":"not_found"}'
     headers:
       Content-Length:
       - "142"
@@ -1907,9 +1907,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:15 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1917,7 +1917,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18d05732-6411-4d6b-8590-559b4753bc02
+      - 57de4937-f98f-459e-bb4f-327f1b19dbe1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1928,22 +1928,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-12-05T10:57:41.535022+00:00","error_details":null,"id":"0b4789d3-2c63-4b41-a774-9bae410cd377","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"tf-snap-optimistic-chatterjee","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"0dcf622a-e575-4429-a444-2eb3067011c2","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:26.109280+00:00","error_details":null,"id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"tf-snap-determined-greider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "539"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:15 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1951,7 +1951,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6354b5aa-81ad-4b48-b09b-2be5968d2aaf
+      - 7a2762ce-3df0-4d0d-9a70-2fd6d5703604
     status: 200 OK
     code: 200
     duration: ""
@@ -1962,7 +1962,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
     method: DELETE
   response:
     body: ""
@@ -1970,9 +1970,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:58:15 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1980,7 +1980,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ebc2b9dc-b615-4771-a58e-fa2ee038bf64
+      - 633a3f6c-da2c-4bb0-99b8-38756e847c1a
     status: 204 No Content
     code: 204
     duration: ""
@@ -1991,10 +1991,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"0b4789d3-2c63-4b41-a774-9bae410cd377","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","type":"not_found"}'
     headers:
       Content-Length:
       - "145"
@@ -2003,9 +2003,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:16 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2013,7 +2013,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47ebe118-26ed-4d42-a585-38688bccd130
+      - 13d75e22-67a3-4641-a709-23321474c2d9
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2024,27 +2024,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:57:36.875738+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:23.008638+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2799"
+      - "2832"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:16 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2052,7 +2052,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c04c49c-fc31-4a5c-b74f-706e6fdaca9a
+      - fe7a6256-d88f-4f24-94e2-8913e49c08ba
     status: 200 OK
     code: 200
     duration: ""
@@ -2065,10 +2065,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a/action","href_result":"/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a","id":"cd07599f-9cc3-4481-a31b-b7d82d94389c","started_at":"2023-12-05T10:58:16.550517+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e/action","href_result":"/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","id":"ca0e5e5d-aa29-4f7a-a262-1044001aabf3","started_at":"2024-02-22T07:32:53.579931+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -2077,11 +2077,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:16 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/cd07599f-9cc3-4481-a31b-b7d82d94389c
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/ca0e5e5d-aa29-4f7a-a262-1044001aabf3
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2089,7 +2089,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3460a4e-adbe-4a83-ad59-b0785408576b
+      - 59428ced-9d58-4460-8519-2466ac95d9e1
     status: 202 Accepted
     code: 202
     duration: ""
@@ -2100,27 +2100,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:58:16.215732+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:53.440928+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2800"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:16 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2128,7 +2128,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50cf4386-e531-49ce-b0bb-8bd2948a88ac
+      - b260aa67-782d-4d6d-8a31-b63ca4ad9bd5
     status: 200 OK
     code: 200
     duration: ""
@@ -2139,27 +2139,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:58:16.215732+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:53.440928+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2800"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:22 GMT
+      - Thu, 22 Feb 2024 07:32:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2167,7 +2167,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8afca2f6-b837-4fcf-9bb7-27c6f9b4fce1
+      - 317eb545-8596-4f44-8723-edf7c3beb6f3
     status: 200 OK
     code: 200
     duration: ""
@@ -2178,27 +2178,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:58:16.215732+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:53.440928+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2800"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:27 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2206,7 +2206,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fcf14dfc-6a99-4290-a12d-f6278e000925
+      - 4278c6a6-1e68-4fe3-a779-a7406d656a63
     status: 200 OK
     code: 200
     duration: ""
@@ -2217,27 +2217,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:58:16.215732+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:53.440928+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2800"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:32 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2245,7 +2245,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cfc7c48-68c8-49e6-a141-a65446a68674
+      - 32173079-983c-46ee-a6e0-958ba708e0b7
     status: 200 OK
     code: 200
     duration: ""
@@ -2256,27 +2256,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:58:16.215732+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:53.440928+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2800"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:37 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2284,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e8a5028-7ab0-44c6-b219-fab6cdcdc511
+      - f316486a-f0d5-4dd8-8694-2b14cf041039
     status: 200 OK
     code: 200
     duration: ""
@@ -2295,27 +2295,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:58:16.215732+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:53.440928+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2800"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:42 GMT
+      - Thu, 22 Feb 2024 07:33:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2323,7 +2323,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a4d169e-3b2b-4067-9b09-d237e39c10dd
+      - 5c8451ee-c0c7-45aa-a2bd-0ecb97ca7620
     status: 200 OK
     code: 200
     duration: ""
@@ -2334,27 +2334,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:58:16.215732+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:53.440928+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2800"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:48 GMT
+      - Thu, 22 Feb 2024 07:33:24 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2362,7 +2362,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bef862a8-b011-45ef-9be6-46e855721cab
+      - 2da3072d-771a-4d1d-82fe-84647299326f
     status: 200 OK
     code: 200
     duration: ""
@@ -2373,27 +2373,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:58:16.215732+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:53.440928+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2800"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:53 GMT
+      - Thu, 22 Feb 2024 07:33:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2401,7 +2401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28f93a2b-48ba-4230-be27-bcc229427973
+      - 66150a73-0ba7-42c8-81db-d369c89ede5d
     status: 200 OK
     code: 200
     duration: ""
@@ -2412,27 +2412,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"40","hypervisor_id":"1601","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:58:16.215732+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.60.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"94","hypervisor_id":"702","node_id":"9","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:32:53.440928+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.114.17","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2767"
+      - "2800"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:58:58 GMT
+      - Thu, 22 Feb 2024 07:33:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2440,7 +2440,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7da7a4bd-3135-4bb5-b233-66c5503e44c1
+      - 61fc4f32-3d1c-48c8-8076-084112a45bca
     status: 200 OK
     code: 200
     duration: ""
@@ -2451,27 +2451,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:59:01.225236+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:33:39.511798+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2645"
+      - "2679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:03 GMT
+      - Thu, 22 Feb 2024 07:33:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2479,7 +2479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb6882d5-211b-4c1c-aad1-42672a8cfa69
+      - feaf144a-f441-49b5-b731-e115daefafeb
     status: 200 OK
     code: 200
     duration: ""
@@ -2490,27 +2490,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-12-05T10:57:18.688395+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-adoring-bouman","id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","image":{"arch":"x86_64","creation_date":"2023-11-27T16:12:47.639821+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"bc2f0ae3-bfca-4055-89c9-e84c54e568b1","modification_date":"2023-11-27T16:12:47.639821+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"6bc86f32-e6ca-4570-9823-daf6bc722114","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:30:ca:fb","maintenances":[],"modification_date":"2023-12-05T10:59:01.225236+00:00","name":"tf-srv-adoring-bouman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-12-05T10:57:18.688395+00:00","export_uri":null,"id":"216afa50-07ae-4537-8510-03ed8f00e9b7","modification_date":"2023-12-05T10:57:58.969959+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","name":"tf-srv-adoring-bouman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.021118+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hardcore-heyrovsky","id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a9","maintenances":[],"modification_date":"2024-02-22T07:33:39.511798+00:00","name":"tf-srv-hardcore-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.021118+00:00","export_uri":null,"id":"0dcf622a-e575-4429-a444-2eb3067011c2","modification_date":"2024-02-22T07:32:43.963326+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","name":"tf-srv-hardcore-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2645"
+      - "2679"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:03 GMT
+      - Thu, 22 Feb 2024 07:33:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2518,7 +2518,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79547777-2f59-4f60-a183-76bbfe8af3e1
+      - 97c8bedb-4e43-4c8d-aaa0-e70ec73ca946
     status: 200 OK
     code: 200
     duration: ""
@@ -2529,7 +2529,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: DELETE
   response:
     body: ""
@@ -2537,9 +2537,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:59:04 GMT
+      - Thu, 22 Feb 2024 07:33:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2547,7 +2547,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4521d6bb-feb1-4c13-b065-4a48e20613da
+      - 52ed0997-9053-478c-a9ac-9291505b138f
     status: 204 No Content
     code: 204
     duration: ""
@@ -2558,10 +2558,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -2570,9 +2570,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:04 GMT
+      - Thu, 22 Feb 2024 07:33:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2580,7 +2580,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 240296f1-65f2-4766-bf0a-a2d07ec0aec7
+      - 6d67db17-3b69-4d87-a6f4-297cb587c95e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2591,7 +2591,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/216afa50-07ae-4537-8510-03ed8f00e9b7
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0dcf622a-e575-4429-a444-2eb3067011c2
     method: DELETE
   response:
     body: ""
@@ -2599,9 +2599,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 05 Dec 2023 10:59:04 GMT
+      - Thu, 22 Feb 2024 07:33:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2609,7 +2609,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1dd3220-1a27-4c9d-949c-e4e325dca674
+      - 38554350-677a-4c90-9b43-7a72110c7098
     status: 204 No Content
     code: 204
     duration: ""
@@ -2620,10 +2620,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/79adb1c4-e0ab-463b-ae01-17c2b1224caf
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/images/2d8a28a9-9555-4802-ab09-19bbd642622b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_image","resource_id":"79adb1c4-e0ab-463b-ae01-17c2b1224caf","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_image","resource_id":"2d8a28a9-9555-4802-ab09-19bbd642622b","type":"not_found"}'
     headers:
       Content-Length:
       - "142"
@@ -2632,9 +2632,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:04 GMT
+      - Thu, 22 Feb 2024 07:33:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2642,7 +2642,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7ac1c59-9148-42c7-93da-3f3f0f8027f6
+      - 2234a78a-3e36-46fb-9c9d-6121373963c8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2653,10 +2653,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/0b4789d3-2c63-4b41-a774-9bae410cd377
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/78abf11c-ef48-481d-8d4b-4a0ce6d0158f
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"0b4789d3-2c63-4b41-a774-9bae410cd377","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"78abf11c-ef48-481d-8d4b-4a0ce6d0158f","type":"not_found"}'
     headers:
       Content-Length:
       - "145"
@@ -2665,9 +2665,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:04 GMT
+      - Thu, 22 Feb 2024 07:33:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2675,7 +2675,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0310a62d-0ffb-4f87-860f-8fb0378c1c3f
+      - c971c3f8-8e3b-4215-b5fc-39746aab11de
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2686,10 +2686,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/695ce704-ecd1-4103-a6be-ebc741a8fb7a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0a3bc9af-b4f6-4076-9d2d-8d5eff13343e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"695ce704-ecd1-4103-a6be-ebc741a8fb7a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"0a3bc9af-b4f6-4076-9d2d-8d5eff13343e","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -2698,9 +2698,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 05 Dec 2023 10:59:04 GMT
+      - Thu, 22 Feb 2024 07:33:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2708,7 +2708,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ee69991-e724-4d66-aae6-b9745a6829fa
+      - d6de4442-8cc3-48ca-af0b-15778360fe91
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-server-block-external.cassette.yaml
+++ b/scaleway/testdata/instance-server-block-external.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"tf-volume-determined-goldberg","perf_iops":5000,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","from_empty":{"size":10000000000},"tags":null}'
+    body: '{"name":"tf-volume-charming-jang","perf_iops":5000,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","from_empty":{"size":10000000000},"tags":[]}'
     form: {}
     headers:
       Content-Type:
@@ -13,18 +13,18 @@ interactions:
     url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":null,"name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"creating","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T12:59:10.664342Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":null,"name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"creating","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:05:26.706891Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "412"
+      - "420"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:10 GMT
+      - Wed, 21 Feb 2024 14:05:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 023c1933-b0e9-4b6c-870a-c2f9eeaa040c
+      - 80bb9436-a20f-4ab5-a6d8-ea63a92d0af2
     status: 200 OK
     code: 200
     duration: ""
@@ -43,21 +43,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":null,"name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"creating","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T12:59:10.664342Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":null,"name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"creating","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:05:26.706891Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "412"
+      - "420"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:10 GMT
+      - Wed, 21 Feb 2024 14:05:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5a52758-0092-4c5f-a23e-d53d8351bbdd
+      - cf3127c5-34a3-4484-822d-14d82e961b00
     status: 200 OK
     code: 200
     duration: ""
@@ -76,21 +76,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":null,"name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T12:59:10.749816Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":null,"name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:05:26.862886Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "413"
+      - "421"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:15 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a8ef6aa-91f1-4ce4-8ce0-2f8ef73fea9c
+      - fb9b3c33-5c48-4a27-adb7-4237c1bca9b5
     status: 200 OK
     code: 200
     duration: ""
@@ -109,21 +109,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":null,"name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T12:59:10.749816Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":null,"name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:05:26.862886Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "413"
+      - "421"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:15 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -131,7 +131,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2968dccb-4a96-49f6-9283-22bd55e6b2f6
+      - b14ee792-936c-44d7-8d81-802974cf6103
     status: 200 OK
     code: 200
     duration: ""
@@ -145,18 +145,18 @@ interactions:
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"d206b7e7-6d66-485c-85a6-d8acf220e62c","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"f0d486ff-f178-4941-ad62-8bbda478b53a","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"9467798a-e554-4658-a008-82a868d42a3b","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1183"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:15 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -164,7 +164,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fd887bc-499e-440c-ba96-8e502379f22b
+      - a5dac798-0b8f-4035-95e5-58da5a309352
     status: 200 OK
     code: 200
     duration: ""
@@ -178,21 +178,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38421"
+      - "38183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:15 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -200,9 +200,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59b0ea4a-5e96-4963-95e3-83ffe7081eff
+      - 52ba8ef0-d81b-43cf-9a22-329ca1aac038
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
@@ -216,21 +216,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4865"
+      - "8882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:16 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -238,9 +238,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44b4806d-a531-4083-b6a0-a67df6ee3cb6
+      - 8bdee853-292b-43cf-9e59-d87eca5000fa
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
@@ -251,10 +251,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"da652b3f-21e0-4b38-bc54-00f919518ed7","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -263,9 +263,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:16 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -273,7 +273,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 942a0550-f1ff-4c39-a797-608c36e8d8e1
+      - 01090bbb-fa3b-4a55-b5ba-36a31641f1c2
     status: 404 Not Found
     code: 404
     duration: ""
@@ -284,21 +284,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":null,"name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T12:59:10.749816Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":null,"name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:05:26.862886Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "413"
+      - "421"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:16 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -306,12 +306,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ddc90937-bd9f-4a2e-8ff8-f437471890f0
+      - 1d3373fb-538e-43ab-a0ee-53a841ce9c44
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-awesome-sutherland","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"PLAY2-PICO","image":"8668cacd-51d6-43b5-88ed-abeda429cdb2","volumes":{"0":{"boot":false,"volume_type":"b_ssd"},"1":{"id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","volume_type":"sbs_volume"}},"boot_type":"local","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b"}'
+    body: '{"name":"tf-srv-vigilant-golick","dynamic_ip_required":false,"commercial_type":"PLAY2-PICO","image":"9467798a-e554-4658-a008-82a868d42a3b","volumes":{"0":{"boot":false,"volume_type":"b_ssd"},"1":{"id":"da652b3f-21e0-4b38-bc54-00f919518ed7","volume_type":"sbs_volume"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -324,24 +324,24 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:16.707901+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:33.783923+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"da652b3f-21e0-4b38-bc54-00f919518ed7","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2770"
+      - "2783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:17 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -349,7 +349,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1814d7c0-55e1-49f5-80de-883ce7608334
+      - e04a721b-5090-4557-8e75-a7d55191b756
     status: 201 Created
     code: 201
     duration: ""
@@ -360,27 +360,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:16.707901+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:33.783923+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"da652b3f-21e0-4b38-bc54-00f919518ed7","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2770"
+      - "2783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:17 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -388,7 +388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45081b01-0e19-4b19-821f-ff1155dc5b9b
+      - 318d6831-23ca-465d-a969-aa1a605f2a51
     status: 200 OK
     code: 200
     duration: ""
@@ -399,27 +399,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:16.707901+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:33.783923+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"da652b3f-21e0-4b38-bc54-00f919518ed7","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2770"
+      - "2783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:17 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -427,7 +427,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2682b2d9-c6c4-4a77-b83e-fc3750d249e7
+      - ecc663e0-13be-44bd-b4ba-7a0ab1d1df46
     status: 200 OK
     code: 200
     duration: ""
@@ -438,21 +438,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":null,"name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[{"created_at":"2023-11-23T12:59:16.813947Z","id":"cf4e57a4-800c-48e4-a132-dbc0e87da6c1","product_resource_id":"f33fce43-05a4-4c55-9636-60982d200a9d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T12:59:16.813947Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":null,"name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2024-02-21T14:05:33.947753Z","id":"7b098277-4ca2-437f-9902-fb755a7cc842","product_resource_id":"93d531c8-5298-415b-b1e6-053a462f8139","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:05:33.947753Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "640"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:17 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -460,7 +460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a8aad6b-5959-45f3-9264-8ae23053d4d2
+      - d50a1ebe-7a1f-4b2b-8f94-885a873d3d07
     status: 200 OK
     code: 200
     duration: ""
@@ -473,10 +473,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/f33fce43-05a4-4c55-9636-60982d200a9d/action","href_result":"/servers/f33fce43-05a4-4c55-9636-60982d200a9d","id":"496aed72-a094-4c92-ad1e-bcea90fb83ce","started_at":"2023-11-23T12:59:18.384579+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/93d531c8-5298-415b-b1e6-053a462f8139/action","href_result":"/servers/93d531c8-5298-415b-b1e6-053a462f8139","id":"0feb4667-e7e0-400d-bc00-45fe2e7b8e70","started_at":"2024-02-21T14:05:35.206406+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -485,11 +485,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:18 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/496aed72-a094-4c92-ad1e-bcea90fb83ce
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/0feb4667-e7e0-400d-bc00-45fe2e7b8e70
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8372f2eb-0252-430b-a753-0f6ae01a1b6f
+      - 12b937c6-d248-413f-8be9-9c926acf9bb4
     status: 202 Accepted
     code: 202
     duration: ""
@@ -508,27 +508,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:17.910720+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:35.052003+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"da652b3f-21e0-4b38-bc54-00f919518ed7","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2792"
+      - "2805"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:18 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -536,7 +536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e928776-4f8b-4217-b266-9f6345ae0702
+      - e84cb0f7-542e-419e-a1bf-2485b58f3b0b
     status: 200 OK
     code: 200
     duration: ""
@@ -547,27 +547,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:17.910720+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:35.052003+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"da652b3f-21e0-4b38-bc54-00f919518ed7","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2901"
+      - "2915"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:24 GMT
+      - Wed, 21 Feb 2024 14:05:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -575,7 +575,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aecc69f6-9521-492d-a3bf-6b3c69cadcdb
+      - 92b247c0-7c4a-476c-8d65-46e682669254
     status: 200 OK
     code: 200
     duration: ""
@@ -586,27 +586,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:17.910720+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:35.052003+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"da652b3f-21e0-4b38-bc54-00f919518ed7","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2901"
+      - "2915"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:29 GMT
+      - Wed, 21 Feb 2024 14:05:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -614,7 +614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3acc172-9df2-4611-a9d9-adb793e65933
+      - fdf8acb8-3225-4366-8853-f0cc81987075
     status: 200 OK
     code: 200
     duration: ""
@@ -625,27 +625,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:31.660373+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:49.776987+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"da652b3f-21e0-4b38-bc54-00f919518ed7","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2932"
+      - "2946"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:34 GMT
+      - Wed, 21 Feb 2024 14:05:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -653,7 +653,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e15e0587-5d5e-4fc9-80eb-efd69e210c37
+      - a1cebd55-7122-433c-bb2c-c7f5485d1fe6
     status: 200 OK
     code: 200
     duration: ""
@@ -664,27 +664,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:31.660373+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:49.776987+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"da652b3f-21e0-4b38-bc54-00f919518ed7","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2932"
+      - "2946"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:34 GMT
+      - Wed, 21 Feb 2024 14:05:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -692,7 +692,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ee2344c-70b1-4948-8904-7e232dd48320
+      - 5c92825f-3c87-406c-a631-b3f63849ebe7
     status: 200 OK
     code: 200
     duration: ""
@@ -703,7 +703,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -715,9 +715,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:34 GMT
+      - Wed, 21 Feb 2024 14:05:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -725,7 +725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f57c66ce-3d7a-4744-9d1e-b79279e06b33
+      - 11c72bd6-7778-4903-9666-d2a6ed2783dd
     status: 200 OK
     code: 200
     duration: ""
@@ -736,7 +736,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -748,12 +748,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:34 GMT
+      - Wed, 21 Feb 2024 14:05:52 GMT
       Link:
-      - </servers/f33fce43-05a4-4c55-9636-60982d200a9d/private_nics?page=0&per_page=50&>;
+      - </servers/93d531c8-5298-415b-b1e6-053a462f8139/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -761,7 +761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da61bf22-9a5a-4b40-b517-6a5038dc630a
+      - 50164317-004a-4b09-8aef-a9f8d3a68ce2
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -774,21 +774,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":null,"name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[{"created_at":"2023-11-23T12:59:16.813947Z","id":"cf4e57a4-800c-48e4-a132-dbc0e87da6c1","product_resource_id":"f33fce43-05a4-4c55-9636-60982d200a9d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T12:59:16.813947Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":null,"name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2024-02-21T14:05:33.947753Z","id":"7b098277-4ca2-437f-9902-fb755a7cc842","product_resource_id":"93d531c8-5298-415b-b1e6-053a462f8139","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:05:33.947753Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "640"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:35 GMT
+      - Wed, 21 Feb 2024 14:05:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -796,7 +796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 322384d4-0baf-4101-831c-6bb8ba1bdcd0
+      - 11787b4b-1a3d-41fa-a0d1-6315945be0f4
     status: 200 OK
     code: 200
     duration: ""
@@ -807,27 +807,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:31.660373+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:49.776987+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"da652b3f-21e0-4b38-bc54-00f919518ed7","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2932"
+      - "2946"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:35 GMT
+      - Wed, 21 Feb 2024 14:05:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -835,7 +835,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e6a2a6b-e0ed-46b3-8057-cd3f69b5c847
+      - cf5fbed2-7883-4a4b-8609-9c05748ff9c8
     status: 200 OK
     code: 200
     duration: ""
@@ -846,7 +846,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -858,9 +858,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:35 GMT
+      - Wed, 21 Feb 2024 14:05:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -868,7 +868,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22def15f-b5d5-465c-aead-853a7bec7116
+      - e73614be-ea05-4e6c-af5f-a059293b8c35
     status: 200 OK
     code: 200
     duration: ""
@@ -879,7 +879,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -891,12 +891,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:35 GMT
+      - Wed, 21 Feb 2024 14:05:53 GMT
       Link:
-      - </servers/f33fce43-05a4-4c55-9636-60982d200a9d/private_nics?page=0&per_page=50&>;
+      - </servers/93d531c8-5298-415b-b1e6-053a462f8139/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -904,7 +904,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e81ea88-02f9-480c-959e-f0b9dbd21b04
+      - 3206a063-09cc-49b9-8b77-89ddd0405ed1
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -917,21 +917,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":null,"name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[{"created_at":"2023-11-23T12:59:16.813947Z","id":"cf4e57a4-800c-48e4-a132-dbc0e87da6c1","product_resource_id":"f33fce43-05a4-4c55-9636-60982d200a9d","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T12:59:16.813947Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":null,"name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2024-02-21T14:05:33.947753Z","id":"7b098277-4ca2-437f-9902-fb755a7cc842","product_resource_id":"93d531c8-5298-415b-b1e6-053a462f8139","product_resource_type":"instance_server","status":"attached","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:05:33.947753Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "640"
+      - "653"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:36 GMT
+      - Wed, 21 Feb 2024 14:05:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -939,7 +939,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43c6eb8e-42c5-4abb-8749-e4fffc4e400e
+      - f7195a37-0fc4-4590-b3b6-0573fe862e92
     status: 200 OK
     code: 200
     duration: ""
@@ -950,27 +950,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:31.660373+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:49.776987+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"da652b3f-21e0-4b38-bc54-00f919518ed7","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2932"
+      - "2946"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:36 GMT
+      - Wed, 21 Feb 2024 14:05:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -978,7 +978,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3648e4c1-d2f0-4329-b0f0-eead0d614350
+      - 7cc65ec9-16e2-490f-b9ac-9fed0eae45d2
     status: 200 OK
     code: 200
     duration: ""
@@ -989,7 +989,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1001,9 +1001,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:36 GMT
+      - Wed, 21 Feb 2024 14:05:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1011,7 +1011,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f594ef6e-7465-43ac-a8a8-29774bf879aa
+      - 81230bdc-b21a-4b66-841f-50db3d58a0b9
     status: 200 OK
     code: 200
     duration: ""
@@ -1022,7 +1022,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1034,12 +1034,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:36 GMT
+      - Wed, 21 Feb 2024 14:05:53 GMT
       Link:
-      - </servers/f33fce43-05a4-4c55-9636-60982d200a9d/private_nics?page=0&per_page=50&>;
+      - </servers/93d531c8-5298-415b-b1e6-053a462f8139/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1047,7 +1047,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 291a29ba-694e-4eaa-94f2-519225b81145
+      - 8e9a5152-016f-4300-af49-7d0d29e4c79d
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1060,27 +1060,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:31.660373+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:49.776987+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"1":{"boot":false,"id":"da652b3f-21e0-4b38-bc54-00f919518ed7","volume_type":"sbs_volume"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2932"
+      - "2946"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:36 GMT
+      - Wed, 21 Feb 2024 14:05:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1088,12 +1088,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf1d99b7-75df-4deb-85b0-a55e5a470960
+      - 82be8e98-b79e-44d2-b0bc-25e30200bbb0
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"volumes":{"0":{"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","boot":false,"name":"tf-vol-boring-cerf"}}}'
+    body: '{"volumes":{"0":{"id":"6f209834-2092-4006-bd29-d7c392c76779","boot":false,"name":"tf-vol-sleepy-hamilton"}}}'
     form: {}
     headers:
       Content-Type:
@@ -1101,27 +1101,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: PATCH
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:31.660373+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:49.776987+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2835"
+      - "2849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:37 GMT
+      - Wed, 21 Feb 2024 14:05:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1129,7 +1129,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bc2dd238-e6f9-46bc-9731-bea32f676f47
+      - 80f13666-2857-4bdf-9304-e72658bd86c2
     status: 200 OK
     code: 200
     duration: ""
@@ -1140,27 +1140,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:31.660373+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:49.776987+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2835"
+      - "2849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:37 GMT
+      - Wed, 21 Feb 2024 14:05:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1168,7 +1168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cb2886b-7396-4c59-984e-7252b431878e
+      - 3861afc1-2da9-4eba-add2-a74a7423165a
     status: 200 OK
     code: 200
     duration: ""
@@ -1179,27 +1179,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:31.660373+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:49.776987+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2835"
+      - "2849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:37 GMT
+      - Wed, 21 Feb 2024 14:05:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1207,7 +1207,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2746574-8844-419d-94da-1ea3b54928ef
+      - c8e29238-9b87-4023-8c20-88f8afac6d98
     status: 200 OK
     code: 200
     duration: ""
@@ -1218,7 +1218,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1230,9 +1230,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:37 GMT
+      - Wed, 21 Feb 2024 14:05:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1240,7 +1240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a63a65b-f0ce-48de-8eef-8de125281c5e
+      - fb851dbc-1bed-4448-a351-b43eb0909bae
     status: 200 OK
     code: 200
     duration: ""
@@ -1251,7 +1251,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1263,12 +1263,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:37 GMT
+      - Wed, 21 Feb 2024 14:05:55 GMT
       Link:
-      - </servers/f33fce43-05a4-4c55-9636-60982d200a9d/private_nics?page=0&per_page=50&>;
+      - </servers/93d531c8-5298-415b-b1e6-053a462f8139/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1276,7 +1276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aadf7de0-d15a-402c-a51d-4f9b1b183286
+      - bbde06b0-42be-4ebf-a238-b110467bb547
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1289,21 +1289,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":null,"name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[{"created_at":"2023-11-23T12:59:16.813947Z","id":"cf4e57a4-800c-48e4-a132-dbc0e87da6c1","product_resource_id":"f33fce43-05a4-4c55-9636-60982d200a9d","product_resource_type":"instance_server","status":"detaching","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T12:59:16.813947Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":null,"name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2024-02-21T14:05:33.947753Z","id":"7b098277-4ca2-437f-9902-fb755a7cc842","product_resource_id":"93d531c8-5298-415b-b1e6-053a462f8139","product_resource_type":"instance_server","status":"detaching","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:05:33.947753Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "654"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:38 GMT
+      - Wed, 21 Feb 2024 14:05:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1311,7 +1311,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 619e2bb7-eb55-47e3-9c73-9eab1979e893
+      - 8019c4b1-45d1-4bb3-baa8-c202785e1c55
     status: 200 OK
     code: 200
     duration: ""
@@ -1322,27 +1322,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:31.660373+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:49.776987+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2835"
+      - "2849"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:38 GMT
+      - Wed, 21 Feb 2024 14:05:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1350,7 +1350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a02a300-cb05-4973-a613-3d5dcb8160f2
+      - 32c97255-33c2-4a01-8216-9624c8440e80
     status: 200 OK
     code: 200
     duration: ""
@@ -1361,7 +1361,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1373,9 +1373,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:38 GMT
+      - Wed, 21 Feb 2024 14:05:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1383,7 +1383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96a3bcac-42f0-4dfc-85fe-c7568916fa8b
+      - 1a9a07fd-01a3-4554-bf65-d8c2d9467f46
     status: 200 OK
     code: 200
     duration: ""
@@ -1394,7 +1394,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1406,12 +1406,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:38 GMT
+      - Wed, 21 Feb 2024 14:05:57 GMT
       Link:
-      - </servers/f33fce43-05a4-4c55-9636-60982d200a9d/private_nics?page=0&per_page=50&>;
+      - </servers/93d531c8-5298-415b-b1e6-053a462f8139/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1419,7 +1419,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ed9d2556-c5fd-4bd4-86fe-18e292a6828e
+      - ea59dc5f-bf1e-4f19-bbcb-25b479f755dd
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1432,21 +1432,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":null,"name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[{"created_at":"2023-11-23T12:59:16.813947Z","id":"cf4e57a4-800c-48e4-a132-dbc0e87da6c1","product_resource_id":"f33fce43-05a4-4c55-9636-60982d200a9d","product_resource_type":"instance_server","status":"detaching","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T12:59:16.813947Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":null,"name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2024-02-21T14:05:33.947753Z","id":"7b098277-4ca2-437f-9902-fb755a7cc842","product_resource_id":"93d531c8-5298-415b-b1e6-053a462f8139","product_resource_type":"instance_server","status":"detaching","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:05:33.947753Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "654"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:43 GMT
+      - Wed, 21 Feb 2024 14:06:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1454,7 +1454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78bcf09b-dabb-428b-a9f8-b362c12abf14
+      - 8ed89c35-a15d-49ca-8a1d-975648d73108
     status: 200 OK
     code: 200
     duration: ""
@@ -1465,21 +1465,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":null,"name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[{"created_at":"2023-11-23T12:59:16.813947Z","id":"cf4e57a4-800c-48e4-a132-dbc0e87da6c1","product_resource_id":"f33fce43-05a4-4c55-9636-60982d200a9d","product_resource_type":"instance_server","status":"detaching","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T12:59:16.813947Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":null,"name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2024-02-21T14:05:33.947753Z","id":"7b098277-4ca2-437f-9902-fb755a7cc842","product_resource_id":"93d531c8-5298-415b-b1e6-053a462f8139","product_resource_type":"instance_server","status":"detaching","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:05:33.947753Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "654"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:48 GMT
+      - Wed, 21 Feb 2024 14:06:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1487,7 +1487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1b48325-5b1d-42d5-bf03-2a0ae6a0a608
+      - da5b83ca-b44d-4b63-bae6-72623075d24b
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,21 +1498,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":null,"name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[{"created_at":"2023-11-23T12:59:16.813947Z","id":"cf4e57a4-800c-48e4-a132-dbc0e87da6c1","product_resource_id":"f33fce43-05a4-4c55-9636-60982d200a9d","product_resource_type":"instance_server","status":"detaching","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T12:59:16.813947Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":null,"name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2024-02-21T14:05:33.947753Z","id":"7b098277-4ca2-437f-9902-fb755a7cc842","product_resource_id":"93d531c8-5298-415b-b1e6-053a462f8139","product_resource_type":"instance_server","status":"detaching","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:05:33.947753Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "654"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:53 GMT
+      - Wed, 21 Feb 2024 14:06:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1520,7 +1520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99b7df8c-30c9-4d79-8e5c-1dbd803df6d5
+      - c9e384fc-4735-46a4-b7b5-214bed9f4d5c
     status: 200 OK
     code: 200
     duration: ""
@@ -1531,21 +1531,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":null,"name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[{"created_at":"2023-11-23T12:59:16.813947Z","id":"cf4e57a4-800c-48e4-a132-dbc0e87da6c1","product_resource_id":"f33fce43-05a4-4c55-9636-60982d200a9d","product_resource_type":"instance_server","status":"detaching","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T12:59:16.813947Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":null,"name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2024-02-21T14:05:33.947753Z","id":"7b098277-4ca2-437f-9902-fb755a7cc842","product_resource_id":"93d531c8-5298-415b-b1e6-053a462f8139","product_resource_type":"instance_server","status":"detaching","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:05:33.947753Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "654"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 12:59:58 GMT
+      - Wed, 21 Feb 2024 14:06:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1553,7 +1553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06b55068-0716-4689-818d-6386c2f7ead1
+      - 99a9261e-a4b7-4a17-9817-d3936ddaf21b
     status: 200 OK
     code: 200
     duration: ""
@@ -1564,21 +1564,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":null,"name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[{"created_at":"2023-11-23T12:59:16.813947Z","id":"cf4e57a4-800c-48e4-a132-dbc0e87da6c1","product_resource_id":"f33fce43-05a4-4c55-9636-60982d200a9d","product_resource_type":"instance_server","status":"detaching","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T12:59:16.813947Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":null,"name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[{"created_at":"2024-02-21T14:05:33.947753Z","id":"7b098277-4ca2-437f-9902-fb755a7cc842","product_resource_id":"93d531c8-5298-415b-b1e6-053a462f8139","product_resource_type":"instance_server","status":"detaching","type":"exclusive"}],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"in_use","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:05:33.947753Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "641"
+      - "654"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:03 GMT
+      - Wed, 21 Feb 2024 14:06:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1586,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b070950-43d4-4443-8d94-3d779aef1150
+      - 9fb695dd-75ab-4c2a-85f8-095ab0fb3f3e
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,21 +1597,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":"2023-11-23T13:00:08.128865Z","name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T13:00:08.148646Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":"2024-02-21T14:06:26.368951Z","name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:06:26.368951Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "438"
+      - "446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:09 GMT
+      - Wed, 21 Feb 2024 14:06:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1619,7 +1619,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7943a8e1-1906-4634-a69f-9ce1afb8b378
+      - 136a8904-cebc-4d53-89a1-6e80e4df63b5
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,21 +1630,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"created_at":"2023-11-23T12:59:10.664342Z","id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","last_detached_at":"2023-11-23T13:00:08.128865Z","name":"tf-volume-determined-goldberg","parent_snapshot_id":null,"project_id":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2023-11-23T13:00:08.148646Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-21T14:05:26.706891Z","id":"da652b3f-21e0-4b38-bc54-00f919518ed7","last_detached_at":"2024-02-21T14:06:26.368951Z","name":"tf-volume-charming-jang","parent_snapshot_id":null,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","references":[],"size":10000000000,"specs":{"class":"sbs","perf_iops":5000},"status":"available","tags":[],"type":"sbs_5k","updated_at":"2024-02-21T14:06:26.368951Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "438"
+      - "446"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:09 GMT
+      - Wed, 21 Feb 2024 14:06:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1652,7 +1652,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3186da5-49e2-4604-9bd6-d2a34455d196
+      - cfe245e2-2281-4549-bfc8-515c81a375a0
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,7 +1663,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: DELETE
   response:
     body: ""
@@ -1673,9 +1673,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:09 GMT
+      - Wed, 21 Feb 2024 14:06:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1683,7 +1683,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1d1385a-e873-4805-b88e-58e1b3f4d7f1
+      - eaeb458f-b4e2-4fb1-892b-ed846c692fe7
     status: 204 No Content
     code: 204
     duration: ""
@@ -1694,21 +1694,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"volume","resource_id":"f4d2ba2a-030d-4de5-92ea-7bd9b0c0a2c5","type":"not_found"}'
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:05:49.776987+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "127"
+      - "2841"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:09 GMT
+      - Wed, 21 Feb 2024 14:06:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1716,9 +1722,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 341f5d61-3c28-4558-abbe-ec9dc3a31dd4
-    status: 404 Not Found
-    code: 404
+      - 00c8f423-ec40-448d-9178-75a21c43df0e
+    status: 200 OK
+    code: 200
     duration: ""
 - request:
     body: ""
@@ -1727,27 +1733,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/block/v1alpha1/zones/fr-par-1/volumes/da652b3f-21e0-4b38-bc54-00f919518ed7
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T12:59:31.660373+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"message":"resource is not found","resource":"volume","resource_id":"da652b3f-21e0-4b38-bc54-00f919518ed7","type":"not_found"}'
     headers:
       Content-Length:
-      - "2827"
+      - "127"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:09 GMT
+      - Wed, 21 Feb 2024 14:06:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1755,9 +1755,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1ad6996d-265e-4d90-bd99-21da66dd7ae3
-    status: 200 OK
-    code: 200
+      - fc641fe1-c5c5-4849-8e1d-477f460b2145
+    status: 404 Not Found
+    code: 404
     duration: ""
 - request:
     body: '{"action":"poweroff"}'
@@ -1768,10 +1768,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/f33fce43-05a4-4c55-9636-60982d200a9d/action","href_result":"/servers/f33fce43-05a4-4c55-9636-60982d200a9d","id":"478168fc-1778-4817-bc68-07941a9d2cbd","started_at":"2023-11-23T13:00:10.038479+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/93d531c8-5298-415b-b1e6-053a462f8139/action","href_result":"/servers/93d531c8-5298-415b-b1e6-053a462f8139","id":"dacd491b-a3d4-4a8c-9d9d-e14f50033635","started_at":"2024-02-21T14:06:28.728068+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -1780,11 +1780,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:10 GMT
+      - Wed, 21 Feb 2024 14:06:28 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/478168fc-1778-4817-bc68-07941a9d2cbd
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/dacd491b-a3d4-4a8c-9d9d-e14f50033635
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1792,7 +1792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c225928-5ef8-45ba-90a3-7dd37958b2bb
+      - c19aec89-f82c-44de-aeb7-b569b2802cae
     status: 202 Accepted
     code: 202
     duration: ""
@@ -1803,27 +1803,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T13:00:09.884468+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:06:28.565775+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2795"
+      - "2809"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:10 GMT
+      - Wed, 21 Feb 2024 14:06:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1831,7 +1831,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfe5fb5e-e4e9-429d-90cb-a7180c7e2472
+      - efe0a29d-ca68-427f-a9ce-e95866c407c4
     status: 200 OK
     code: 200
     duration: ""
@@ -1842,27 +1842,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T13:00:09.884468+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:06:28.565775+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2795"
+      - "2809"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:15 GMT
+      - Wed, 21 Feb 2024 14:06:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1870,7 +1870,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40e7f5d2-55e5-424a-8592-8a93f3ec4c96
+      - 43bd06e0-c2d1-4960-a7b6-c878b2f7550c
     status: 200 OK
     code: 200
     duration: ""
@@ -1881,27 +1881,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T13:00:09.884468+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:06:28.565775+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2795"
+      - "2809"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:20 GMT
+      - Wed, 21 Feb 2024 14:06:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1909,7 +1909,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb1b0256-2380-402f-89a9-9b9f1c96af20
+      - 3ab6dc66-521c-418a-a54b-ca3a788eb8a6
     status: 200 OK
     code: 200
     duration: ""
@@ -1920,27 +1920,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"901","node_id":"34","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T13:00:09.884468+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":"10.76.160.67","private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:06:28.565775+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2795"
+      - "2809"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:25 GMT
+      - Wed, 21 Feb 2024 14:06:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1948,7 +1948,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e4596435-6409-4f8f-b66f-e2898f81bfaa
+      - b8387e4d-8c5b-4155-a936-6493aa8a7f75
     status: 200 OK
     code: 200
     duration: ""
@@ -1959,27 +1959,66 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"60","hypervisor_id":"201","node_id":"72","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:06:28.565775+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.132.143","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2809"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 60c4d506-da12-46b9-b0cf-6304aead7f33
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T13:00:30.644610+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:06:51.873866+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2673"
+      - "2686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:31 GMT
+      - Wed, 21 Feb 2024 14:06:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1987,7 +2026,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba547dee-a608-47aa-89f9-ed1af52ebf1f
+      - a681b06a-5f6b-4140-b6f9-7fb34fcf745e
     status: 200 OK
     code: 200
     duration: ""
@@ -1998,27 +2037,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2023-11-23T12:59:16.707901+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-awesome-sutherland","id":"f33fce43-05a4-4c55-9636-60982d200a9d","image":{"arch":"x86_64","creation_date":"2023-11-08T10:06:36.355820+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"8668cacd-51d6-43b5-88ed-abeda429cdb2","modification_date":"2023-11-08T10:06:36.355820+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"91aac403-e7d7-4a4a-abbd-e8958c1d1f8d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2e:f1:89","maintenances":[],"modification_date":"2023-11-23T13:00:30.644610+00:00","name":"tf-srv-awesome-sutherland","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","placement_group":null,"private_ip":null,"private_nics":[],"project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"0fe819c3-274d-472a-b3f5-ddb258d2d8bb","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-23T12:59:16.707901+00:00","export_uri":null,"id":"70e58c0f-1b14-4baa-be18-b6c58bea20e4","modification_date":"2023-11-23T12:59:16.707901+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","project":"ee7bd9e1-9cbd-4724-b2f4-19e50f3cf38b","server":{"id":"f33fce43-05a4-4c55-9636-60982d200a9d","name":"tf-srv-awesome-sutherland"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-02-21T14:05:33.783923+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-golick","id":"93d531c8-5298-415b-b1e6-053a462f8139","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:51","maintenances":[],"modification_date":"2024-02-21T14:06:51.873866+00:00","name":"tf-srv-vigilant-golick","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:33.783923+00:00","export_uri":null,"id":"6f209834-2092-4006-bd29-d7c392c76779","modification_date":"2024-02-21T14:05:33.783923+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"93d531c8-5298-415b-b1e6-053a462f8139","name":"tf-srv-vigilant-golick"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2673"
+      - "2686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:31 GMT
+      - Wed, 21 Feb 2024 14:06:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2026,7 +2065,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bceb95f7-6b8b-46f1-8130-69086f4757e8
+      - 8f484cd8-1e6c-4b9c-9e1f-0e20c8ef082a
     status: 200 OK
     code: 200
     duration: ""
@@ -2037,7 +2076,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: DELETE
   response:
     body: ""
@@ -2045,9 +2084,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 23 Nov 2023 13:00:31 GMT
+      - Wed, 21 Feb 2024 14:06:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2055,7 +2094,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 645f3305-f71f-4e41-b6dd-e6e1af989b36
+      - c7ecdd54-75ed-4c99-b93a-e7917ca856fa
     status: 204 No Content
     code: 204
     duration: ""
@@ -2066,10 +2105,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"f33fce43-05a4-4c55-9636-60982d200a9d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"93d531c8-5298-415b-b1e6-053a462f8139","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -2078,9 +2117,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:31 GMT
+      - Wed, 21 Feb 2024 14:06:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2088,7 +2127,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c84369b-d119-4955-880b-cf34adfc1abe
+      - 1b04084d-b42e-414d-9ea4-1de93248c851
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2099,7 +2138,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/70e58c0f-1b14-4baa-be18-b6c58bea20e4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/6f209834-2092-4006-bd29-d7c392c76779
     method: DELETE
   response:
     body: ""
@@ -2107,9 +2146,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 23 Nov 2023 13:00:31 GMT
+      - Wed, 21 Feb 2024 14:06:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2117,7 +2156,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e830bdeb-a706-4401-ae18-79f9b14fb9ac
+      - 81ab953c-3b27-4e6f-b89d-cc0bc3f6e26a
     status: 204 No Content
     code: 204
     duration: ""
@@ -2128,10 +2167,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f33fce43-05a4-4c55-9636-60982d200a9d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/93d531c8-5298-415b-b1e6-053a462f8139
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"f33fce43-05a4-4c55-9636-60982d200a9d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"93d531c8-5298-415b-b1e6-053a462f8139","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -2140,9 +2179,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 23 Nov 2023 13:00:32 GMT
+      - Wed, 21 Feb 2024 14:06:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2150,7 +2189,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 02e75ba1-9e66-427a-ba62-cabdd7e400ab
+      - 1ad67715-53e8-4c95-a6ec-dedf2bae67aa
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-server-ip-migrate.cassette.yaml
+++ b/scaleway/testdata/instance-server-ip-migrate.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"test-acc-scaleway-project-2872104608682628115","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":""}'
+    body: '{"name":"test-acc-scaleway-project-2752905409974357132","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":""}'
     form: {}
     headers:
       Content-Type:
@@ -13,18 +13,18 @@ interactions:
     url: https://api.scaleway.com/account/v3/projects
     method: POST
   response:
-    body: '{"created_at":"2023-10-31T14:30:58.854581Z","description":"","id":"726ee139-370b-4d7e-a75e-178cc13964ce","name":"test-acc-scaleway-project-2872104608682628115","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:30:58.854581Z"}'
+    body: '{"created_at":"2024-02-21T14:05:24.953101Z","description":"","id":"47ba0fed-4b93-4c54-806d-03f660477d5c","name":"test-acc-scaleway-project-2752905409974357132","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2024-02-21T14:05:24.953101Z"}'
     headers:
       Content-Length:
-      - "260"
+      - "265"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:30:59 GMT
+      - Wed, 21 Feb 2024 14:05:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -32,12 +32,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c545cffd-e083-49d9-996f-49c5e7425cbf
+      - d8cadb69-c25e-4817-99c2-72cb262e2b3b
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-acc-scaleway-iam-app-1629775288661479637","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":""}'
+    body: '{"name":"test-acc-scaleway-iam-app-6851140812600325765","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","tags":null}'
     form: {}
     headers:
       Content-Type:
@@ -48,18 +48,18 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/applications
     method: POST
   response:
-    body: '{"created_at":"2023-10-31T14:30:59.194236Z","description":"","editable":true,"id":"a613e751-f2dd-4268-a703-5239004dd2db","name":"test-acc-scaleway-iam-app-1629775288661479637","nb_api_keys":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:30:59.194236Z"}'
+    body: '{"created_at":"2024-02-21T14:05:25.238245Z","description":"","editable":true,"id":"6872b0d0-3a66-410f-b306-2c66852f5609","name":"test-acc-scaleway-iam-app-6851140812600325765","nb_api_keys":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:25.238245Z"}'
     headers:
       Content-Length:
-      - "292"
+      - "310"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:30:59 GMT
+      - Wed, 21 Feb 2024 14:05:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -67,12 +67,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62776215-48e9-4df5-9d1e-3cafd01eec59
+      - f96de71b-0853-44ce-9176-dbb62117b3d4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"test-acc-scaleway-iam-policy-9145000382146989693","description":"","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","rules":[{"permission_set_names":["IAMManager"],"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf"}],"application_id":"a613e751-f2dd-4268-a703-5239004dd2db"}'
+    body: '{"name":"test-acc-scaleway-iam-policy-4212863051137062010","description":"","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","rules":[{"permission_set_names":["IAMManager"],"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf"}],"tags":null,"application_id":"6872b0d0-3a66-410f-b306-2c66852f5609"}'
     form: {}
     headers:
       Content-Type:
@@ -83,18 +83,18 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/policies
     method: POST
   response:
-    body: '{"application_id":"a613e751-f2dd-4268-a703-5239004dd2db","created_at":"2023-10-31T14:30:59.281997Z","description":"","editable":true,"id":"972892cc-b539-4fc8-b099-895c3acbc3d7","name":"test-acc-scaleway-iam-policy-9145000382146989693","nb_permission_sets":0,"nb_rules":0,"nb_scopes":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:30:59.281997Z"}'
+    body: '{"application_id":"6872b0d0-3a66-410f-b306-2c66852f5609","created_at":"2024-02-21T14:05:25.347455Z","description":"","editable":true,"id":"729ec677-6459-4591-b6e1-93dfb708eff0","name":"test-acc-scaleway-iam-policy-4212863051137062010","nb_permission_sets":0,"nb_rules":0,"nb_scopes":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:25.347455Z"}'
     headers:
       Content-Length:
-      - "385"
+      - "406"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:30:59 GMT
+      - Wed, 21 Feb 2024 14:05:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -102,12 +102,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11219e65-8590-4b3b-b717-423b273e4329
+      - 44e6c816-df28-4fc5-a832-3b72d61c8c64
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"application_id":"a613e751-f2dd-4268-a703-5239004dd2db","default_project_id":"726ee139-370b-4d7e-a75e-178cc13964ce","description":""}'
+    body: '{"application_id":"6872b0d0-3a66-410f-b306-2c66852f5609","default_project_id":"47ba0fed-4b93-4c54-806d-03f660477d5c","description":""}'
     form: {}
     headers:
       Content-Type:
@@ -118,18 +118,18 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/api-keys
     method: POST
   response:
-    body: '{"access_key":"SCWDAWVW9R9DHGQP8RPS","application_id":"a613e751-f2dd-4268-a703-5239004dd2db","created_at":"2023-10-31T14:30:59.520455Z","creation_ip":"51.159.46.153","default_project_id":"726ee139-370b-4d7e-a75e-178cc13964ce","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2023-10-31T14:30:59.520455Z"}'
+    body: '{"access_key":"SCWGD7SA7AR5DS9FP83A","application_id":"6872b0d0-3a66-410f-b306-2c66852f5609","created_at":"2024-02-21T14:05:25.756328Z","creation_ip":"51.159.46.153","default_project_id":"47ba0fed-4b93-4c54-806d-03f660477d5c","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2024-02-21T14:05:25.756328Z"}'
     headers:
       Content-Length:
-      - "372"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:30:59 GMT
+      - Wed, 21 Feb 2024 14:05:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -137,12 +137,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ed45fef-83d3-4a52-a55f-8897174834f6
+      - d6345d16-4c0c-4681-a70b-5e472d3436e4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf_tests_instance_server_ipmigrate","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":""}'
+    body: '{"name":"tf_tests_instance_server_ipmigrate","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","tags":[]}'
     form: {}
     headers:
       Content-Type:
@@ -153,18 +153,18 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/applications
     method: POST
   response:
-    body: '{"created_at":"2023-10-31T14:31:00.874026Z","description":"","editable":true,"id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","name":"tf_tests_instance_server_ipmigrate","nb_api_keys":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:31:00.874026Z"}'
+    body: '{"created_at":"2024-02-21T14:05:26.697765Z","description":"","editable":true,"id":"7087053f-a01e-4607-af25-aecb17ae174f","name":"tf_tests_instance_server_ipmigrate","nb_api_keys":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:26.697765Z"}'
     headers:
       Content-Length:
-      - "281"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:00 GMT
+      - Wed, 21 Feb 2024 14:05:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -172,7 +172,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 113d43d7-3880-4573-bdaf-e9efe30b691e
+      - 89e1d694-82a4-4cbb-a024-191eef533088
     status: 200 OK
     code: 200
     duration: ""
@@ -183,21 +183,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c4fed393-9d12-4c97-ac5e-6464a5d185d8
+    url: https://api.scaleway.com/iam/v1alpha1/applications/7087053f-a01e-4607-af25-aecb17ae174f
     method: GET
   response:
-    body: '{"created_at":"2023-10-31T14:31:00.874026Z","description":"","editable":true,"id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","name":"tf_tests_instance_server_ipmigrate","nb_api_keys":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:31:00.874026Z"}'
+    body: '{"created_at":"2024-02-21T14:05:26.697765Z","description":"","editable":true,"id":"7087053f-a01e-4607-af25-aecb17ae174f","name":"tf_tests_instance_server_ipmigrate","nb_api_keys":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:26.697765Z"}'
     headers:
       Content-Length:
-      - "281"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:00 GMT
+      - Wed, 21 Feb 2024 14:05:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -205,12 +205,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1fe5e60-5fb9-4fd2-b057-7312398630f4
+      - f77f5488-01b8-4ffb-bdd1-68c55351d5d6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-policy-pensive-hopper","description":"","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","rules":[{"permission_set_names":["InstancesReadOnly"],"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf"},{"permission_set_names":["ProjectReadOnly","IAMReadOnly"],"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf"}],"application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8"}'
+    body: '{"name":"tf-policy-hardcore-boyd","description":"","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","rules":[{"permission_set_names":["InstancesReadOnly"],"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf"},{"permission_set_names":["ProjectReadOnly","IAMReadOnly"],"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf"}],"tags":[],"application_id":"7087053f-a01e-4607-af25-aecb17ae174f"}'
     form: {}
     headers:
       Content-Type:
@@ -221,18 +221,18 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/policies
     method: POST
   response:
-    body: '{"application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","created_at":"2023-10-31T14:31:01.059488Z","description":"","editable":true,"id":"4661c0a7-f94e-457c-b3b4-c806acbf0783","name":"tf-policy-pensive-hopper","nb_permission_sets":0,"nb_rules":0,"nb_scopes":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:31:01.059488Z"}'
+    body: '{"application_id":"7087053f-a01e-4607-af25-aecb17ae174f","created_at":"2024-02-21T14:05:26.878638Z","description":"","editable":true,"id":"a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1","name":"tf-policy-hardcore-boyd","nb_permission_sets":0,"nb_rules":0,"nb_scopes":0,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:26.878638Z"}'
     headers:
       Content-Length:
-      - "361"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:05:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -240,7 +240,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71d331c3-80df-45fe-a240-1132ba72d747
+      - 547c160b-4363-4916-98b5-3b12e2075588
     status: 200 OK
     code: 200
     duration: ""
@@ -251,21 +251,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/policies/4661c0a7-f94e-457c-b3b4-c806acbf0783
+    url: https://api.scaleway.com/iam/v1alpha1/policies/a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1
     method: GET
   response:
-    body: '{"application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","created_at":"2023-10-31T14:31:01.059488Z","description":"","editable":true,"id":"4661c0a7-f94e-457c-b3b4-c806acbf0783","name":"tf-policy-pensive-hopper","nb_permission_sets":3,"nb_rules":2,"nb_scopes":2,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:31:01.059488Z"}'
+    body: '{"application_id":"7087053f-a01e-4607-af25-aecb17ae174f","created_at":"2024-02-21T14:05:26.878638Z","description":"","editable":true,"id":"a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1","name":"tf-policy-hardcore-boyd","nb_permission_sets":3,"nb_rules":2,"nb_scopes":2,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:26.878638Z"}'
     headers:
       Content-Length:
-      - "361"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -273,12 +273,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a4172a3-6264-4b99-8550-6c2de62a714f
+      - 3c792466-9129-4b4a-ab9a-f50f782699e7
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","description":""}'
+    body: '{"application_id":"7087053f-a01e-4607-af25-aecb17ae174f","description":""}'
     form: {}
     headers:
       Content-Type:
@@ -289,18 +289,18 @@ interactions:
     url: https://api.scaleway.com/iam/v1alpha1/api-keys
     method: POST
   response:
-    body: '{"access_key":"SCW7J5F0JFW3CP6J1KHN","application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","created_at":"2023-10-31T14:31:01.152153Z","creation_ip":"51.159.46.153","default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2023-10-31T14:31:01.152153Z"}'
+    body: '{"access_key":"SCWXZ6J1E1YZ3NEXVGXF","application_id":"7087053f-a01e-4607-af25-aecb17ae174f","created_at":"2024-02-21T14:05:27.001223Z","creation_ip":"51.159.46.153","default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2024-02-21T14:05:27.001223Z"}'
     headers:
       Content-Length:
-      - "372"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -308,7 +308,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b9b3174-8367-44ec-8d89-0ff640d7f043
+      - a3c1a0c2-a598-433e-917e-5e36b727859b
     status: 200 OK
     code: 200
     duration: ""
@@ -319,21 +319,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/rules?policy_id=4661c0a7-f94e-457c-b3b4-c806acbf0783
+    url: https://api.scaleway.com/iam/v1alpha1/rules?policy_id=a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1
     method: GET
   response:
-    body: '{"rules":[{"id":"f0b53a9a-6195-4dd6-8781-bdf023caab83","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["InstancesReadOnly"],"permission_sets_scope_type":"projects"},{"id":"f52747fc-66d3-401c-a013-74c13caf48e6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["IAMReadOnly","ProjectReadOnly"],"permission_sets_scope_type":"organization"}],"total_count":2}'
+    body: '{"rules":[{"id":"598e10f4-dbb6-4771-b9fd-347ab358e165","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["InstancesReadOnly"],"permission_sets_scope_type":"projects"},{"id":"ecd191d0-ad00-4239-b8ef-632e7852abe7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["IAMReadOnly","ProjectReadOnly"],"permission_sets_scope_type":"organization"}],"total_count":2}'
     headers:
       Content-Length:
-      - "419"
+      - "428"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -341,7 +341,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8809979d-1099-4953-ad56-2269d0ee4788
+      - cb81494d-c7bf-44f7-9333-671cd64c294f
     status: 200 OK
     code: 200
     duration: ""
@@ -352,21 +352,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCW7J5F0JFW3CP6J1KHN
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXZ6J1E1YZ3NEXVGXF
     method: GET
   response:
-    body: '{"access_key":"SCW7J5F0JFW3CP6J1KHN","application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","created_at":"2023-10-31T14:31:01.152153Z","creation_ip":"51.159.46.153","default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2023-10-31T14:31:01.152153Z"}'
+    body: '{"access_key":"SCWXZ6J1E1YZ3NEXVGXF","application_id":"7087053f-a01e-4607-af25-aecb17ae174f","created_at":"2024-02-21T14:05:27.001223Z","creation_ip":"51.159.46.153","default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2024-02-21T14:05:27.001223Z"}'
     headers:
       Content-Length:
-      - "338"
+      - "347"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -374,7 +374,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a362e702-9077-45ff-a856-12082b79dd63
+      - 85b8b8c3-2839-4df4-b312-ef2a0888b835
     status: 200 OK
     code: 200
     duration: ""
@@ -390,20 +390,20 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.107.206","id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "324"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/e1d5fc83-0d66-4437-bc70-799764b7457f
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -411,7 +411,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c847e7e1-ffca-4375-bb51-67dd6142a34f
+      - e92aa193-96fe-4f5f-948b-f526d81b441b
     status: 201 Created
     code: 201
     duration: ""
@@ -422,21 +422,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/e1d5fc83-0d66-4437-bc70-799764b7457f
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.107.206","id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "324"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -444,7 +444,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 831fc7af-6610-4466-97a2-da10233c776d
+      - 9b0a5f7a-f494-4cd6-aa4a-39120c528e72
     status: 200 OK
     code: 200
     duration: ""
@@ -458,18 +458,18 @@ interactions:
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","label":"ubuntu_jammy","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2d830ab7-b11c-435e-a582-f390ef11b1e2","label":"ubuntu_jammy","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"f0d486ff-f178-4941-ad62-8bbda478b53a","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"9467798a-e554-4658-a008-82a868d42a3b","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1179"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -477,7 +477,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 466f15d3-4f8b-4969-a760-414c5f4c9ba4
+      - 90c222ff-dc38-4c9f-a95e-15783616320f
     status: 200 OK
     code: 200
     duration: ""
@@ -491,21 +491,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38421"
+      - "38183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -513,9 +513,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8377c963-954b-4937-81a3-ad4d04136ded
+      - 9f6ef487-3d33-40ee-a763-14d8f4f0c3bc
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
@@ -529,21 +529,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4865"
+      - "8882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -551,14 +551,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a06cad1-86d7-413f-a017-0db60236310a
+      - 6881064e-1996-4ce7-9cf6-3a753ab4dc31
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-laughing-moser","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"PRO2-XXS","image":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","volumes":{"0":{"boot":false,"volume_type":"b_ssd"}},"public_ip":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-srv-strange-northcutt","dynamic_ip_required":false,"commercial_type":"PRO2-XXS","image":"9467798a-e554-4658-a008-82a868d42a3b","volumes":{"0":{"boot":false,"volume_type":"b_ssd"}},"public_ip":"e1d5fc83-0d66-4437-bc70-799764b7457f","boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -571,24 +571,24 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:02 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f8226bc-0674-49a5-89f9-00c54f066e81
+      - 285b9865-cd35-4baa-b425-0d2ca0c9966d
     status: 201 Created
     code: 201
     duration: ""
@@ -607,27 +607,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:02 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -635,7 +635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdb1f284-6cf1-4839-a5b3-0dbc56ee84b6
+      - 6975fafa-2f1b-4ec3-a7a9-229af59c0336
     status: 200 OK
     code: 200
     duration: ""
@@ -646,27 +646,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:02 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -674,7 +674,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a73eed17-6e52-404e-a3ad-1351fa6cbd71
+      - 45c2d41d-d705-41a7-9a9e-123de1bfc5a8
     status: 200 OK
     code: 200
     duration: ""
@@ -685,27 +685,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:02 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -713,7 +713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b036bd8-4d38-4bf3-805c-9b7192d8c22b
+      - 84d243c1-9f22-4f56-9980-19cbef028837
     status: 200 OK
     code: 200
     duration: ""
@@ -724,7 +724,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -736,9 +736,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:02 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -746,7 +746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f3f2a6d-7285-4e04-9607-a7d1d6cef129
+      - 780ddab4-ad2c-43a3-a637-7d74055fbf8b
     status: 200 OK
     code: 200
     duration: ""
@@ -757,7 +757,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -769,12 +769,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:03 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Link:
-      - </servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics?page=0&per_page=50&>;
+      - </servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -782,7 +782,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fea0f9f1-e229-4114-9f7e-28c9a64b9ffd
+      - e3915800-c0b8-4b0d-81b4-e342a535f097
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -795,7 +795,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -807,12 +807,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:03 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Link:
-      - </servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics?page=0&per_page=50&>;
+      - </servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -820,7 +820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0ed74f0-46c6-486d-9045-8897d6bd44a8
+      - d0b78cb3-0d28-45e2-a06b-67f542e35633
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -833,21 +833,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c4fed393-9d12-4c97-ac5e-6464a5d185d8
+    url: https://api.scaleway.com/iam/v1alpha1/applications/7087053f-a01e-4607-af25-aecb17ae174f
     method: GET
   response:
-    body: '{"created_at":"2023-10-31T14:31:00.874026Z","description":"","editable":true,"id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","name":"tf_tests_instance_server_ipmigrate","nb_api_keys":1,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:31:00.874026Z"}'
+    body: '{"created_at":"2024-02-21T14:05:26.697765Z","description":"","editable":true,"id":"7087053f-a01e-4607-af25-aecb17ae174f","name":"tf_tests_instance_server_ipmigrate","nb_api_keys":1,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:26.697765Z"}'
     headers:
       Content-Length:
-      - "281"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:03 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -855,7 +855,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b651e4b-fed5-45ed-a2b3-ff33eed41984
+      - 4de00272-e840-4e31-9dc7-eb67769acf80
     status: 200 OK
     code: 200
     duration: ""
@@ -866,10 +866,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/e1d5fc83-0d66-4437-bc70-799764b7457f
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.107.206","id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "402"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:29 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2b5118fc-e4a7-49c6-9def-74763f596e81
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXZ6J1E1YZ3NEXVGXF
+    method: GET
+  response:
+    body: '{"access_key":"SCWXZ6J1E1YZ3NEXVGXF","application_id":"7087053f-a01e-4607-af25-aecb17ae174f","created_at":"2024-02-21T14:05:27.001223Z","creation_ip":"51.159.46.153","default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2024-02-21T14:05:27.001223Z"}'
+    headers:
+      Content-Length:
+      - "347"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:29 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 02c6c2f4-de6e-4728-a65d-78ffa8cbe2b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/policies/a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1
+    method: GET
+  response:
+    body: '{"application_id":"7087053f-a01e-4607-af25-aecb17ae174f","created_at":"2024-02-21T14:05:26.878638Z","description":"","editable":true,"id":"a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1","name":"tf-policy-hardcore-boyd","nb_permission_sets":3,"nb_rules":2,"nb_scopes":2,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:26.878638Z"}'
     headers:
       Content-Length:
       - "381"
@@ -878,9 +944,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:03 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -888,7 +954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac24f600-6bba-4311-930e-c8b03111f49e
+      - 8e7e9578-fdd8-408c-b3b8-b42f6d6639e5
     status: 200 OK
     code: 200
     duration: ""
@@ -899,21 +965,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCW7J5F0JFW3CP6J1KHN
+    url: https://api.scaleway.com/iam/v1alpha1/rules?policy_id=a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1
     method: GET
   response:
-    body: '{"access_key":"SCW7J5F0JFW3CP6J1KHN","application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","created_at":"2023-10-31T14:31:01.152153Z","creation_ip":"51.159.46.153","default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2023-10-31T14:31:01.152153Z"}'
+    body: '{"rules":[{"id":"598e10f4-dbb6-4771-b9fd-347ab358e165","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["InstancesReadOnly"],"permission_sets_scope_type":"projects"},{"id":"ecd191d0-ad00-4239-b8ef-632e7852abe7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["IAMReadOnly","ProjectReadOnly"],"permission_sets_scope_type":"organization"}],"total_count":2}'
     headers:
       Content-Length:
-      - "338"
+      - "428"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:03 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -921,7 +987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4161154-9488-4275-8bf8-666aeb901743
+      - cc874713-ac3a-40f2-a9ae-eec1646d2e70
     status: 200 OK
     code: 200
     duration: ""
@@ -932,60 +998,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/policies/4661c0a7-f94e-457c-b3b4-c806acbf0783
-    method: GET
-  response:
-    body: '{"application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","created_at":"2023-10-31T14:31:01.059488Z","description":"","editable":true,"id":"4661c0a7-f94e-457c-b3b4-c806acbf0783","name":"tf-policy-pensive-hopper","nb_permission_sets":3,"nb_rules":2,"nb_scopes":2,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:31:01.059488Z"}'
-    headers:
-      Content-Length:
-      - "361"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:31:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 389f5dfc-76a4-448b-a709-82739da84735
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:03 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -993,7 +1026,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 020d522a-bf16-4003-bf06-806ff59d9a34
+      - d46da2bb-7817-461f-8213-34fa157d9c57
     status: 200 OK
     code: 200
     duration: ""
@@ -1004,40 +1037,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/rules?policy_id=4661c0a7-f94e-457c-b3b4-c806acbf0783
-    method: GET
-  response:
-    body: '{"rules":[{"id":"f0b53a9a-6195-4dd6-8781-bdf023caab83","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["InstancesReadOnly"],"permission_sets_scope_type":"projects"},{"id":"f52747fc-66d3-401c-a013-74c13caf48e6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["IAMReadOnly","ProjectReadOnly"],"permission_sets_scope_type":"organization"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "419"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:31:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a69b2df5-08cd-4b95-8c32-0fdd43ed639a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1049,9 +1049,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:03 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1059,7 +1059,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee084714-6b1c-4371-b97b-b5f7df5af0e1
+      - 6462bcd3-eaa7-4222-ac3d-986b4b9e31f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1070,7 +1070,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1082,12 +1082,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:03 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Link:
-      - </servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics?page=0&per_page=50&>;
+      - </servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1095,7 +1095,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce0e4bed-c979-4867-9846-606da43e91fb
+      - ec00169b-8be1-4305-b633-77b39fa1baf8
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1108,21 +1108,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c4fed393-9d12-4c97-ac5e-6464a5d185d8
+    url: https://api.scaleway.com/iam/v1alpha1/applications/7087053f-a01e-4607-af25-aecb17ae174f
     method: GET
   response:
-    body: '{"created_at":"2023-10-31T14:31:00.874026Z","description":"","editable":true,"id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","name":"tf_tests_instance_server_ipmigrate","nb_api_keys":1,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:31:00.874026Z"}'
+    body: '{"created_at":"2024-02-21T14:05:26.697765Z","description":"","editable":true,"id":"7087053f-a01e-4607-af25-aecb17ae174f","name":"tf_tests_instance_server_ipmigrate","nb_api_keys":1,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:26.697765Z"}'
     headers:
       Content-Length:
-      - "281"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:04 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1130,7 +1130,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 28031ae9-164c-4b0e-8bad-60f3e684db43
+      - ebb5b0db-4d9e-4ac0-a6db-f4dc92a0bd15
     status: 200 OK
     code: 200
     duration: ""
@@ -1141,10 +1141,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/e1d5fc83-0d66-4437-bc70-799764b7457f
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.107.206","id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "402"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85708d46-b854-4c1b-92e4-8861e54f47f8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXZ6J1E1YZ3NEXVGXF
+    method: GET
+  response:
+    body: '{"access_key":"SCWXZ6J1E1YZ3NEXVGXF","application_id":"7087053f-a01e-4607-af25-aecb17ae174f","created_at":"2024-02-21T14:05:27.001223Z","creation_ip":"51.159.46.153","default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2024-02-21T14:05:27.001223Z"}'
+    headers:
+      Content-Length:
+      - "347"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 495a8116-3ea4-4417-a8db-59a5ab338b54
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/policies/a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1
+    method: GET
+  response:
+    body: '{"application_id":"7087053f-a01e-4607-af25-aecb17ae174f","created_at":"2024-02-21T14:05:26.878638Z","description":"","editable":true,"id":"a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1","name":"tf-policy-hardcore-boyd","nb_permission_sets":3,"nb_rules":2,"nb_scopes":2,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:26.878638Z"}'
     headers:
       Content-Length:
       - "381"
@@ -1153,9 +1219,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:04 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1163,7 +1229,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16599b88-b386-4fd0-8c33-076fad54ca60
+      - 999b06c5-f80c-461c-a798-14edb16365bb
     status: 200 OK
     code: 200
     duration: ""
@@ -1174,21 +1240,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/policies/4661c0a7-f94e-457c-b3b4-c806acbf0783
+    url: https://api.scaleway.com/iam/v1alpha1/rules?policy_id=a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1
     method: GET
   response:
-    body: '{"application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","created_at":"2023-10-31T14:31:01.059488Z","description":"","editable":true,"id":"4661c0a7-f94e-457c-b3b4-c806acbf0783","name":"tf-policy-pensive-hopper","nb_permission_sets":3,"nb_rules":2,"nb_scopes":2,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:31:01.059488Z"}'
+    body: '{"rules":[{"id":"598e10f4-dbb6-4771-b9fd-347ab358e165","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["InstancesReadOnly"],"permission_sets_scope_type":"projects"},{"id":"ecd191d0-ad00-4239-b8ef-632e7852abe7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["IAMReadOnly","ProjectReadOnly"],"permission_sets_scope_type":"organization"}],"total_count":2}'
     headers:
       Content-Length:
-      - "361"
+      - "428"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:04 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1196,7 +1262,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88d93d7e-7c69-4e11-bb8f-8b15f1f3ff2a
+      - f1aa9176-e544-4f34-a13e-a6223081f1af
     status: 200 OK
     code: 200
     duration: ""
@@ -1207,93 +1273,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCW7J5F0JFW3CP6J1KHN
-    method: GET
-  response:
-    body: '{"access_key":"SCW7J5F0JFW3CP6J1KHN","application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","created_at":"2023-10-31T14:31:01.152153Z","creation_ip":"51.159.46.153","default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2023-10-31T14:31:01.152153Z"}'
-    headers:
-      Content-Length:
-      - "338"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:31:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 59147543-9496-4d05-a3b8-afcd6ccd07fe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/rules?policy_id=4661c0a7-f94e-457c-b3b4-c806acbf0783
-    method: GET
-  response:
-    body: '{"rules":[{"id":"f0b53a9a-6195-4dd6-8781-bdf023caab83","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["InstancesReadOnly"],"permission_sets_scope_type":"projects"},{"id":"f52747fc-66d3-401c-a013-74c13caf48e6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["IAMReadOnly","ProjectReadOnly"],"permission_sets_scope_type":"organization"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "419"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:31:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5aa70055-fe51-43a9-b3e8-958c75376df4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:04 GMT
+      - Wed, 21 Feb 2024 14:05:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1301,7 +1301,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 245b9786-7c32-4937-ad0e-d8d62794614c
+      - 246390fa-63d7-49de-8466-29ab712e793d
     status: 200 OK
     code: 200
     duration: ""
@@ -1312,7 +1312,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1324,9 +1324,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:04 GMT
+      - Wed, 21 Feb 2024 14:05:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1334,7 +1334,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4ca85e7-3cd8-4d2c-95e6-b449327d4483
+      - 58bbce11-d937-4725-bfbc-37465d589fb8
     status: 200 OK
     code: 200
     duration: ""
@@ -1345,7 +1345,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1357,12 +1357,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:04 GMT
+      - Wed, 21 Feb 2024 14:05:31 GMT
       Link:
-      - </servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics?page=0&per_page=50&>;
+      - </servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1370,7 +1370,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c30d4109-65cf-4de3-b2a4-aff7bc48ddbd
+      - 741af200-64d6-4844-a6f6-5c23366f029c
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1383,27 +1383,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:05 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1411,7 +1411,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80755da4-dd4e-450f-a298-59d43cb7fcb3
+      - 54aa9abc-2b29-4a57-93da-b73c63942bf7
     status: 200 OK
     code: 200
     duration: ""
@@ -1422,27 +1422,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:05 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1450,7 +1450,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 66b8e478-5f2f-4738-9a3b-65c365ea8b2b
+      - 04e3f181-9fa0-441c-8e8d-4de30685c914
     status: 200 OK
     code: 200
     duration: ""
@@ -1461,27 +1461,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:05 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1489,7 +1489,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c495f91-9a0e-4b77-90e5-725d804705f3
+      - 75c666f3-c603-48c5-9522-9331a7cd7d5e
     status: 200 OK
     code: 200
     duration: ""
@@ -1500,27 +1500,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:05 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1528,7 +1528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7170d0b-8a42-4168-a255-b59d58b131d8
+      - a7e83eff-f4f3-45b4-86e6-5aec73e432ca
     status: 200 OK
     code: 200
     duration: ""
@@ -1539,7 +1539,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1551,9 +1551,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:05 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1561,7 +1561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73b6701b-9b81-4971-a858-1e3d46ab1995
+      - 4e8df00b-64d9-4663-b775-a7406ee4e824
     status: 200 OK
     code: 200
     duration: ""
@@ -1572,7 +1572,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1584,12 +1584,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:05 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Link:
-      - </servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics?page=0&per_page=50&>;
+      - </servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1597,7 +1597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fce1469c-788c-4909-968f-ccf1086003d0
+      - 19e658a5-4f38-41b2-b8f9-17ab1505678f
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1610,7 +1610,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1622,12 +1622,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:05 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Link:
-      - </servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics?page=0&per_page=50&>;
+      - </servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1635,7 +1635,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 605efc73-21d0-4f92-9c70-4083ad8a4978
+      - b04e3532-962d-40a1-8c3c-f1797532e777
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1648,21 +1648,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c4fed393-9d12-4c97-ac5e-6464a5d185d8
+    url: https://api.scaleway.com/iam/v1alpha1/applications/7087053f-a01e-4607-af25-aecb17ae174f
     method: GET
   response:
-    body: '{"created_at":"2023-10-31T14:31:00.874026Z","description":"","editable":true,"id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","name":"tf_tests_instance_server_ipmigrate","nb_api_keys":1,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:31:00.874026Z"}'
+    body: '{"created_at":"2024-02-21T14:05:26.697765Z","description":"","editable":true,"id":"7087053f-a01e-4607-af25-aecb17ae174f","name":"tf_tests_instance_server_ipmigrate","nb_api_keys":1,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:26.697765Z"}'
     headers:
       Content-Length:
-      - "281"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:06 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1670,7 +1670,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7fd0730-5b92-4324-93df-06550e75f9e8
+      - 1e3abadc-4820-4f78-9ab4-563b93d6bbb4
     status: 200 OK
     code: 200
     duration: ""
@@ -1681,10 +1681,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/e1d5fc83-0d66-4437-bc70-799764b7457f
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.107.206","id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "402"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4f9383e5-e791-4416-b10a-9545f8f4404a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/policies/a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1
+    method: GET
+  response:
+    body: '{"application_id":"7087053f-a01e-4607-af25-aecb17ae174f","created_at":"2024-02-21T14:05:26.878638Z","description":"","editable":true,"id":"a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1","name":"tf-policy-hardcore-boyd","nb_permission_sets":3,"nb_rules":2,"nb_scopes":2,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:26.878638Z"}'
     headers:
       Content-Length:
       - "381"
@@ -1693,9 +1726,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:06 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1703,7 +1736,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a0eb4b3-0d9f-4c72-a905-4b2b41aa1981
+      - 5036d200-47aa-4974-a2d7-1fdc5cca9718
     status: 200 OK
     code: 200
     duration: ""
@@ -1714,21 +1747,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/policies/4661c0a7-f94e-457c-b3b4-c806acbf0783
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXZ6J1E1YZ3NEXVGXF
     method: GET
   response:
-    body: '{"application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","created_at":"2023-10-31T14:31:01.059488Z","description":"","editable":true,"id":"4661c0a7-f94e-457c-b3b4-c806acbf0783","name":"tf-policy-pensive-hopper","nb_permission_sets":3,"nb_rules":2,"nb_scopes":2,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:31:01.059488Z"}'
+    body: '{"access_key":"SCWXZ6J1E1YZ3NEXVGXF","application_id":"7087053f-a01e-4607-af25-aecb17ae174f","created_at":"2024-02-21T14:05:27.001223Z","creation_ip":"51.159.46.153","default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2024-02-21T14:05:27.001223Z"}'
     headers:
       Content-Length:
-      - "361"
+      - "347"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:06 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1736,7 +1769,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16b90b44-c4c9-46b5-82a0-bc656b08203a
+      - af345cdd-3ecb-4d0f-bf0d-8d83fa44b940
     status: 200 OK
     code: 200
     duration: ""
@@ -1747,21 +1780,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCW7J5F0JFW3CP6J1KHN
+    url: https://api.scaleway.com/iam/v1alpha1/rules?policy_id=a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1
     method: GET
   response:
-    body: '{"access_key":"SCW7J5F0JFW3CP6J1KHN","application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","created_at":"2023-10-31T14:31:01.152153Z","creation_ip":"51.159.46.153","default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2023-10-31T14:31:01.152153Z"}'
+    body: '{"rules":[{"id":"598e10f4-dbb6-4771-b9fd-347ab358e165","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["InstancesReadOnly"],"permission_sets_scope_type":"projects"},{"id":"ecd191d0-ad00-4239-b8ef-632e7852abe7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["IAMReadOnly","ProjectReadOnly"],"permission_sets_scope_type":"organization"}],"total_count":2}'
     headers:
       Content-Length:
-      - "338"
+      - "428"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:06 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1769,7 +1802,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93f1b1f7-8aa5-4c98-ab09-98ce7199f920
+      - 1c4b9ddc-208f-45ff-b168-a255035dc0e6
     status: 200 OK
     code: 200
     duration: ""
@@ -1780,60 +1813,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/rules?policy_id=4661c0a7-f94e-457c-b3b4-c806acbf0783
-    method: GET
-  response:
-    body: '{"rules":[{"id":"f0b53a9a-6195-4dd6-8781-bdf023caab83","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["InstancesReadOnly"],"permission_sets_scope_type":"projects"},{"id":"f52747fc-66d3-401c-a013-74c13caf48e6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["IAMReadOnly","ProjectReadOnly"],"permission_sets_scope_type":"organization"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "419"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:31:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fbafdb77-90b5-4424-b845-4213de7da1a1
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:06 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1841,7 +1841,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67a0be54-63ca-4bce-890f-7facd46e7a8d
+      - 1e35f98a-9b70-4495-bab4-2603681bacf4
     status: 200 OK
     code: 200
     duration: ""
@@ -1852,7 +1852,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1864,9 +1864,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:06 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1874,7 +1874,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 147261da-f5be-448d-8314-55c9dfdc88c6
+      - 801f216d-3f4e-45e3-ab23-2a3e0dc50932
     status: 200 OK
     code: 200
     duration: ""
@@ -1885,7 +1885,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1897,12 +1897,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:06 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Link:
-      - </servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics?page=0&per_page=50&>;
+      - </servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1910,7 +1910,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 662823c4-2f8b-45b7-ab4f-3464b2afbdd0
+      - 52dcd50e-e079-4dde-a060-f9a1d566e668
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1923,21 +1923,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c4fed393-9d12-4c97-ac5e-6464a5d185d8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/e1d5fc83-0d66-4437-bc70-799764b7457f
     method: GET
   response:
-    body: '{"created_at":"2023-10-31T14:31:00.874026Z","description":"","editable":true,"id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","name":"tf_tests_instance_server_ipmigrate","nb_api_keys":1,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:31:00.874026Z"}'
+    body: '{"ip":{"address":"51.158.107.206","id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "281"
+      - "402"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:06 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1945,7 +1945,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b608744b-4c96-43d6-8fb7-84fab986f311
+      - 71e1b05c-ab58-4a45-ad0f-3aef4155b6e0
     status: 200 OK
     code: 200
     duration: ""
@@ -1956,10 +1956,43 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/iam/v1alpha1/applications/7087053f-a01e-4607-af25-aecb17ae174f
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"created_at":"2024-02-21T14:05:26.697765Z","description":"","editable":true,"id":"7087053f-a01e-4607-af25-aecb17ae174f","name":"tf_tests_instance_server_ipmigrate","nb_api_keys":1,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:26.697765Z"}'
+    headers:
+      Content-Length:
+      - "299"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4c66b884-28a5-45c6-9a69-57fc231c8174
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/policies/a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1
+    method: GET
+  response:
+    body: '{"application_id":"7087053f-a01e-4607-af25-aecb17ae174f","created_at":"2024-02-21T14:05:26.878638Z","description":"","editable":true,"id":"a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1","name":"tf-policy-hardcore-boyd","nb_permission_sets":3,"nb_rules":2,"nb_scopes":2,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:26.878638Z"}'
     headers:
       Content-Length:
       - "381"
@@ -1968,9 +2001,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:07 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1978,7 +2011,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e351673-3d2c-4a9e-923d-8e2bbd37aea8
+      - 07764dac-12e6-404e-9ae8-541ccffee6f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1989,21 +2022,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/policies/4661c0a7-f94e-457c-b3b4-c806acbf0783
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXZ6J1E1YZ3NEXVGXF
     method: GET
   response:
-    body: '{"application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","created_at":"2023-10-31T14:31:01.059488Z","description":"","editable":true,"id":"4661c0a7-f94e-457c-b3b4-c806acbf0783","name":"tf-policy-pensive-hopper","nb_permission_sets":3,"nb_rules":2,"nb_scopes":2,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:31:01.059488Z"}'
+    body: '{"access_key":"SCWXZ6J1E1YZ3NEXVGXF","application_id":"7087053f-a01e-4607-af25-aecb17ae174f","created_at":"2024-02-21T14:05:27.001223Z","creation_ip":"51.159.46.153","default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2024-02-21T14:05:27.001223Z"}'
     headers:
       Content-Length:
-      - "361"
+      - "347"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:07 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2011,7 +2044,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c8d6a9c-9cfd-4418-b2f8-612bb1a2b738
+      - 531cd662-a173-4436-89ad-a4d26caa7cf8
     status: 200 OK
     code: 200
     duration: ""
@@ -2022,93 +2055,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCW7J5F0JFW3CP6J1KHN
-    method: GET
-  response:
-    body: '{"access_key":"SCW7J5F0JFW3CP6J1KHN","application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","created_at":"2023-10-31T14:31:01.152153Z","creation_ip":"51.159.46.153","default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2023-10-31T14:31:01.152153Z"}'
-    headers:
-      Content-Length:
-      - "338"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:31:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 412125e1-5ca8-4adf-aa70-3ef6508b6eba
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/rules?policy_id=4661c0a7-f94e-457c-b3b4-c806acbf0783
-    method: GET
-  response:
-    body: '{"rules":[{"id":"f0b53a9a-6195-4dd6-8781-bdf023caab83","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["InstancesReadOnly"],"permission_sets_scope_type":"projects"},{"id":"f52747fc-66d3-401c-a013-74c13caf48e6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["IAMReadOnly","ProjectReadOnly"],"permission_sets_scope_type":"organization"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "419"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:31:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 742d0f0c-006a-4309-861a-25c7bfd612b5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:07 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2116,7 +2083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dcada86e-97f6-4038-a021-5bd952972c26
+      - cda6f436-a737-43e7-9042-39092ade502d
     status: 200 OK
     code: 200
     duration: ""
@@ -2127,7 +2094,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/user_data
+    url: https://api.scaleway.com/iam/v1alpha1/rules?policy_id=a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1
+    method: GET
+  response:
+    body: '{"rules":[{"id":"598e10f4-dbb6-4771-b9fd-347ab358e165","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["InstancesReadOnly"],"permission_sets_scope_type":"projects"},{"id":"ecd191d0-ad00-4239-b8ef-632e7852abe7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["IAMReadOnly","ProjectReadOnly"],"permission_sets_scope_type":"organization"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "428"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e1563eba-fecf-40ea-afda-0457a587db51
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2139,9 +2139,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:07 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2149,7 +2149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6444daf8-13f1-4b23-8402-44aca1861cb7
+      - d1e15188-9c9a-499e-b72e-b6949aff5cf0
     status: 200 OK
     code: 200
     duration: ""
@@ -2160,7 +2160,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -2172,12 +2172,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:07 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Link:
-      - </servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics?page=0&per_page=50&>;
+      - </servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2185,7 +2185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3301b832-2ef4-46eb-aa92-bdec2e3701b4
+      - bbc9fcb0-2fa5-4ea1-9498-c6a263f55c94
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -2198,21 +2198,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c4fed393-9d12-4c97-ac5e-6464a5d185d8
+    url: https://api.scaleway.com/iam/v1alpha1/applications/7087053f-a01e-4607-af25-aecb17ae174f
     method: GET
   response:
-    body: '{"created_at":"2023-10-31T14:31:00.874026Z","description":"","editable":true,"id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","name":"tf_tests_instance_server_ipmigrate","nb_api_keys":1,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:31:00.874026Z"}'
+    body: '{"created_at":"2024-02-21T14:05:26.697765Z","description":"","editable":true,"id":"7087053f-a01e-4607-af25-aecb17ae174f","name":"tf_tests_instance_server_ipmigrate","nb_api_keys":1,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:26.697765Z"}'
     headers:
       Content-Length:
-      - "281"
+      - "299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:08 GMT
+      - Wed, 21 Feb 2024 14:05:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2220,7 +2220,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad7bfa2f-ecd1-4ea7-8211-73eb51b98b52
+      - 284e1165-a647-4817-9f2e-6af149cb9960
     status: 200 OK
     code: 200
     duration: ""
@@ -2231,10 +2231,76 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/e1d5fc83-0d66-4437-bc70-799764b7457f
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.107.206","id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "402"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:37 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 925b5546-f724-4f09-9302-4169f30d7948
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXZ6J1E1YZ3NEXVGXF
+    method: GET
+  response:
+    body: '{"access_key":"SCWXZ6J1E1YZ3NEXVGXF","application_id":"7087053f-a01e-4607-af25-aecb17ae174f","created_at":"2024-02-21T14:05:27.001223Z","creation_ip":"51.159.46.153","default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2024-02-21T14:05:27.001223Z"}'
+    headers:
+      Content-Length:
+      - "347"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:37 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 392e3711-f594-4f85-957b-70af3d4d9bb7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/iam/v1alpha1/policies/a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1
+    method: GET
+  response:
+    body: '{"application_id":"7087053f-a01e-4607-af25-aecb17ae174f","created_at":"2024-02-21T14:05:26.878638Z","description":"","editable":true,"id":"a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1","name":"tf-policy-hardcore-boyd","nb_permission_sets":3,"nb_rules":2,"nb_scopes":2,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"updated_at":"2024-02-21T14:05:26.878638Z"}'
     headers:
       Content-Length:
       - "381"
@@ -2243,9 +2309,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:08 GMT
+      - Wed, 21 Feb 2024 14:05:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2253,7 +2319,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 589a3213-2ef9-49ce-aedf-9daf072069f0
+      - 0b606f76-aa05-453e-be92-ed501b06fe7e
     status: 200 OK
     code: 200
     duration: ""
@@ -2264,21 +2330,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/policies/4661c0a7-f94e-457c-b3b4-c806acbf0783
+    url: https://api.scaleway.com/iam/v1alpha1/rules?policy_id=a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1
     method: GET
   response:
-    body: '{"application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","created_at":"2023-10-31T14:31:01.059488Z","description":"","editable":true,"id":"4661c0a7-f94e-457c-b3b4-c806acbf0783","name":"tf-policy-pensive-hopper","nb_permission_sets":3,"nb_rules":2,"nb_scopes":2,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","updated_at":"2023-10-31T14:31:01.059488Z"}'
+    body: '{"rules":[{"id":"598e10f4-dbb6-4771-b9fd-347ab358e165","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["InstancesReadOnly"],"permission_sets_scope_type":"projects"},{"id":"ecd191d0-ad00-4239-b8ef-632e7852abe7","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["IAMReadOnly","ProjectReadOnly"],"permission_sets_scope_type":"organization"}],"total_count":2}'
     headers:
       Content-Length:
-      - "361"
+      - "428"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:08 GMT
+      - Wed, 21 Feb 2024 14:05:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2286,7 +2352,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7e732fb-9463-4928-9bce-7442940a4aef
+      - 0240b6d0-edc2-48f9-8384-2a6abd83144c
     status: 200 OK
     code: 200
     duration: ""
@@ -2297,93 +2363,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCW7J5F0JFW3CP6J1KHN
-    method: GET
-  response:
-    body: '{"access_key":"SCW7J5F0JFW3CP6J1KHN","application_id":"c4fed393-9d12-4c97-ac5e-6464a5d185d8","created_at":"2023-10-31T14:31:01.152153Z","creation_ip":"51.159.46.153","default_project_id":"105bdce1-64c0-48ab-899d-868455867ecf","description":"","editable":true,"expires_at":null,"secret_key":"00000000-0000-0000-0000-000000000000","updated_at":"2023-10-31T14:31:01.152153Z"}'
-    headers:
-      Content-Length:
-      - "338"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:31:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - be0726cf-49dc-47b6-83ae-f3e8ad7d53eb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/rules?policy_id=4661c0a7-f94e-457c-b3b4-c806acbf0783
-    method: GET
-  response:
-    body: '{"rules":[{"id":"f0b53a9a-6195-4dd6-8781-bdf023caab83","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["InstancesReadOnly"],"permission_sets_scope_type":"projects"},{"id":"f52747fc-66d3-401c-a013-74c13caf48e6","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","permission_set_names":["IAMReadOnly","ProjectReadOnly"],"permission_sets_scope_type":"organization"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "419"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:31:08 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 35880689-0ddf-41f6-a48b-8a7c8beeb6b5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:08 GMT
+      - Wed, 21 Feb 2024 14:05:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2391,7 +2391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cdc4042a-4d4d-4aba-9462-b71add3345fb
+      - 38787479-b4df-4d9b-8961-b1c203ae27c6
     status: 200 OK
     code: 200
     duration: ""
@@ -2402,7 +2402,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2414,9 +2414,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:08 GMT
+      - Wed, 21 Feb 2024 14:05:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2424,7 +2424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2002aa1-0d2b-4405-a85b-e89134b093d7
+      - 69d1282b-dcbb-4511-97f7-77a4b8d93277
     status: 200 OK
     code: 200
     duration: ""
@@ -2435,7 +2435,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -2447,12 +2447,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:08 GMT
+      - Wed, 21 Feb 2024 14:05:37 GMT
       Link:
-      - </servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71/private_nics?page=0&per_page=50&>;
+      - </servers/5887f8d4-58b3-46e4-bd84-d44f992396fa/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2460,7 +2460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aae52ac4-a4c9-41c2-8976-0b997dcc0be0
+      - 5715e429-e596-4c72-a460-1b7508545c03
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -2473,7 +2473,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/policies/4661c0a7-f94e-457c-b3b4-c806acbf0783
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWXZ6J1E1YZ3NEXVGXF
     method: DELETE
   response:
     body: ""
@@ -2483,9 +2483,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:09 GMT
+      - Wed, 21 Feb 2024 14:05:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2493,7 +2493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c20f1274-a815-4492-92ff-4f6a56736cd0
+      - 1a4136b6-54c6-4292-bcae-456273c10a09
     status: 204 No Content
     code: 204
     duration: ""
@@ -2504,7 +2504,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCW7J5F0JFW3CP6J1KHN
+    url: https://api.scaleway.com/iam/v1alpha1/policies/a72f0ac7-ea1c-4f1c-a6e5-45e0ee9eb6d1
     method: DELETE
   response:
     body: ""
@@ -2514,9 +2514,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:09 GMT
+      - Wed, 21 Feb 2024 14:05:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2524,7 +2524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b110f703-740b-4eef-a529-0a7d2ba6b092
+      - 7dc8ffd4-970f-4c25-903e-f8d645b80679
     status: 204 No Content
     code: 204
     duration: ""
@@ -2535,27 +2535,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:09 GMT
+      - Wed, 21 Feb 2024 14:05:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2563,7 +2563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 562ffdc5-03a9-4912-bed9-8dde9d42b1ca
+      - 808f72da-1d4e-47d2-a0b8-35c7955db601
     status: 200 OK
     code: 200
     duration: ""
@@ -2574,7 +2574,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/c4fed393-9d12-4c97-ac5e-6464a5d185d8
+    url: https://api.scaleway.com/iam/v1alpha1/applications/7087053f-a01e-4607-af25-aecb17ae174f
     method: DELETE
   response:
     body: ""
@@ -2584,9 +2584,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:09 GMT
+      - Wed, 21 Feb 2024 14:05:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2594,7 +2594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd898568-ea58-4d2b-a70e-80d277369dcb
+      - 23c90eda-0492-4044-b779-e2af0e3317ee
     status: 204 No Content
     code: 204
     duration: ""
@@ -2605,27 +2605,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-10-31T14:31:02.192172+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-laughing-moser","id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:11","maintenances":[],"modification_date":"2023-10-31T14:31:02.192172+00:00","name":"tf-srv-laughing-moser","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:02.192172+00:00","export_uri":null,"id":"089fa7c2-c961-409d-926b-e406c36d9e08","modification_date":"2023-10-31T14:31:02.192172+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","name":"tf-srv-laughing-moser"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:28.013436+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-strange-northcutt","id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:49","maintenances":[],"modification_date":"2024-02-21T14:05:28.013436+00:00","name":"tf-srv-strange-northcutt","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":false,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:28.013436+00:00","export_uri":null,"id":"02b65218-f4d4-419b-a99a-8e3ff87a775f","modification_date":"2024-02-21T14:05:28.013436+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","name":"tf-srv-strange-northcutt"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3067"
+      - "3134"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:09 GMT
+      - Wed, 21 Feb 2024 14:05:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2633,7 +2633,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db863973-cdcb-4235-91a4-ec380dd6b85a
+      - 4986fc66-f486-4864-9128-5cb1989c79dd
     status: 200 OK
     code: 200
     duration: ""
@@ -2644,7 +2644,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: DELETE
   response:
     body: ""
@@ -2652,9 +2652,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:31:09 GMT
+      - Wed, 21 Feb 2024 14:05:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2662,7 +2662,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbf49529-c84f-4b4e-b7e9-e42039105888
+      - 1ed0eac8-f29b-4cdc-b886-28f3a8c20642
     status: 204 No Content
     code: 204
     duration: ""
@@ -2673,10 +2673,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -2685,9 +2685,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:09 GMT
+      - Wed, 21 Feb 2024 14:05:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2695,7 +2695,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5577ed5f-db91-4adb-9e83-267ff6c6c551
+      - e65d1084-d3c9-4f20-b444-1914ce96360e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2706,7 +2706,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/089fa7c2-c961-409d-926b-e406c36d9e08
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/02b65218-f4d4-419b-a99a-8e3ff87a775f
     method: DELETE
   response:
     body: ""
@@ -2714,9 +2714,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:31:09 GMT
+      - Wed, 21 Feb 2024 14:05:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2724,7 +2724,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dca348f8-bd06-44ef-9faf-382c136ce40a
+      - bcb1de1f-f754-4de0-b960-b6cac4892e03
     status: 204 No Content
     code: 204
     duration: ""
@@ -2735,7 +2735,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/e1d5fc83-0d66-4437-bc70-799764b7457f
     method: DELETE
   response:
     body: ""
@@ -2743,9 +2743,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:31:09 GMT
+      - Wed, 21 Feb 2024 14:05:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2753,7 +2753,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e214d78-7906-4584-859f-3b404b594112
+      - 9230f28e-83ae-4f26-af82-f50e1e3ba3ad
     status: 204 No Content
     code: 204
     duration: ""
@@ -2764,38 +2764,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWDAWVW9R9DHGQP8RPS
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:31:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1e9a895e-40c3-4794-9c8b-222ec30d94cc
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/policies/972892cc-b539-4fc8-b099-895c3acbc3d7
+    url: https://api.scaleway.com/iam/v1alpha1/api-keys/SCWGD7SA7AR5DS9FP83A
     method: DELETE
   response:
     body: ""
@@ -2805,9 +2774,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:09 GMT
+      - Wed, 21 Feb 2024 14:05:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2815,7 +2784,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d24c848-7b8d-452c-a596-2007ed23adcf
+      - 82efe619-49d5-4cd3-a311-9a46a5b24a27
     status: 204 No Content
     code: 204
     duration: ""
@@ -2826,7 +2795,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/iam/v1alpha1/applications/a613e751-f2dd-4268-a703-5239004dd2db
+    url: https://api.scaleway.com/iam/v1alpha1/policies/729ec677-6459-4591-b6e1-93dfb708eff0
     method: DELETE
   response:
     body: ""
@@ -2836,9 +2805,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:09 GMT
+      - Wed, 21 Feb 2024 14:05:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2846,7 +2815,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10c8f5e1-5693-43d6-ab39-478d029c9514
+      - da250529-5847-4ed2-a862-a35029c1f3c1
     status: 204 No Content
     code: 204
     duration: ""
@@ -2857,7 +2826,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/account/v3/projects/726ee139-370b-4d7e-a75e-178cc13964ce
+    url: https://api.scaleway.com/iam/v1alpha1/applications/6872b0d0-3a66-410f-b306-2c66852f5609
     method: DELETE
   response:
     body: ""
@@ -2867,9 +2836,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:11 GMT
+      - Wed, 21 Feb 2024 14:05:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2877,7 +2846,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c8d39e5-af80-47bd-8cf1-2ddb32f9e634
+      - cc72d744-aa7d-487e-8dda-d7951fd442d8
     status: 204 No Content
     code: 204
     duration: ""
@@ -2888,10 +2857,41 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71
+    url: https://api.scaleway.com/account/v3/projects/47ba0fed-4b93-4c54-806d-03f660477d5c
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:40 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ecc04da5-6b95-4402-9654-db5812e08cb5
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5887f8d4-58b3-46e4-bd84-d44f992396fa
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"f1b14cc2-ab0b-49f0-a1ac-c02fa3e06c71","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"5887f8d4-58b3-46e4-bd84-d44f992396fa","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -2900,9 +2900,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:11 GMT
+      - Wed, 21 Feb 2024 14:05:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2910,7 +2910,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 38324c85-0fb4-4a24-86a9-d7283e4983f6
+      - 40da8d0f-9f10-48f2-b0be-697405f971af
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-server-ip-removed.cassette.yaml
+++ b/scaleway/testdata/instance-server-ip-removed.cassette.yaml
@@ -13,20 +13,20 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"ip":{"address":"51.15.217.95","id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.128.186","id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "305"
+      - "325"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/7abc05a9-05a9-42c0-9ae8-0ea5566453c6
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cf86dc8e-9330-4dce-8c9a-02ceaab157e0
+      - 065134a0-ab04-4b70-a4c5-ad605c3a61d2
     status: 201 Created
     code: 201
     duration: ""
@@ -45,21 +45,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/7abc05a9-05a9-42c0-9ae8-0ea5566453c6
     method: GET
   response:
-    body: '{"ip":{"address":"51.15.217.95","id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.128.186","id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "305"
+      - "325"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -67,7 +67,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6ddae87-24d1-4f45-a445-967e3697df91
+      - eeba0b53-b66e-401c-b5f9-f26f61c73c0a
     status: 200 OK
     code: 200
     duration: ""
@@ -81,18 +81,18 @@ interactions:
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","label":"ubuntu_jammy","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2d830ab7-b11c-435e-a582-f390ef11b1e2","label":"ubuntu_jammy","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"f0d486ff-f178-4941-ad62-8bbda478b53a","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"9467798a-e554-4658-a008-82a868d42a3b","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1179"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 797f5901-db11-4f1a-8a20-98e9ade40223
+      - ead39fb3-d95c-4e70-8e23-b904b00513b7
     status: 200 OK
     code: 200
     duration: ""
@@ -114,21 +114,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38421"
+      - "38183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -136,9 +136,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c70ac32-e724-4ac5-93f4-f1620aec912b
+      - b2794901-1a84-46af-91ef-054292e32c61
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
@@ -152,21 +152,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4865"
+      - "8882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -174,14 +174,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da08b888-d27f-454d-bae0-3ba299e3162a
+      - e655c9b1-0e67-40c6-9961-036b3fe19e1a
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-tests-instance-server-ip-removed","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"PRO2-XXS","image":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","volumes":{"0":{"boot":false,"volume_type":"b_ssd"}},"public_ip":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-tests-instance-server-ip-removed","dynamic_ip_required":false,"commercial_type":"PRO2-XXS","image":"9467798a-e554-4658-a008-82a868d42a3b","volumes":{"0":{"boot":false,"volume_type":"b_ssd"}},"public_ip":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -194,24 +194,24 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3107"
+      - "3169"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:00 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -219,7 +219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 312b734e-a8ed-4a3b-b77f-7d4ecb18a4c6
+      - 00229c73-4790-4460-a81d-ac21a0115263
     status: 201 Created
     code: 201
     duration: ""
@@ -230,27 +230,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3107"
+      - "3169"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -258,7 +258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e002ab2d-5c67-4306-a57c-e1734b8a29a5
+      - 23c46f49-9ad1-4477-92ab-d205f4a93fa7
     status: 200 OK
     code: 200
     duration: ""
@@ -269,27 +269,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3107"
+      - "3169"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -297,7 +297,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d362fd08-13b2-47ef-a0e9-29271de2a273
+      - 40b8a020-df97-4f7e-9c0a-d15654f60588
     status: 200 OK
     code: 200
     duration: ""
@@ -308,27 +308,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3107"
+      - "3169"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -336,7 +336,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f57e19f6-e34d-4233-abeb-ded173f5c165
+      - 605c991b-69a4-478f-b5ff-f1f50836fa21
     status: 200 OK
     code: 200
     duration: ""
@@ -347,7 +347,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -359,9 +359,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -369,7 +369,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd831b2e-b8af-4ed8-b662-cac59d036c1c
+      - 6c9459de-e0d5-4e84-976c-88c7127c8768
     status: 200 OK
     code: 200
     duration: ""
@@ -380,7 +380,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -392,12 +392,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Link:
-      - </servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/private_nics?page=0&per_page=50&>;
+      - </servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -405,7 +405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - acf6ade4-9a40-4038-8ae7-6fd3a276b910
+      - da28b83e-7162-4e5d-bb7a-9312ebb4910d
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -418,7 +418,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -430,12 +430,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Link:
-      - </servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/private_nics?page=0&per_page=50&>;
+      - </servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -443,7 +443,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f9423f0-d630-4f8d-b462-ecb92b6b280c
+      - a1d7713c-0a6c-4efb-a445-04a19493d23c
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -456,21 +456,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/7abc05a9-05a9-42c0-9ae8-0ea5566453c6
     method: GET
   response:
-    body: '{"ip":{"address":"51.15.217.95","id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.128.186","id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "394"
+      - "414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -478,7 +478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac780f09-8861-4c1f-a49c-c75906bf2e66
+      - b8412d08-38d4-4ff8-92f1-eb7b9734df4a
     status: 200 OK
     code: 200
     duration: ""
@@ -489,27 +489,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3107"
+      - "3169"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:02 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -517,7 +517,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67a0bed9-6da8-4d86-9a55-7d92293a2a22
+      - 7bdb53ae-fc8a-4522-bd8d-36c56386c7e3
     status: 200 OK
     code: 200
     duration: ""
@@ -528,7 +528,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -540,9 +540,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:02 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -550,7 +550,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d29e60fc-47c2-4aad-9cf1-4f3f66da4e79
+      - 77fd409c-6814-4ed7-9707-9a5113071154
     status: 200 OK
     code: 200
     duration: ""
@@ -561,7 +561,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -573,12 +573,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:02 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Link:
-      - </servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/private_nics?page=0&per_page=50&>;
+      - </servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -586,7 +586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05787580-9f45-40fe-9f2f-16315ac3f40a
+      - 9792df6d-e868-4456-ba0d-541de933fd23
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -599,21 +599,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/7abc05a9-05a9-42c0-9ae8-0ea5566453c6
     method: GET
   response:
-    body: '{"ip":{"address":"51.15.217.95","id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.128.186","id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "394"
+      - "414"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:02 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -621,7 +621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49748459-b4d7-4ee2-afb5-44dcfc2381a4
+      - 50257c51-bf38-4b87-8ec7-dd2bc88b6928
     status: 200 OK
     code: 200
     duration: ""
@@ -632,27 +632,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3107"
+      - "3169"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:02 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -660,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93ac4418-c42b-4724-bb78-2bfaf6603442
+      - ab8d6051-5e09-471c-b0c1-d99dc64ec6c8
     status: 200 OK
     code: 200
     duration: ""
@@ -671,7 +671,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -683,9 +683,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:03 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -693,7 +693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c65e81ac-10f4-46cc-9e7a-e4bf4cabf25f
+      - 862cc710-cb36-455a-8a15-b362e4996db6
     status: 200 OK
     code: 200
     duration: ""
@@ -704,7 +704,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -716,12 +716,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:03 GMT
+      - Wed, 21 Feb 2024 14:05:31 GMT
       Link:
-      - </servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/private_nics?page=0&per_page=50&>;
+      - </servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -729,7 +729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31d92cb2-6b6e-42e6-a467-a6391d207302
+      - 85e99c2e-ad97-4736-8613-e34927e29596
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -742,27 +742,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3107"
+      - "3169"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:03 GMT
+      - Wed, 21 Feb 2024 14:05:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -770,7 +770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5aa2e92e-0bc2-44ea-bd13-bb0c80346d5e
+      - 5abcab4f-1de6-45d8-9eb0-1da5d5ad7abe
     status: 200 OK
     code: 200
     duration: ""
@@ -781,27 +781,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.217.95","dynamic":false,"family":"inet","gateway":null,"id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.128.186","dynamic":false,"family":"inet","gateway":null,"id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3107"
+      - "3169"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:03 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -809,7 +809,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f72709d3-a026-4f76-aced-026497ce02d6
+      - 7a22e3ba-6ca9-49ac-a587-a5560c101d61
     status: 200 OK
     code: 200
     duration: ""
@@ -822,21 +822,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/7abc05a9-05a9-42c0-9ae8-0ea5566453c6
     method: PATCH
   response:
-    body: '{"ip":{"address":"51.15.217.95","id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.128.186","id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "305"
+      - "325"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -844,7 +844,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b103d042-ae3d-4ffc-8786-637ecfffb59b
+      - d81fcaae-bd21-4968-979b-a9257e8631ff
     status: 200 OK
     code: 200
     duration: ""
@@ -855,27 +855,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2701"
+      - "2723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -883,7 +883,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09340f30-89fa-4e0d-8a7d-364e1837349e
+      - 11b9bc27-ffbf-481f-a5d8-080d64a66937
     status: 200 OK
     code: 200
     duration: ""
@@ -894,27 +894,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2701"
+      - "2723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -922,7 +922,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aaaf2fa0-580d-465d-a563-1e59d19e07bd
+      - d2dcbc05-52b4-45ad-a8a5-4cac4286fa5b
     status: 200 OK
     code: 200
     duration: ""
@@ -933,27 +933,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2701"
+      - "2723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -961,7 +961,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9bcca744-0f19-426c-9d32-5eb1c8516bcc
+      - 6cf897b7-1161-4176-ba30-3655cdc0c5fd
     status: 200 OK
     code: 200
     duration: ""
@@ -972,7 +972,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -984,9 +984,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -994,7 +994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9389c320-bf0b-4ce5-b909-11934f566254
+      - 4a7ac015-3f78-4d61-a7cc-5bd12ce346a2
     status: 200 OK
     code: 200
     duration: ""
@@ -1005,7 +1005,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1017,12 +1017,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Link:
-      - </servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/private_nics?page=0&per_page=50&>;
+      - </servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1030,7 +1030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1db4e198-8cc9-4424-a756-5331003832ca
+      - 45cf8303-c888-4265-8c10-24c3f1cac210
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1043,7 +1043,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1055,12 +1055,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Link:
-      - </servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/private_nics?page=0&per_page=50&>;
+      - </servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1068,7 +1068,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25e266e4-5145-404b-9251-0e678fa40402
+      - d4b6bf56-3510-407e-9b44-28caf9ae1a55
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1081,27 +1081,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2701"
+      - "2723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1109,7 +1109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 396d92b2-73af-4efd-8739-57692d9a8021
+      - 42a727eb-a700-4873-8dfc-85621bf400fa
     status: 200 OK
     code: 200
     duration: ""
@@ -1120,21 +1120,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/7abc05a9-05a9-42c0-9ae8-0ea5566453c6
     method: GET
   response:
-    body: '{"ip":{"address":"51.15.217.95","id":"c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.128.186","id":"7abc05a9-05a9-42c0-9ae8-0ea5566453c6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "305"
+      - "325"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1142,7 +1142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7a1f637-dfb9-40ad-af17-75a5755c7f98
+      - 400bd892-cb43-46e0-a24e-2b34da26cfa2
     status: 200 OK
     code: 200
     duration: ""
@@ -1153,27 +1153,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2701"
+      - "2723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1181,7 +1181,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0078a34-65e0-485c-bd49-5d7b29f8e05f
+      - d9df4f90-50a6-4f03-95b0-8d0e986026b5
     status: 200 OK
     code: 200
     duration: ""
@@ -1192,7 +1192,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1204,9 +1204,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1214,7 +1214,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 182ef803-014b-4682-a401-1952e635b517
+      - b526c269-8988-46f6-b0e6-927a5e6c8c03
     status: 200 OK
     code: 200
     duration: ""
@@ -1225,7 +1225,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1237,12 +1237,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Link:
-      - </servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1/private_nics?page=0&per_page=50&>;
+      - </servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1250,7 +1250,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33ad2a11-897c-459e-afa0-820ebb08eb39
+      - ddd368b9-633a-48e1-bab1-4100595c6866
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1263,27 +1263,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2701"
+      - "2723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:06 GMT
+      - Wed, 21 Feb 2024 14:05:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1291,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 367babfa-9646-456b-80dd-eb1471b4674c
+      - 2241e7c9-0d31-4901-a657-32186e3a8f39
     status: 200 OK
     code: 200
     duration: ""
@@ -1302,7 +1302,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c7bbe2cf-8d29-46c8-bf3c-98e1c78486cd
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/7abc05a9-05a9-42c0-9ae8-0ea5566453c6
     method: DELETE
   response:
     body: ""
@@ -1310,9 +1310,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 03 Nov 2023 10:01:06 GMT
+      - Wed, 21 Feb 2024 14:05:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1320,7 +1320,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 103923d9-5504-4cbe-92ad-31be4e1c0f74
+      - daa5ab7c-4f92-4b64-89d3-88b4b4ad1b89
     status: 204 No Content
     code: 204
     duration: ""
@@ -1331,27 +1331,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:01:00.020437+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2f","maintenances":[],"modification_date":"2023-11-03T10:01:00.020437+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:01:00.020437+00:00","export_uri":null,"id":"3a529f9e-2e59-457e-890f-9e9f7a917e82","modification_date":"2023-11-03T10:01:00.020437+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.906557+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-ip-removed","id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:47","maintenances":[],"modification_date":"2024-02-21T14:05:27.906557+00:00","name":"tf-tests-instance-server-ip-removed","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.906557+00:00","export_uri":null,"id":"d78d430a-e3b4-4a41-9d27-ddf750339c87","modification_date":"2024-02-21T14:05:27.906557+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","name":"tf-tests-instance-server-ip-removed"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2701"
+      - "2723"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:06 GMT
+      - Wed, 21 Feb 2024 14:05:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1359,7 +1359,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5bd325e5-d836-44f3-a83a-13a160ab1cbf
+      - d4c24055-2f8b-41eb-ac65-d5960a3d9c0f
     status: 200 OK
     code: 200
     duration: ""
@@ -1370,7 +1370,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: DELETE
   response:
     body: ""
@@ -1378,9 +1378,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 03 Nov 2023 10:01:06 GMT
+      - Wed, 21 Feb 2024 14:05:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1388,7 +1388,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45bad4d2-591d-4380-9284-c7499437c611
+      - b87bd23e-bede-4d7c-9f6d-8e20b488b0cc
     status: 204 No Content
     code: 204
     duration: ""
@@ -1399,10 +1399,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -1411,9 +1411,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:06 GMT
+      - Wed, 21 Feb 2024 14:05:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1421,7 +1421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae3c92a6-c4f7-4c76-aa13-53efa8a7bc0e
+      - 63f9ed37-35e5-41ea-af6e-eca9a13b6403
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1432,7 +1432,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/3a529f9e-2e59-457e-890f-9e9f7a917e82
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d78d430a-e3b4-4a41-9d27-ddf750339c87
     method: DELETE
   response:
     body: ""
@@ -1440,9 +1440,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 03 Nov 2023 10:01:06 GMT
+      - Wed, 21 Feb 2024 14:05:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1450,7 +1450,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd0d5936-6339-4700-b2e5-587bdc059efd
+      - e0fbb53e-b1dc-4f1f-9393-d49dbf71feb4
     status: 204 No Content
     code: 204
     duration: ""
@@ -1461,10 +1461,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/39b3e68a-c953-402d-a6c5-03c2f1697cd1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/ae7a3bbe-35fd-48fc-9948-98fcdc9f510e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"39b3e68a-c953-402d-a6c5-03c2f1697cd1","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"ae7a3bbe-35fd-48fc-9948-98fcdc9f510e","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -1473,9 +1473,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:06 GMT
+      - Wed, 21 Feb 2024 14:05:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1483,7 +1483,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9dbe2a58-e4b5-424f-9352-dd3e21d3f114
+      - 4634e9c3-ce93-43a0-92c7-db396d6689fd
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-server-private-network.cassette.yaml
+++ b/scaleway/testdata/instance-server-private-network.cassette.yaml
@@ -2,29 +2,29 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"private_network_instance","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"private_network_instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-27T07:45:58.532342Z","dhcp_enabled":true,"id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:45:58.532342Z","id":"a2cc2e01-2b23-4349-92fa-d0837a0e8682","subnet":"172.16.72.0/22","updated_at":"2023-10-27T07:45:58.532342Z"},{"created_at":"2023-10-27T07:45:58.532342Z","id":"4ae52286-6b20-477c-84e8-f93697ecfa59","subnet":"fd46:78ab:30b8:daea::/64","updated_at":"2023-10-27T07:45:58.532342Z"}],"tags":[],"updated_at":"2023-10-27T07:45:58.532342Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:05:26.652752Z","dhcp_enabled":true,"id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:05:26.652752Z","id":"a13ba56c-23c2-4901-8548-219626e0c073","subnet":"172.16.4.0/22","updated_at":"2024-02-21T14:05:26.652752Z"},{"created_at":"2024-02-21T14:05:26.652752Z","id":"3b2d788d-fa96-4c6a-8dee-3bb21f82345f","subnet":"fd5f:519c:6d46:f5db::/64","updated_at":"2024-02-21T14:05:26.652752Z"}],"tags":[],"updated_at":"2024-02-21T14:05:26.652752Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "725"
+      - "724"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:45:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8e48cfd0-79f0-4bc1-8220-6b5484035a4a
+      - 9afe5049-ba77-468f-8f7f-257b32ab7262
     status: 200 OK
     code: 200
     duration: ""
@@ -41,23 +41,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/0a06e430-cacb-4609-8ba3-57affcbcc2db
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:45:58.532342Z","dhcp_enabled":true,"id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:45:58.532342Z","id":"a2cc2e01-2b23-4349-92fa-d0837a0e8682","subnet":"172.16.72.0/22","updated_at":"2023-10-27T07:45:58.532342Z"},{"created_at":"2023-10-27T07:45:58.532342Z","id":"4ae52286-6b20-477c-84e8-f93697ecfa59","subnet":"fd46:78ab:30b8:daea::/64","updated_at":"2023-10-27T07:45:58.532342Z"}],"tags":[],"updated_at":"2023-10-27T07:45:58.532342Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:05:26.652752Z","dhcp_enabled":true,"id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:05:26.652752Z","id":"a13ba56c-23c2-4901-8548-219626e0c073","subnet":"172.16.4.0/22","updated_at":"2024-02-21T14:05:26.652752Z"},{"created_at":"2024-02-21T14:05:26.652752Z","id":"3b2d788d-fa96-4c6a-8dee-3bb21f82345f","subnet":"fd5f:519c:6d46:f5db::/64","updated_at":"2024-02-21T14:05:26.652752Z"}],"tags":[],"updated_at":"2024-02-21T14:05:26.652752Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "725"
+      - "724"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:45:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -65,7 +65,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df8e3c13-a5ad-47e6-8976-9cacb2ffea66
+      - 8bb0f067-ec6a-43f0-b4d7-fe71c15ce148
     status: 200 OK
     code: 200
     duration: ""
@@ -74,23 +74,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-2
     method: GET
   response:
-    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"5f1186f4-d258-4ac3-b9d4-19824761e8c0","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-2"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-2"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-2"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"951e4742-8153-4c87-9110-6da742e36871","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-2"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1241"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:45:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -98,7 +98,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4234e75b-68ff-4017-936d-05b629c45410
+      - 31c1c1f5-2658-495a-9a67-33f8b3658423
     status: 200 OK
     code: 200
     duration: ""
@@ -107,26 +107,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-2/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"AMP2-C1":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.005007,"mig_profile":null,"monthly_price":3.6,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":1879048192,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"AMP2-C12":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.039752,"mig_profile":null,"monthly_price":28.62,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1200000000}],"ipv6_support":true,"sum_internal_bandwidth":1200000000,"sum_internet_bandwidth":1200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":25501368320,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"AMP2-C2":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.008165,"mig_profile":null,"monthly_price":5.88,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4026531840,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"AMP2-C24":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.077657,"mig_profile":null,"monthly_price":55.91,"ncpus":24,"network":{"interfaces":[{"internal_bandwidth":2400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2400000000}],"ipv6_support":true,"sum_internal_bandwidth":2400000000,"sum_internet_bandwidth":2400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":51271172096,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"AMP2-C4":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014483,"mig_profile":null,"monthly_price":10.43,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8321499136,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"AMP2-C48":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.153466,"mig_profile":null,"monthly_price":110.5,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":4800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":4800000000}],"ipv6_support":true,"sum_internal_bandwidth":4800000000,"sum_internet_bandwidth":4800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":102810779648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"AMP2-C60":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.19137,"mig_profile":null,"monthly_price":137.79,"ncpus":60,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":128580583424,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"AMP2-C8":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027118,"mig_profile":null,"monthly_price":19.52,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":16911433728,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"GPU-3070-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":0.98,"mig_profile":null,"monthly_price":715.4,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":2500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2500000000}],"ipv6_support":true,"sum_internal_bandwidth":2500000000,"sum_internet_bandwidth":2500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"H100-1-80G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":2.52,"mig_profile":null,"monthly_price":1839.6,"ncpus":24,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":257698037760,"scratch_storage_max_size":1920000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"H100-2-80G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":2,"hourly_price":5.04,"mig_profile":null,"monthly_price":3679.2,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":515396075520,"scratch_storage_max_size":3840000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"GPU-3070-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":0.98,"mig_profile":null,"monthly_price":715.4,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":2500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2500000000}],"ipv6_support":true,"sum_internal_bandwidth":2500000000,"sum_internet_bandwidth":2500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"H100-1-80G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":2.52,"mig_profile":null,"monthly_price":1839.6,"ncpus":24,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":257698037760,"scratch_storage_max_size":3000000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"H100-1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":4.2,"mig_profile":null,"monthly_price":3066,"ncpus":24,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":257698037760,"scratch_storage_max_size":3000000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"H100-2-80G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":2,"hourly_price":5.04,"mig_profile":null,"monthly_price":3679.2,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":515396075520,"scratch_storage_max_size":6000000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"H100-2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":2,"hourly_price":8.4,"mig_profile":null,"monthly_price":6132,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":515396075520,"scratch_storage_max_size":6000000000000,"volumes_constraint":{"max_size":0,"min_size":0}},"L4-1-24G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":0.75,"mig_profile":null,"monthly_price":547.5,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":2500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":2500000000}],"ipv6_support":true,"sum_internal_bandwidth":2500000000,"sum_internet_bandwidth":2500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":51539607552,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"L4-2-24G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":2,"hourly_price":1.5,"mig_profile":null,"monthly_price":1095,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":103079215104,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"L4-4-24G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":4,"hourly_price":3,"mig_profile":null,"monthly_price":2190,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":206158430208,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"L4-8-24G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":8,"hourly_price":6,"mig_profile":null,"monthly_price":4380,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38089"
+      - "38133"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:45:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -134,9 +134,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0390d863-f162-46a6-bcb1-764b3ee36d89
+      - 671aace3-4e57-489c-9e8a-0eb8fc233446
       X-Total-Count:
-      - "54"
+      - "57"
     status: 200 OK
     code: 200
     duration: ""
@@ -145,26 +145,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-2/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}}}}'
+    body: '{"servers":{"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "3038"
+      - "5299"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:45:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -172,44 +172,44 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a39965b3-6048-4ee0-a06a-9158f610352b
+      - 99408ac3-62d2-4b08-a256-be70e21bad18
       X-Total-Count:
-      - "54"
+      - "57"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-affectionate-wilbur","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5"}'
+    body: '{"name":"tf-srv-tender-stallman","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers
     method: POST
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:45:59.735913+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:05:27.585284+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "2660"
+      - "2670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:46:00 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
+      - https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -217,7 +217,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c869c4c1-967c-472b-b8cd-25f4a08cf684
+      - c31eaa33-b4e2-4236-8d98-5bdb6ae00a9d
     status: 201 Created
     code: 201
     duration: ""
@@ -226,29 +226,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:45:59.735913+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:05:27.585284+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "2660"
+      - "2670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:46:00 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -256,7 +256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b151b98e-e5b5-49dc-8cce-f8f860d90f34
+      - da730f63-a91b-4b80-977e-bec6820d5d41
     status: 200 OK
     code: 200
     duration: ""
@@ -265,29 +265,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:45:59.735913+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:05:27.585284+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
     headers:
       Content-Length:
-      - "2660"
+      - "2670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:46:00 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -295,7 +295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d8f9134-96c2-4dd3-aedb-5a008413f4f9
+      - 229a3b7d-f7c7-489f-948c-79598ed876e0
     status: 200 OK
     code: 200
     duration: ""
@@ -306,12 +306,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/action","href_result":"/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59","id":"0bb3e93b-5ec5-4699-bed9-1c8f7c0d37c3","started_at":"2023-10-27T07:46:01.053438+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/action","href_result":"/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d","id":"9534a9a7-153b-43bf-a293-163714c19c1a","started_at":"2024-02-21T14:05:28.703089+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -320,11 +320,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:46:01 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/0bb3e93b-5ec5-4699-bed9-1c8f7c0d37c3
+      - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/9534a9a7-153b-43bf-a293-163714c19c1a
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -332,7 +332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae2eb371-0bed-47e8-aa70-8e945f8c47c0
+      - 03844dff-8699-48ff-ab28-6fda178639fd
     status: 202 Accepted
     code: 202
     duration: ""
@@ -341,18 +341,1873 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:00.545617+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:05:28.537451+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "2692"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:29 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 501ae772-92f5-4672-b376-dc560e1a5065
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:05:28.537451+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "2806"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 40881641-7c81-42c3-bad0-2fd1e48a5a02
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:05:38.873190+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "2837"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:39 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d6efa442-17c4-4eb3-ac5b-51814a6e7bc7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-21T14:05:26.652752Z","dhcp_enabled":true,"id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:05:26.652752Z","id":"a13ba56c-23c2-4901-8548-219626e0c073","subnet":"172.16.4.0/22","updated_at":"2024-02-21T14:05:26.652752Z"},{"created_at":"2024-02-21T14:05:26.652752Z","id":"3b2d788d-fa96-4c6a-8dee-3bb21f82345f","subnet":"fd5f:519c:6d46:f5db::/64","updated_at":"2024-02-21T14:05:26.652752Z"}],"tags":[],"updated_at":"2024-02-21T14:05:26.652752Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "724"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:39 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - efe391cb-5b1d-42f1-885d-72bd8286f8f2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:05:38.873190+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "2837"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:39 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 73638102-b1dc-4fe2-817e-eb735991729f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics
+    method: POST
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:05:39.531652+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "376"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:40 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f2c606ce-3cc8-4bf6-8d37-16e29fe88e9a
+    status: 201 Created
+    code: 201
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics/3a499974-baac-46e4-aa99-dc108afd809d
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:05:39.531652+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "376"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:40 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c6fb38e5-fd8b-47e6-b46a-0e08d3dcdab4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics/3a499974-baac-46e4-aa99-dc108afd809d
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:05:40.301651+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "376"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 04da92b7-90c9-4568-9e9a-bfd7270d135c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics/3a499974-baac-46e4-aa99-dc108afd809d
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:05:40.301651+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "376"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2478f998-e6b9-40c3-abae-73305f5a8f6e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics/3a499974-baac-46e4-aa99-dc108afd809d
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:05:40.301651+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "376"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:05:55 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fbd8f05a-c5a9-4a49-9c56-14450c54b974
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics/3a499974-baac-46e4-aa99-dc108afd809d
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:05:40.301651+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "376"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:00 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2d0c8ef1-c66b-40e4-bfc4-ea326ac5dd56
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics/3a499974-baac-46e4-aa99-dc108afd809d
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:05:40.301651+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "376"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:05 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 158dddbf-2b82-4186-8751-7542449840a7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics/3a499974-baac-46e4-aa99-dc108afd809d
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:05:40.301651+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"syncing","tags":[],"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "376"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:10 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aece6343-b536-488b-92d3-f57f62a8fc50
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics/3a499974-baac-46e4-aa99-dc108afd809d
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 531997fd-2621-454e-8c31-d596d07d6d0f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics/3a499974-baac-46e4-aa99-dc108afd809d
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a83f6579-d254-4eda-8e25-d2e1bcc84c27
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:05:38.873190+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "3190"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b2b14867-c6d5-44b1-90d1-b998ecadbebd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/user_data
+    method: GET
+  response:
+    body: '{"user_data":[]}'
+    headers:
+      Content-Length:
+      - "17"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:19 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6318d785-f0bc-4a06-89fe-4bdff037fe06
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics
+    method: GET
+  response:
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}]}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:19 GMT
+      Link:
+      - </servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics?page=1&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 60d2c6aa-09d5-442b-a2f7-8fa6e254567c
+      X-Total-Count:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics
+    method: GET
+  response:
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}]}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:20 GMT
+      Link:
+      - </servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics?page=1&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6146c508-4699-48c5-b1ac-89d645a7198c
+      X-Total-Count:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-21T14:05:26.652752Z","dhcp_enabled":true,"id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:05:26.652752Z","id":"a13ba56c-23c2-4901-8548-219626e0c073","subnet":"172.16.4.0/22","updated_at":"2024-02-21T14:05:26.652752Z"},{"created_at":"2024-02-21T14:05:26.652752Z","id":"3b2d788d-fa96-4c6a-8dee-3bb21f82345f","subnet":"fd5f:519c:6d46:f5db::/64","updated_at":"2024-02-21T14:05:26.652752Z"}],"tags":[],"updated_at":"2024-02-21T14:05:26.652752Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "724"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 18a5dd10-65cb-44d4-a4bd-1797703ef27f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:05:38.873190+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "3190"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a704a166-78e8-4786-a6fc-0d4d4424a8b5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/user_data
+    method: GET
+  response:
+    body: '{"user_data":[]}'
+    headers:
+      Content-Length:
+      - "17"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e20a72ef-7c85-4b7a-9249-8cd8d0d2f7ca
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics
+    method: GET
+  response:
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}]}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:21 GMT
+      Link:
+      - </servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics?page=1&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ac055812-e54f-4e4b-9c76-44053aa954f3
+      X-Total-Count:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-21T14:05:26.652752Z","dhcp_enabled":true,"id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:05:26.652752Z","id":"a13ba56c-23c2-4901-8548-219626e0c073","subnet":"172.16.4.0/22","updated_at":"2024-02-21T14:05:26.652752Z"},{"created_at":"2024-02-21T14:05:26.652752Z","id":"3b2d788d-fa96-4c6a-8dee-3bb21f82345f","subnet":"fd5f:519c:6d46:f5db::/64","updated_at":"2024-02-21T14:05:26.652752Z"}],"tags":[],"updated_at":"2024-02-21T14:05:26.652752Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "724"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 83dd667f-1b1f-4e02-ad50-295dbcf27ee7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:05:38.873190+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "3190"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4b7b0309-3e4d-4706-8b5d-c4d88daf6daa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/user_data
+    method: GET
+  response:
+    body: '{"user_data":[]}'
+    headers:
+      Content-Length:
+      - "17"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:22 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dddb21cb-a439-4eb0-ba69-9dc6efaf9bce
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics
+    method: GET
+  response:
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}]}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:22 GMT
+      Link:
+      - </servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics?page=1&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7f6ad209-c453-454f-9898-3f6018c9791c
+      X-Total-Count:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:05:38.873190+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "3190"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:23 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 37ddf894-0c78-4d20-902a-5c48c642cf4a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"action":"poweroff"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/action
+    method: POST
+  response:
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/action","href_result":"/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d","id":"4216ad40-c25f-4bfb-8568-d2cdcb742606","started_at":"2024-02-21T14:06:23.512837+00:00","status":"pending","terminated_at":null}}'
+    headers:
+      Content-Length:
+      - "317"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:23 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/4216ad40-c25f-4bfb-8568-d2cdcb742606
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 68022443-3f1f-4ff1-9b91-49cb7d572e2d
+    status: 202 Accepted
+    code: 202
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:06:23.114783+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "3158"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:23 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0b4ab330-6ec0-40c9-b200-37e10c439a2f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:06:23.114783+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "3158"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:29 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1c8d5d68-1c98-4ee9-8079-507221f5e393
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:06:23.114783+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "3158"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5b4fb8cd-2e98-4df7-8d53-1e15ddce5e09
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:06:23.114783+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "3158"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:39 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2da09c8b-1beb-4e9d-a90e-bfa33f258a01
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:06:23.114783+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "3158"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7c200ea6-b32e-4ca6-91ef-45d9937e16b4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:06:23.114783+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "3158"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:49 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 86a40d87-2973-42b6-9732-bbd8325c08f9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:06:23.114783+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "3158"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:06:55 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 779776f8-cd30-4184-839c-ce012b6c2c28
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"21","hypervisor_id":"802","node_id":"33","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:06:23.114783+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.200.164.65","private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "3158"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:07:00 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2329181b-7d5e-4ac6-b609-5e46207b6a8f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:07:01.318680+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "3031"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:07:05 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eaced6df-d4a0-4974-9738-2a155600624a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics
+    method: GET
+  response:
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}]}'
+    headers:
+      Content-Length:
+      - "381"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:07:05 GMT
+      Link:
+      - </servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics?page=1&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c4594c4a-4080-42c3-badf-db0d708952a1
+      X-Total-Count:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics/3a499974-baac-46e4-aa99-dc108afd809d
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:05:39.531652+00:00","id":"3a499974-baac-46e4-aa99-dc108afd809d","mac_address":"02:00:00:24:84:b6","modification_date":"2024-02-21T14:06:10.639855+00:00","private_network_id":"b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318","server_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","state":"available","tags":[],"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "378"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:07:05 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b555cf2f-a521-4ade-886f-3d26e6b6d40b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics/3a499974-baac-46e4-aa99-dc108afd809d
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Wed, 21 Feb 2024 14:07:06 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 34cd3c8e-88f3-42ac-b684-5bbc9d9040eb
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d/private_nics/3a499974-baac-46e4-aa99-dc108afd809d
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"3a499974-baac-46e4-aa99-dc108afd809d","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "148"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:07:06 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 81dcdcf3-54a5-4718-b7c5-514bcff2c599
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:05:27.585284+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-tender-stallman","id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:26.702575+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"a0102ed0-eb98-415b-8daf-1b8c6ad453a1","modification_date":"2024-01-31T15:37:26.702575+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"128da271-9f57-4bf7-a124-7bd6cfca70b4","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:2e:ea:d1","maintenances":[],"modification_date":"2024-02-21T14:07:01.318680+00:00","name":"tf-srv-tender-stallman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"eaabb9f4-fbdf-4310-9cb6-4d42934b673a","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.585284+00:00","export_uri":null,"id":"2813a366-148b-4daa-b9c8-d7dcf495bf39","modification_date":"2024-02-21T14:05:27.585284+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","name":"tf-srv-tender-stallman"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
+    headers:
+      Content-Length:
+      - "2670"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:07:06 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 740a2118-3439-4be5-baed-a6cd1946824b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Wed, 21 Feb 2024 14:07:06 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d24f4245-eecb-4995-8809-1fdad9a00fd5
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/00cb9ace-dfab-45fe-837a-e47b6b532e5d
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"00cb9ace-dfab-45fe-837a-e47b6b532e5d","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "143"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:07:07 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - dd3b2733-a6eb-4780-b58a-99795ae16190
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/2813a366-148b-4daa-b9c8-d7dcf495bf39
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Date:
+      - Wed, 21 Feb 2024 14:07:07 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 725aacf2-6cea-442a-8bef-3e00759c7f53
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: '{"name":"private_network_instance","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2024-02-21T14:07:07.302001Z","dhcp_enabled":true,"id":"2198d72d-9049-4382-8f70-57206fc6e529","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:07:07.302001Z","id":"c0868a98-2e30-4a6f-b971-381523d1c714","subnet":"172.16.44.0/22","updated_at":"2024-02-21T14:07:07.302001Z"},{"created_at":"2024-02-21T14:07:07.302001Z","id":"11028c1c-55a3-479a-9b49-91fc218420b5","subnet":"fd5f:519c:6d46:8ca9::/64","updated_at":"2024-02-21T14:07:07.302001Z"}],"tags":[],"updated_at":"2024-02-21T14:07:07.302001Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:07:07 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 04a45457-12ea-48be-b012-2880caf55f1f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2198d72d-9049-4382-8f70-57206fc6e529
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-21T14:07:07.302001Z","dhcp_enabled":true,"id":"2198d72d-9049-4382-8f70-57206fc6e529","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:07:07.302001Z","id":"c0868a98-2e30-4a6f-b971-381523d1c714","subnet":"172.16.44.0/22","updated_at":"2024-02-21T14:07:07.302001Z"},{"created_at":"2024-02-21T14:07:07.302001Z","id":"11028c1c-55a3-479a-9b49-91fc218420b5","subnet":"fd5f:519c:6d46:8ca9::/64","updated_at":"2024-02-21T14:07:07.302001Z"}],"tags":[],"updated_at":"2024-02-21T14:07:07.302001Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "725"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:07:07 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a9b16792-9425-4cac-a0f0-4c2595734a9c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b4e35caa-f1f2-4f6d-8ea7-9699cbaa1318
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:07:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 12e095ae-564e-43fc-aa40-e5d757b31425
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2f1f7a57-c508-4f72-9f7f-536b316f36e1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"5d083890-4354-47ab-b769-8b0de601eb3a","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1260"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:07:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a9a1053d-13ba-475a-aaf8-5780dbbd9d8f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+    method: GET
+  response:
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
+    headers:
+      Content-Length:
+      - "38183"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:07:08 GMT
+      Link:
+      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
+        rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3c37852f-aef0-478b-8453-35ede7b91af9
+      X-Total-Count:
+      - "61"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+    method: GET
+  response:
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    headers:
+      Content-Length:
+      - "8882"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:07:08 GMT
+      Link:
+      - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
+        rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fb926ac0-690b-4a86-9146-3e48a034b757
+      X-Total-Count:
+      - "61"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"tf-srv-unruffled-heyrovsky","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5d083890-4354-47ab-b769-8b0de601eb3a","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+    method: POST
+  response:
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:09.028752+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "2682"
@@ -361,9 +2216,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:46:01 GMT
+      - Wed, 21 Feb 2024 14:07:09 GMT
+      Location:
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -371,231 +2228,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bbb9d0c5-dcf3-4080-96b5-6651400eba71
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:00.545617+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "2795"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e0fd0d3f-23f4-437b-a647-fac27c900acd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:00.545617+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "2795"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 17a2e0de-0ede-48b2-be93-739f5cace826
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:14.323088+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "2826"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d82cb2fc-b87d-4c77-96f6-bd7478ee82af
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/0a06e430-cacb-4609-8ba3-57affcbcc2db
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-27T07:45:58.532342Z","dhcp_enabled":true,"id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:45:58.532342Z","id":"a2cc2e01-2b23-4349-92fa-d0837a0e8682","subnet":"172.16.72.0/22","updated_at":"2023-10-27T07:45:58.532342Z"},{"created_at":"2023-10-27T07:45:58.532342Z","id":"4ae52286-6b20-477c-84e8-f93697ecfa59","subnet":"fd46:78ab:30b8:daea::/64","updated_at":"2023-10-27T07:45:58.532342Z"}],"tags":[],"updated_at":"2023-10-27T07:45:58.532342Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
-    headers:
-      Content-Length:
-      - "725"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2910ab1a-3218-4413-ab5c-2fc384b44494
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:14.323088+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "2826"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a1b852ec-5a02-4d82-bf90-edac099add01
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics
-    method: POST
-  response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:16.882698+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"syncing","tags":[],"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 69610ab2-c71d-40cc-9b22-7847da7c478e
+      - d310bf32-7fb8-4327-a174-585921ba3795
     status: 201 Created
     code: 201
     duration: ""
@@ -604,1779 +2237,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics/5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:16.882698+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"syncing","tags":[],"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d4db919d-830e-4c25-b823-11760fabf5a4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics/5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:17.823283+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"syncing","tags":[],"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e2c6b40e-ce7d-4721-800e-4bb26c5a6fc7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics/5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:17.823283+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"syncing","tags":[],"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e2b00351-73ec-4072-aced-33869312454d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics/5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:17.823283+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"syncing","tags":[],"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fceef583-76e3-4ac8-8b66-9896a9cd2335
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics/5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:17.823283+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"syncing","tags":[],"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a8ad5c52-506d-4f78-9687-6d8e19c69870
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics/5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:17.823283+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"syncing","tags":[],"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cd0f9ad2-d27d-4fa8-9923-5839fba73c08
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics/5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:17.823283+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"syncing","tags":[],"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e888f61a-1307-4b76-926f-313332ee4de0
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics/5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 93fcf291-80d7-4f57-8e2b-33ca54832f1d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics/5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3674cc2d-d619-4378-b470-3a62f3bbc753
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:14.323088+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3179"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 94b43d7f-683f-4180-8837-501f9d958c3b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/user_data
-    method: GET
-  response:
-    body: '{"user_data":[]}'
-    headers:
-      Content-Length:
-      - "17"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:53 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a37f4d07-994a-4826-969b-b52a771c12bf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics
-    method: GET
-  response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}]}'
-    headers:
-      Content-Length:
-      - "381"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:53 GMT
-      Link:
-      - </servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics?page=1&per_page=50&>;
-        rel="last"
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 179ef3b5-b641-4e76-918a-22b2e52521bb
-      X-Total-Count:
-      - "1"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics
-    method: GET
-  response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}]}'
-    headers:
-      Content-Length:
-      - "381"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:53 GMT
-      Link:
-      - </servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics?page=1&per_page=50&>;
-        rel="last"
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b612a94f-bc1c-4dbe-ad5f-7f1e64a6ef94
-      X-Total-Count:
-      - "1"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/0a06e430-cacb-4609-8ba3-57affcbcc2db
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-27T07:45:58.532342Z","dhcp_enabled":true,"id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:45:58.532342Z","id":"a2cc2e01-2b23-4349-92fa-d0837a0e8682","subnet":"172.16.72.0/22","updated_at":"2023-10-27T07:45:58.532342Z"},{"created_at":"2023-10-27T07:45:58.532342Z","id":"4ae52286-6b20-477c-84e8-f93697ecfa59","subnet":"fd46:78ab:30b8:daea::/64","updated_at":"2023-10-27T07:45:58.532342Z"}],"tags":[],"updated_at":"2023-10-27T07:45:58.532342Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
-    headers:
-      Content-Length:
-      - "725"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 355fe1a0-7507-4db4-9cb8-52972e5715a3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:14.323088+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3179"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e678e04e-9bd9-41a5-8226-08febbdbbbfa
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/user_data
-    method: GET
-  response:
-    body: '{"user_data":[]}'
-    headers:
-      Content-Length:
-      - "17"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9912e5b2-bc5d-4a2c-a38f-fb0888f0bfc3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics
-    method: GET
-  response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}]}'
-    headers:
-      Content-Length:
-      - "381"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:54 GMT
-      Link:
-      - </servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics?page=1&per_page=50&>;
-        rel="last"
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d71d8820-fa43-4bfc-b6e4-45ea563d61e8
-      X-Total-Count:
-      - "1"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/0a06e430-cacb-4609-8ba3-57affcbcc2db
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-27T07:45:58.532342Z","dhcp_enabled":true,"id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:45:58.532342Z","id":"a2cc2e01-2b23-4349-92fa-d0837a0e8682","subnet":"172.16.72.0/22","updated_at":"2023-10-27T07:45:58.532342Z"},{"created_at":"2023-10-27T07:45:58.532342Z","id":"4ae52286-6b20-477c-84e8-f93697ecfa59","subnet":"fd46:78ab:30b8:daea::/64","updated_at":"2023-10-27T07:45:58.532342Z"}],"tags":[],"updated_at":"2023-10-27T07:45:58.532342Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
-    headers:
-      Content-Length:
-      - "725"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d6c73763-af10-4163-b713-16463deafd2c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:14.323088+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3179"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bcdb0404-ec19-4789-ae56-32401fa1e173
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/user_data
-    method: GET
-  response:
-    body: '{"user_data":[]}'
-    headers:
-      Content-Length:
-      - "17"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:54 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 165b23de-2679-4609-b44c-2289d242d76c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics
-    method: GET
-  response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}]}'
-    headers:
-      Content-Length:
-      - "381"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:55 GMT
-      Link:
-      - </servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics?page=1&per_page=50&>;
-        rel="last"
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 756028c2-d477-400a-9385-a7151f1f74a7
-      X-Total-Count:
-      - "1"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:14.323088+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3179"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4d63b3dd-fce0-434c-9a79-4f2ec766a6b7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"action":"poweroff"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/action
-    method: POST
-  response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/action","href_result":"/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59","id":"c79cc73a-ac20-4d65-b8b9-96cdf0b45aeb","started_at":"2023-10-27T07:46:55.949891+00:00","status":"pending","terminated_at":null}}'
-    headers:
-      Content-Length:
-      - "317"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:55 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-2/tasks/c79cc73a-ac20-4d65-b8b9-96cdf0b45aeb
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - de36130a-69bd-4cf8-b296-73855d4b3bfb
-    status: 202 Accepted
-    code: 202
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:55.642326+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3147"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:46:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ac1faa42-d02f-449d-8c3e-2c7ccf6e0557
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:55.642326+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3147"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:01 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d372c35e-8545-4a62-b484-22ae02a75871
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:55.642326+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3147"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 949a0496-da84-42dd-9b02-304039ea3022
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:55.642326+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3147"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4d1dad4b-3cb4-4a1a-bc74-992c463bde97
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:55.642326+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3147"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:16 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 103a4836-1549-42b7-8987-713347f9423b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:55.642326+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3147"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2d936549-6d12-4637-a325-bfc447b949cd
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:55.642326+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3147"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:27 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2e50969b-07bb-4198-ac5b-9c179432191f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:55.642326+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3147"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:32 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 125bc396-e5a9-4a2a-82af-292db40bdc86
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:55.642326+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3147"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:38 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2dbf7a1f-befd-4efe-b651-909203ad01be
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":{"cluster_id":"14","hypervisor_id":"401","node_id":"22","platform_id":"30","zone_id":"fr-par-2"},"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:46:55.642326+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.197.90.43","private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3147"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:43 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 17034c19-0ddd-4bfa-a53c-34f52f3b2a81
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:47:44.866273+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "3021"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8583196e-43d3-47ae-aa35-4a1d308ef359
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics
-    method: GET
-  response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}]}'
-    headers:
-      Content-Length:
-      - "381"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:48 GMT
-      Link:
-      - </servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics?page=1&per_page=50&>;
-        rel="last"
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0c1f0700-584c-469b-9cf0-dda7febf52a4
-      X-Total-Count:
-      - "1"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics/5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:46:16.882698+00:00","id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","mac_address":"02:00:00:22:f7:f0","modification_date":"2023-10-27T07:46:48.424692+00:00","private_network_id":"0a06e430-cacb-4609-8ba3-57affcbcc2db","server_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","state":"available","tags":[],"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "378"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 207a6483-9d98-4189-9a69-5745063fd78a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics/5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Date:
-      - Fri, 27 Oct 2023 07:47:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fbf5044b-669f-4966-927e-35a053a02547
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59/private_nics/5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"5b0dabc0-c64f-41dc-ac6f-7db4b49d8dd1","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "148"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f062dc3d-fb2a-4d68-96b9-229fab8eb395
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"e6a56379-9ef4-48d4-a1d2-12b475e0fed8","initrd":"http://10.197.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.197.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-2"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:45:59.735913+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-affectionate-wilbur","id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:52.792003+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c279d367-db1f-4cfe-bb4c-d8c589062fbf","modification_date":"2023-08-08T13:33:52.792003+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"dd333413-110e-4533-b991-05c4b0fbf017","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-2"},"ipv6":null,"location":null,"mac_address":"de:00:00:21:5d:a1","maintenances":[],"modification_date":"2023-10-27T07:47:44.866273+00:00","name":"tf-srv-affectionate-wilbur","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"9c7310aa-d544-4ceb-916c-cc2b25f7c8e1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:45:59.735913+00:00","export_uri":null,"id":"1612f013-75ba-4c5a-813e-431e459954e1","modification_date":"2023-10-27T07:45:59.735913+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","name":"tf-srv-affectionate-wilbur"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-2"}},"zone":"fr-par-2"}}'
-    headers:
-      Content-Length:
-      - "2660"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bde251b0-eae9-4064-92c2-fc553d51cdbc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Date:
-      - Fri, 27 Oct 2023 07:47:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - c906d83c-3ea9-4b08-8738-fa0b08dd03d1
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/servers/b448a001-f034-4ea7-86fe-5d15cdf49d59
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"b448a001-f034-4ea7-86fe-5d15cdf49d59","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "143"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:48 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9a84acd5-c066-4444-b56c-12f368e45baa
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-2/volumes/1612f013-75ba-4c5a-813e-431e459954e1
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Date:
-      - Fri, 27 Oct 2023 07:47:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9784d412-3e19-4a14-b1d5-c67e6d6c39db
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/0a06e430-cacb-4609-8ba3-57affcbcc2db
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eb7ac89b-53f8-49c4-b0b7-4fc610c9ea61
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: '{"name":"private_network_instance","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null,"vpc_id":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
-    method: POST
-  response:
-    body: '{"created_at":"2023-10-27T07:47:49.166464Z","dhcp_enabled":true,"id":"161831c6-4081-4f6b-940c-6f059525f368","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:47:49.166464Z","id":"bd0e7733-5c20-45d4-8ddc-a28aea069d30","subnet":"172.16.68.0/22","updated_at":"2023-10-27T07:47:49.166464Z"},{"created_at":"2023-10-27T07:47:49.166464Z","id":"eb3af6ea-438f-4108-befb-90b1eb8a0ab7","subnet":"fd46:78ab:30b8:4672::/64","updated_at":"2023-10-27T07:47:49.166464Z"}],"tags":[],"updated_at":"2023-10-27T07:47:49.166464Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
-    headers:
-      Content-Length:
-      - "725"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eb592f53-65a1-40f5-9b83-748dbc67aaef
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/161831c6-4081-4f6b-940c-6f059525f368
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-27T07:47:49.166464Z","dhcp_enabled":true,"id":"161831c6-4081-4f6b-940c-6f059525f368","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:47:49.166464Z","id":"bd0e7733-5c20-45d4-8ddc-a28aea069d30","subnet":"172.16.68.0/22","updated_at":"2023-10-27T07:47:49.166464Z"},{"created_at":"2023-10-27T07:47:49.166464Z","id":"eb3af6ea-438f-4108-befb-90b1eb8a0ab7","subnet":"fd46:78ab:30b8:4672::/64","updated_at":"2023-10-27T07:47:49.166464Z"}],"tags":[],"updated_at":"2023-10-27T07:47:49.166464Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
-    headers:
-      Content-Length:
-      - "725"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5143dd7f-2e82-4ef0-beca-a7e85c2b64b2
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
-    method: GET
-  response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"10b2d3c3-bfa7-42d4-910b-389e95f95ccb","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "1256"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:49 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 33bea040-2b66-4ba6-b403-897c40075ad5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
-    method: GET
-  response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
-    headers:
-      Content-Length:
-      - "38421"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:50 GMT
-      Link:
-      - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
-        rel="last"
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 64dcbc08-405d-41d4-aaa3-43d2f705e10d
-      X-Total-Count:
-      - "56"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
-    method: GET
-  response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
-    headers:
-      Content-Length:
-      - "4865"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:50 GMT
-      Link:
-      - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
-        rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a16e86c3-d6f0-419c-a557-3d584a2cc6c1
-      X-Total-Count:
-      - "56"
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"tf-srv-relaxed-aryabhata","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5"}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
-    method: POST
-  response:
-    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:47:50.306320+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2654"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:47:50 GMT
-      Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1e8db961-8b70-4d01-8109-814bf58eb94f
-    status: 201 Created
-    code: 201
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:47:50.306320+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:09.028752+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2654"
+      - "2682"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:47:50 GMT
+      - Wed, 21 Feb 2024 14:07:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2384,7 +2267,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6787105e-a3cb-4b39-9a9e-5960398b7f29
+      - baff8e50-070a-4ff8-a4cc-bded8ecc7034
     status: 200 OK
     code: 200
     duration: ""
@@ -2393,29 +2276,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:47:50.306320+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:09.028752+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2654"
+      - "2682"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:47:50 GMT
+      - Wed, 21 Feb 2024 14:07:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2423,7 +2306,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea503f54-2b6f-4e02-a40e-18697047dfe5
+      - 94581aa7-83a6-45a6-b59c-55468d95dbdd
     status: 200 OK
     code: 200
     duration: ""
@@ -2434,12 +2317,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/action","href_result":"/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","id":"d9f58c13-6a7e-43dc-aa5c-180b2041ad29","started_at":"2023-10-27T07:47:51.339733+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/b098331e-a548-48af-b451-7f8062029c4c/action","href_result":"/servers/b098331e-a548-48af-b451-7f8062029c4c","id":"90034763-91d0-4cdf-951e-ef6f78b20897","started_at":"2024-02-21T14:07:10.627307+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -2448,11 +2331,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:47:51 GMT
+      - Wed, 21 Feb 2024 14:07:10 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/d9f58c13-6a7e-43dc-aa5c-180b2041ad29
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/90034763-91d0-4cdf-951e-ef6f78b20897
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2460,7 +2343,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3708a395-b670-46e2-9d02-a66e75ccbc2d
+      - f44cf6aa-0141-4f16-bd4c-8743c75e436d
     status: 202 Accepted
     code: 202
     duration: ""
@@ -2469,29 +2352,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:47:51.013601+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:10.462660+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2676"
+      - "2704"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:47:51 GMT
+      - Wed, 21 Feb 2024 14:07:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2499,7 +2382,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2886a87e-5bda-4b43-ae4b-a5f22bd7451c
+      - c55cdd0e-e8e1-493e-a834-79922f7f3a27
     status: 200 OK
     code: 200
     duration: ""
@@ -2508,29 +2391,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:47:51.013601+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:10.462660+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2783"
+      - "2813"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:47:56 GMT
+      - Wed, 21 Feb 2024 14:07:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2538,7 +2421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32a8928e-c4f1-4287-886d-6c39c2fa4661
+      - 3cdaf9a8-82a1-4663-845f-5dc0ecd83e64
     status: 200 OK
     code: 200
     duration: ""
@@ -2547,29 +2430,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:47:51.013601+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:10.462660+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2783"
+      - "2813"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:01 GMT
+      - Wed, 21 Feb 2024 14:07:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2577,7 +2460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba53c06d-5823-4b02-915b-4243a41fb4ed
+      - 0d7d49c0-28f7-400e-bc38-fcaf5dab130e
     status: 200 OK
     code: 200
     duration: ""
@@ -2586,29 +2469,68 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:10.462660+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2813"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:07:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5cb85ef7-64cf-48f6-aee8-d2aa235da486
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2814"
+      - "2844"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:06 GMT
+      - Wed, 21 Feb 2024 14:07:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2616,7 +2538,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - febad3fc-e104-48ae-b3e0-f037f03d796e
+      - a7ef59bc-778e-4fc7-9bba-8f8c502ffc23
     status: 200 OK
     code: 200
     duration: ""
@@ -2625,12 +2547,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/161831c6-4081-4f6b-940c-6f059525f368
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2198d72d-9049-4382-8f70-57206fc6e529
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:47:49.166464Z","dhcp_enabled":true,"id":"161831c6-4081-4f6b-940c-6f059525f368","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:47:49.166464Z","id":"bd0e7733-5c20-45d4-8ddc-a28aea069d30","subnet":"172.16.68.0/22","updated_at":"2023-10-27T07:47:49.166464Z"},{"created_at":"2023-10-27T07:47:49.166464Z","id":"eb3af6ea-438f-4108-befb-90b1eb8a0ab7","subnet":"fd46:78ab:30b8:4672::/64","updated_at":"2023-10-27T07:47:49.166464Z"}],"tags":[],"updated_at":"2023-10-27T07:47:49.166464Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:07:07.302001Z","dhcp_enabled":true,"id":"2198d72d-9049-4382-8f70-57206fc6e529","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:07:07.302001Z","id":"c0868a98-2e30-4a6f-b971-381523d1c714","subnet":"172.16.44.0/22","updated_at":"2024-02-21T14:07:07.302001Z"},{"created_at":"2024-02-21T14:07:07.302001Z","id":"11028c1c-55a3-479a-9b49-91fc218420b5","subnet":"fd5f:519c:6d46:8ca9::/64","updated_at":"2024-02-21T14:07:07.302001Z"}],"tags":[],"updated_at":"2024-02-21T14:07:07.302001Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -2639,9 +2561,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:07 GMT
+      - Wed, 21 Feb 2024 14:07:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2649,7 +2571,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 129421ad-4ff3-49a4-a298-0fddc6e6f4c1
+      - b5921ef6-0787-4807-aaf8-a55c065e9647
     status: 200 OK
     code: 200
     duration: ""
@@ -2658,29 +2580,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2814"
+      - "2844"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:07 GMT
+      - Wed, 21 Feb 2024 14:07:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2688,23 +2610,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13c37914-ba67-4576-bc79-651ca6b3fcc6
+      - cafbf030-bf5d-4710-8ae2-bb1a0c4d202c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"161831c6-4081-4f6b-940c-6f059525f368"}'
+    body: '{"private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:07.195269+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:07:32.539113+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2713,9 +2635,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:07 GMT
+      - Wed, 21 Feb 2024 14:07:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2723,7 +2645,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 398c9755-fbf3-4bfd-a074-7255e865ddf7
+      - 67ea897a-945c-4354-87b2-b247fff95d8d
     status: 201 Created
     code: 201
     duration: ""
@@ -2732,12 +2654,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/cc4b8e6a-1ad3-438d-a18f-2466d6983e4a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/e6d7e868-2379-4cff-bc4f-24cb41835456
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:07.195269+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:07:32.539113+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2746,9 +2668,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:07 GMT
+      - Wed, 21 Feb 2024 14:07:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2756,7 +2678,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75f4a5e7-e26d-40c7-b4d3-cc57e612bdaf
+      - 4eecc3bc-3af1-48cd-bf5f-ae5336df6b59
     status: 200 OK
     code: 200
     duration: ""
@@ -2765,12 +2687,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/cc4b8e6a-1ad3-438d-a18f-2466d6983e4a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/e6d7e868-2379-4cff-bc4f-24cb41835456
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:10.147070+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:07:33.569882+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2779,9 +2701,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:12 GMT
+      - Wed, 21 Feb 2024 14:07:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2789,7 +2711,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 104ed56e-4410-43c6-b12b-01d3490d7e0c
+      - 6dc68e98-9b4d-49d6-8ed4-ff32b4e9cda5
     status: 200 OK
     code: 200
     duration: ""
@@ -2798,12 +2720,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/cc4b8e6a-1ad3-438d-a18f-2466d6983e4a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/e6d7e868-2379-4cff-bc4f-24cb41835456
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:10.147070+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:07:33.569882+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2812,9 +2734,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:18 GMT
+      - Wed, 21 Feb 2024 14:07:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2822,7 +2744,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e224af5e-5108-473f-8a6b-d936dbb70ff2
+      - 5e509305-d175-40f4-9b6f-5483d8906ce8
     status: 200 OK
     code: 200
     duration: ""
@@ -2831,12 +2753,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/cc4b8e6a-1ad3-438d-a18f-2466d6983e4a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/e6d7e868-2379-4cff-bc4f-24cb41835456
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:10.147070+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:07:33.569882+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2845,9 +2767,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:23 GMT
+      - Wed, 21 Feb 2024 14:07:48 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2855,7 +2777,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75bd054d-6335-49bb-be6a-1a7f6376b296
+      - faa3f85d-4bbf-4f3a-a1b6-80186b784855
     status: 200 OK
     code: 200
     duration: ""
@@ -2864,12 +2786,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/cc4b8e6a-1ad3-438d-a18f-2466d6983e4a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/e6d7e868-2379-4cff-bc4f-24cb41835456
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:10.147070+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:07:33.569882+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2878,9 +2800,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:28 GMT
+      - Wed, 21 Feb 2024 14:07:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2888,7 +2810,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2738b49-b476-4e0c-8e18-82e7c82a2125
+      - 6566b698-e1b2-45d4-9960-5188f8d3844c
     status: 200 OK
     code: 200
     duration: ""
@@ -2897,12 +2819,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/cc4b8e6a-1ad3-438d-a18f-2466d6983e4a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/e6d7e868-2379-4cff-bc4f-24cb41835456
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:10.147070+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:07:33.569882+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2911,9 +2833,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:33 GMT
+      - Wed, 21 Feb 2024 14:07:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2921,7 +2843,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eafd58a5-c080-477d-b251-0168e047cbd6
+      - 11f4c05d-5de6-487e-a816-66ed648f1c49
     status: 200 OK
     code: 200
     duration: ""
@@ -2930,12 +2852,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/cc4b8e6a-1ad3-438d-a18f-2466d6983e4a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/e6d7e868-2379-4cff-bc4f-24cb41835456
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:10.147070+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:07:33.569882+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -2944,9 +2866,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:38 GMT
+      - Wed, 21 Feb 2024 14:08:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2954,7 +2876,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1421018f-eb38-4a6f-924a-66a404fab271
+      - acedc358-1b35-4447-aff1-bbd398071949
     status: 200 OK
     code: 200
     duration: ""
@@ -2963,12 +2885,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/cc4b8e6a-1ad3-438d-a18f-2466d6983e4a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/e6d7e868-2379-4cff-bc4f-24cb41835456
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:38.478525+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:08:03.971863+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -2977,9 +2899,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:43 GMT
+      - Wed, 21 Feb 2024 14:08:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2987,7 +2909,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40d1a8cc-d6ac-4d8c-9024-7a467c1adaf6
+      - 287f3726-0e3c-4bc5-8dbe-da982d0b35ec
     status: 200 OK
     code: 200
     duration: ""
@@ -2996,12 +2918,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/cc4b8e6a-1ad3-438d-a18f-2466d6983e4a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/e6d7e868-2379-4cff-bc4f-24cb41835456
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:38.478525+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:08:03.971863+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -3010,9 +2932,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:43 GMT
+      - Wed, 21 Feb 2024 14:08:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3020,7 +2942,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50ebd580-4a35-4ca7-bc8d-70b334aed2d6
+      - dc10d05d-8dd1-443e-8adb-9687256dce58
     status: 200 OK
     code: 200
     duration: ""
@@ -3029,29 +2951,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:38.478525+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:08:03.971863+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3167"
+      - "3197"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:43 GMT
+      - Wed, 21 Feb 2024 14:08:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3059,7 +2981,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d126ab2-e931-40d6-b297-7fbbfff4a11a
+      - 3f0a6077-f7e0-4930-9e37-2596aca3dc6b
     status: 200 OK
     code: 200
     duration: ""
@@ -3068,9 +2990,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -3082,9 +3004,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:43 GMT
+      - Wed, 21 Feb 2024 14:08:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3092,7 +3014,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e2147bf-57ba-40fa-8fd4-18ae63b955c1
+      - 36d839f2-6440-4e72-b47b-9b7098df09bb
     status: 200 OK
     code: 200
     duration: ""
@@ -3101,12 +3023,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:38.478525+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:08:03.971863+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3115,12 +3037,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:43 GMT
+      - Wed, 21 Feb 2024 14:08:09 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3128,7 +3050,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 028deb21-2789-4744-a11e-5acb6e97b054
+      - 7c3eff5e-7b08-40af-82ef-8ccf7a7b446e
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3139,12 +3061,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:38.478525+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:08:03.971863+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3153,12 +3075,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:44 GMT
+      - Wed, 21 Feb 2024 14:08:09 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3166,7 +3088,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b79d34e-2798-4b6a-bf8a-d6deae168eed
+      - 1f68a50f-909c-4fc1-a1ab-40df2c9b60f4
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3177,12 +3099,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/161831c6-4081-4f6b-940c-6f059525f368
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2198d72d-9049-4382-8f70-57206fc6e529
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:47:49.166464Z","dhcp_enabled":true,"id":"161831c6-4081-4f6b-940c-6f059525f368","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:47:49.166464Z","id":"bd0e7733-5c20-45d4-8ddc-a28aea069d30","subnet":"172.16.68.0/22","updated_at":"2023-10-27T07:47:49.166464Z"},{"created_at":"2023-10-27T07:47:49.166464Z","id":"eb3af6ea-438f-4108-befb-90b1eb8a0ab7","subnet":"fd46:78ab:30b8:4672::/64","updated_at":"2023-10-27T07:47:49.166464Z"}],"tags":[],"updated_at":"2023-10-27T07:47:49.166464Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:07:07.302001Z","dhcp_enabled":true,"id":"2198d72d-9049-4382-8f70-57206fc6e529","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:07:07.302001Z","id":"c0868a98-2e30-4a6f-b971-381523d1c714","subnet":"172.16.44.0/22","updated_at":"2024-02-21T14:07:07.302001Z"},{"created_at":"2024-02-21T14:07:07.302001Z","id":"11028c1c-55a3-479a-9b49-91fc218420b5","subnet":"fd5f:519c:6d46:8ca9::/64","updated_at":"2024-02-21T14:07:07.302001Z"}],"tags":[],"updated_at":"2024-02-21T14:07:07.302001Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -3191,9 +3113,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:44 GMT
+      - Wed, 21 Feb 2024 14:08:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3201,7 +3123,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4d84e88-9a68-465a-94a6-2c545c3a99d0
+      - 063c29ad-c0b8-4b74-a0a5-148479388f71
     status: 200 OK
     code: 200
     duration: ""
@@ -3210,29 +3132,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:38.478525+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:08:03.971863+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3167"
+      - "3197"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:44 GMT
+      - Wed, 21 Feb 2024 14:08:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3240,7 +3162,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0305f8b7-8170-4886-981a-21baa27c460e
+      - fd277bb4-6690-464c-aefd-e20a90b61086
     status: 200 OK
     code: 200
     duration: ""
@@ -3249,9 +3171,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -3263,9 +3185,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:44 GMT
+      - Wed, 21 Feb 2024 14:08:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3273,7 +3195,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6230842-4d7d-4129-849a-9cfb0ce0a868
+      - 99fc352d-f261-4a1d-8ca0-272e9ab451ce
     status: 200 OK
     code: 200
     duration: ""
@@ -3282,12 +3204,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:38.478525+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:08:03.971863+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3296,12 +3218,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:45 GMT
+      - Wed, 21 Feb 2024 14:08:10 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3309,7 +3231,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb0c7364-7dff-4260-9355-f09100fac17f
+      - 8d51201b-1b96-4967-8aa2-49b39e5cd022
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3320,12 +3242,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/161831c6-4081-4f6b-940c-6f059525f368
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2198d72d-9049-4382-8f70-57206fc6e529
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:47:49.166464Z","dhcp_enabled":true,"id":"161831c6-4081-4f6b-940c-6f059525f368","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:47:49.166464Z","id":"bd0e7733-5c20-45d4-8ddc-a28aea069d30","subnet":"172.16.68.0/22","updated_at":"2023-10-27T07:47:49.166464Z"},{"created_at":"2023-10-27T07:47:49.166464Z","id":"eb3af6ea-438f-4108-befb-90b1eb8a0ab7","subnet":"fd46:78ab:30b8:4672::/64","updated_at":"2023-10-27T07:47:49.166464Z"}],"tags":[],"updated_at":"2023-10-27T07:47:49.166464Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:07:07.302001Z","dhcp_enabled":true,"id":"2198d72d-9049-4382-8f70-57206fc6e529","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:07:07.302001Z","id":"c0868a98-2e30-4a6f-b971-381523d1c714","subnet":"172.16.44.0/22","updated_at":"2024-02-21T14:07:07.302001Z"},{"created_at":"2024-02-21T14:07:07.302001Z","id":"11028c1c-55a3-479a-9b49-91fc218420b5","subnet":"fd5f:519c:6d46:8ca9::/64","updated_at":"2024-02-21T14:07:07.302001Z"}],"tags":[],"updated_at":"2024-02-21T14:07:07.302001Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -3334,9 +3256,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:45 GMT
+      - Wed, 21 Feb 2024 14:08:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3344,7 +3266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05226dfc-7895-4da9-9444-774031372205
+      - cb8fe8b5-3eb2-4168-a0fb-a078dca4f9b1
     status: 200 OK
     code: 200
     duration: ""
@@ -3353,29 +3275,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:38.478525+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:08:03.971863+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3167"
+      - "3197"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:45 GMT
+      - Wed, 21 Feb 2024 14:08:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3383,7 +3305,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 818eb928-4417-4a6a-ba12-5b8ef81f03a1
+      - 1ec0683c-8403-45b7-bc43-52d400e3e9d0
     status: 200 OK
     code: 200
     duration: ""
@@ -3392,9 +3314,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -3406,9 +3328,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:45 GMT
+      - Wed, 21 Feb 2024 14:08:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3416,7 +3338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2c27066-963c-4d40-94f3-bba25c84c75c
+      - c3bb9619-e1e9-46b0-856b-d8f84f46a069
     status: 200 OK
     code: 200
     duration: ""
@@ -3425,12 +3347,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:38.478525+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:08:03.971863+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3439,12 +3361,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:45 GMT
+      - Wed, 21 Feb 2024 14:08:11 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3452,36 +3374,36 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09d638ec-a2c8-4aeb-9790-a1ef568cf35f
+      - 5a4af36f-aed1-48b6-9fc2-ae8f5cb3bd13
       X-Total-Count:
       - "1"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"private_network_instance_02","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"name":"private_network_instance_02","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-27T07:48:46.207442Z","dhcp_enabled":true,"id":"040bfff2-f699-4d80-a039-76b58a209bac","name":"private_network_instance_02","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:48:46.207442Z","id":"785affe7-5a45-4707-9985-6f7a258fc428","subnet":"172.16.60.0/22","updated_at":"2023-10-27T07:48:46.207442Z"},{"created_at":"2023-10-27T07:48:46.207442Z","id":"6429a1b4-3860-4dc6-ada2-f58cc135077c","subnet":"fd46:78ab:30b8:f991::/64","updated_at":"2023-10-27T07:48:46.207442Z"}],"tags":[],"updated_at":"2023-10-27T07:48:46.207442Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:08:11.895318Z","dhcp_enabled":true,"id":"515caa98-3a8f-4246-a5d0-085251445b23","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:08:11.895318Z","id":"53071bab-15dd-4265-a127-c114ee9f7a82","subnet":"172.16.4.0/22","updated_at":"2024-02-21T14:08:11.895318Z"},{"created_at":"2024-02-21T14:08:11.895318Z","id":"12bc663d-1728-4782-9b39-94270e7e163f","subnet":"fd5f:519c:6d46:792a::/64","updated_at":"2024-02-21T14:08:11.895318Z"}],"tags":[],"updated_at":"2024-02-21T14:08:11.895318Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "728"
+      - "727"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:46 GMT
+      - Wed, 21 Feb 2024 14:08:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3489,7 +3411,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae90e262-b8c9-4624-831d-c60b0a15b890
+      - 5dfc53bd-23a0-49d7-8528-dbfca248cdce
     status: 200 OK
     code: 200
     duration: ""
@@ -3498,23 +3420,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/040bfff2-f699-4d80-a039-76b58a209bac
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/515caa98-3a8f-4246-a5d0-085251445b23
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:48:46.207442Z","dhcp_enabled":true,"id":"040bfff2-f699-4d80-a039-76b58a209bac","name":"private_network_instance_02","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:48:46.207442Z","id":"785affe7-5a45-4707-9985-6f7a258fc428","subnet":"172.16.60.0/22","updated_at":"2023-10-27T07:48:46.207442Z"},{"created_at":"2023-10-27T07:48:46.207442Z","id":"6429a1b4-3860-4dc6-ada2-f58cc135077c","subnet":"fd46:78ab:30b8:f991::/64","updated_at":"2023-10-27T07:48:46.207442Z"}],"tags":[],"updated_at":"2023-10-27T07:48:46.207442Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:08:11.895318Z","dhcp_enabled":true,"id":"515caa98-3a8f-4246-a5d0-085251445b23","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:08:11.895318Z","id":"53071bab-15dd-4265-a127-c114ee9f7a82","subnet":"172.16.4.0/22","updated_at":"2024-02-21T14:08:11.895318Z"},{"created_at":"2024-02-21T14:08:11.895318Z","id":"12bc663d-1728-4782-9b39-94270e7e163f","subnet":"fd5f:519c:6d46:792a::/64","updated_at":"2024-02-21T14:08:11.895318Z"}],"tags":[],"updated_at":"2024-02-21T14:08:11.895318Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "728"
+      - "727"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:46 GMT
+      - Wed, 21 Feb 2024 14:08:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3522,7 +3444,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00653280-ab23-4cfb-882e-5ca687c72a31
+      - 5a983330-3a55-4214-be93-95ca38815eea
     status: 200 OK
     code: 200
     duration: ""
@@ -3531,29 +3453,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:38.478525+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:08:03.971863+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3167"
+      - "3197"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:47 GMT
+      - Wed, 21 Feb 2024 14:08:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3561,7 +3483,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b671c1f3-246c-4b53-86d8-793254590a3a
+      - 19c13266-186e-4d14-9c28-6fc9c6b98ae3
     status: 200 OK
     code: 200
     duration: ""
@@ -3570,12 +3492,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:38.478525+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:08:03.971863+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3584,12 +3506,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:47 GMT
+      - Wed, 21 Feb 2024 14:08:14 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3597,7 +3519,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79b1518d-5a90-4e0d-a400-12caaa1426b9
+      - 71c2c335-13ed-492b-afc9-2b49f5042079
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3608,29 +3530,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:38.478525+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:08:03.971863+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3167"
+      - "3197"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:47 GMT
+      - Wed, 21 Feb 2024 14:08:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3638,7 +3560,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b0a81651-6472-46fb-bf73-57352581aa2f
+      - 4bcf1d57-53de-45a4-ac80-1bb15e7f0f8e
     status: 200 OK
     code: 200
     duration: ""
@@ -3647,12 +3569,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/cc4b8e6a-1ad3-438d-a18f-2466d6983e4a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/e6d7e868-2379-4cff-bc4f-24cb41835456
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:07.195269+00:00","id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","mac_address":"02:00:00:14:73:c1","modification_date":"2023-10-27T07:48:38.478525+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:07:32.539113+00:00","id":"e6d7e868-2379-4cff-bc4f-24cb41835456","mac_address":"02:00:00:18:88:87","modification_date":"2024-02-21T14:08:03.971863+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -3661,9 +3583,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:48 GMT
+      - Wed, 21 Feb 2024 14:08:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3671,7 +3593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2cd37970-e97c-4ed1-bb28-c37d7e0af90f
+      - 394b8d64-d99f-44dd-bb29-e1e9256c0858
     status: 200 OK
     code: 200
     duration: ""
@@ -3680,9 +3602,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/cc4b8e6a-1ad3-438d-a18f-2466d6983e4a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/e6d7e868-2379-4cff-bc4f-24cb41835456
     method: DELETE
   response:
     body: ""
@@ -3690,9 +3612,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 27 Oct 2023 07:48:48 GMT
+      - Wed, 21 Feb 2024 14:08:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3700,7 +3622,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 085e56e6-9f2d-4c8a-89bc-93f6c671e64b
+      - 18f72874-1787-437e-a364-78dea5825e02
     status: 204 No Content
     code: 204
     duration: ""
@@ -3709,12 +3631,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/cc4b8e6a-1ad3-438d-a18f-2466d6983e4a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/e6d7e868-2379-4cff-bc4f-24cb41835456
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"cc4b8e6a-1ad3-438d-a18f-2466d6983e4a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"e6d7e868-2379-4cff-bc4f-24cb41835456","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -3723,9 +3645,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:48 GMT
+      - Wed, 21 Feb 2024 14:08:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3733,23 +3655,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b91beef-dd80-4439-8cdb-97f4cfc4e454
+      - 47a8f60e-7718-402d-b2e1-491ddeba6db8
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac"}'
+    body: '{"private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:48.770285+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:15.626821+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -3758,9 +3680,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:49 GMT
+      - Wed, 21 Feb 2024 14:08:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3768,7 +3690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8405074b-de14-473e-9f09-73266cd21a02
+      - ce16eb5a-b232-4122-9558-a937e6cd1456
     status: 201 Created
     code: 201
     duration: ""
@@ -3777,12 +3699,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/47b1fe3a-498e-40b4-b065-7df3f53c8aab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/68ce4593-dc7f-49fe-b670-2167088b6ba7
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:48.770285+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:16.674820+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -3791,9 +3713,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:49 GMT
+      - Wed, 21 Feb 2024 14:08:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3801,7 +3723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0411bc79-b736-457a-aa4b-04290b7f51ab
+      - 00614941-1889-42f1-aa04-a49b9a89db4a
     status: 200 OK
     code: 200
     duration: ""
@@ -3810,23 +3732,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/47b1fe3a-498e-40b4-b065-7df3f53c8aab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/68ce4593-dc7f-49fe-b670-2167088b6ba7
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:49.955735+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing_error","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "382"
+      - "378"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:54 GMT
+      - Wed, 21 Feb 2024 14:08:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3834,7 +3756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12176d2e-613f-4640-9519-b8c0ce2f1626
+      - 11cdf403-6aff-4102-8d06-f20e70247c61
     status: 200 OK
     code: 200
     duration: ""
@@ -3843,23 +3765,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/47b1fe3a-498e-40b4-b065-7df3f53c8aab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/68ce4593-dc7f-49fe-b670-2167088b6ba7
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:49.955735+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing_error","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "382"
+      - "378"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:54 GMT
+      - Wed, 21 Feb 2024 14:08:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3867,48 +3789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f8ea09f4-7c6b-4b5a-a5d8-9206047cf3f6
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
-    method: PATCH
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:49.955735+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing_error","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3171"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:48:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - eef513d6-e096-491b-b704-922dfcb87992
+      - 68c9a2a7-8050-4888-94be-3bef361243c8
     status: 200 OK
     code: 200
     duration: ""
@@ -3917,29 +3798,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:49.955735+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing_error","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3171"
+      - "3197"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:55 GMT
+      - Wed, 21 Feb 2024 14:08:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3947,7 +3828,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 307c08ee-e504-4526-b22b-32ebe25fed27
+      - c6c8766c-b12f-43ec-af3d-37c990c921c9
     status: 200 OK
     code: 200
     duration: ""
@@ -3956,29 +3837,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:49.955735+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing_error","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3171"
+      - "3197"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:55 GMT
+      - Wed, 21 Feb 2024 14:08:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3986,7 +3867,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8e7d6cf-c6df-44e1-bf07-dabfbc58fbfe
+      - 6aa3293b-8f15-4d4c-8581-a238014f5975
     status: 200 OK
     code: 200
     duration: ""
@@ -3995,9 +3876,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -4009,9 +3890,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:55 GMT
+      - Wed, 21 Feb 2024 14:08:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4019,7 +3900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00837bf6-bcb3-4e15-bbbe-6aacd634f72e
+      - cacf28ac-df81-45c6-93f4-d759c747e8e8
     status: 200 OK
     code: 200
     duration: ""
@@ -4028,26 +3909,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:49.955735+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing_error","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
-      - "385"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:55 GMT
+      - Wed, 21 Feb 2024 14:08:22 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4055,7 +3936,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5c799af-a36d-4638-ba26-9f4fa3edd7da
+      - a709afe3-0da4-4d65-9a3f-6d6b03cf4545
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -4066,26 +3947,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:49.955735+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing_error","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
-      - "385"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:55 GMT
+      - Wed, 21 Feb 2024 14:08:22 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4093,7 +3974,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7faa1984-e563-4583-b402-998589d77b04
+      - c109eba5-f195-45e2-97a2-f068188a6e86
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -4104,12 +3985,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/161831c6-4081-4f6b-940c-6f059525f368
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2198d72d-9049-4382-8f70-57206fc6e529
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:47:49.166464Z","dhcp_enabled":true,"id":"161831c6-4081-4f6b-940c-6f059525f368","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:47:49.166464Z","id":"bd0e7733-5c20-45d4-8ddc-a28aea069d30","subnet":"172.16.68.0/22","updated_at":"2023-10-27T07:47:49.166464Z"},{"created_at":"2023-10-27T07:47:49.166464Z","id":"eb3af6ea-438f-4108-befb-90b1eb8a0ab7","subnet":"fd46:78ab:30b8:4672::/64","updated_at":"2023-10-27T07:47:49.166464Z"}],"tags":[],"updated_at":"2023-10-27T07:47:49.166464Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:07:07.302001Z","dhcp_enabled":true,"id":"2198d72d-9049-4382-8f70-57206fc6e529","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:07:07.302001Z","id":"c0868a98-2e30-4a6f-b971-381523d1c714","subnet":"172.16.44.0/22","updated_at":"2024-02-21T14:07:07.302001Z"},{"created_at":"2024-02-21T14:07:07.302001Z","id":"11028c1c-55a3-479a-9b49-91fc218420b5","subnet":"fd5f:519c:6d46:8ca9::/64","updated_at":"2024-02-21T14:07:07.302001Z"}],"tags":[],"updated_at":"2024-02-21T14:07:07.302001Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -4118,9 +3999,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:56 GMT
+      - Wed, 21 Feb 2024 14:08:23 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4128,7 +4009,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15f92a15-03b4-4e24-9214-77dabc19fe0b
+      - d05b8eb0-af2a-4535-8b6d-33467203605e
     status: 200 OK
     code: 200
     duration: ""
@@ -4137,23 +4018,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/040bfff2-f699-4d80-a039-76b58a209bac
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/515caa98-3a8f-4246-a5d0-085251445b23
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:48:46.207442Z","dhcp_enabled":true,"id":"040bfff2-f699-4d80-a039-76b58a209bac","name":"private_network_instance_02","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:48:46.207442Z","id":"785affe7-5a45-4707-9985-6f7a258fc428","subnet":"172.16.60.0/22","updated_at":"2023-10-27T07:48:46.207442Z"},{"created_at":"2023-10-27T07:48:46.207442Z","id":"6429a1b4-3860-4dc6-ada2-f58cc135077c","subnet":"fd46:78ab:30b8:f991::/64","updated_at":"2023-10-27T07:48:46.207442Z"}],"tags":[],"updated_at":"2023-10-27T07:48:46.207442Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:08:11.895318Z","dhcp_enabled":true,"id":"515caa98-3a8f-4246-a5d0-085251445b23","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:08:11.895318Z","id":"53071bab-15dd-4265-a127-c114ee9f7a82","subnet":"172.16.4.0/22","updated_at":"2024-02-21T14:08:11.895318Z"},{"created_at":"2024-02-21T14:08:11.895318Z","id":"12bc663d-1728-4782-9b39-94270e7e163f","subnet":"fd5f:519c:6d46:792a::/64","updated_at":"2024-02-21T14:08:11.895318Z"}],"tags":[],"updated_at":"2024-02-21T14:08:11.895318Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "728"
+      - "727"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:56 GMT
+      - Wed, 21 Feb 2024 14:08:23 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4161,7 +4042,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b3e23187-fb7c-4c2b-8b0a-853fba94a22a
+      - 45867074-0b85-49a5-8bc1-45de20d0d442
     status: 200 OK
     code: 200
     duration: ""
@@ -4170,29 +4051,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:49.955735+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing_error","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3171"
+      - "3197"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:56 GMT
+      - Wed, 21 Feb 2024 14:08:23 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4200,7 +4081,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc06fddb-f770-4eeb-a64a-b4088b7a65d8
+      - 85e0f4c4-45aa-4c40-8f1b-47df91c62012
     status: 200 OK
     code: 200
     duration: ""
@@ -4209,9 +4090,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -4223,9 +4104,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:56 GMT
+      - Wed, 21 Feb 2024 14:08:23 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4233,7 +4114,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93e55f2d-6b81-4cb6-87b1-158d86cb4d6c
+      - 6460d4ae-1e25-46bc-af2d-f5eefbef2167
     status: 200 OK
     code: 200
     duration: ""
@@ -4242,26 +4123,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:49.955735+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing_error","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
-      - "385"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:56 GMT
+      - Wed, 21 Feb 2024 14:08:23 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4269,7 +4150,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 965c2a99-b532-4182-9aa1-20607c09f6c2
+      - 2531cb66-0a24-430f-a888-1c388cc9f01b
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -4280,12 +4161,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/161831c6-4081-4f6b-940c-6f059525f368
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2198d72d-9049-4382-8f70-57206fc6e529
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:47:49.166464Z","dhcp_enabled":true,"id":"161831c6-4081-4f6b-940c-6f059525f368","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:47:49.166464Z","id":"bd0e7733-5c20-45d4-8ddc-a28aea069d30","subnet":"172.16.68.0/22","updated_at":"2023-10-27T07:47:49.166464Z"},{"created_at":"2023-10-27T07:47:49.166464Z","id":"eb3af6ea-438f-4108-befb-90b1eb8a0ab7","subnet":"fd46:78ab:30b8:4672::/64","updated_at":"2023-10-27T07:47:49.166464Z"}],"tags":[],"updated_at":"2023-10-27T07:47:49.166464Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:07:07.302001Z","dhcp_enabled":true,"id":"2198d72d-9049-4382-8f70-57206fc6e529","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:07:07.302001Z","id":"c0868a98-2e30-4a6f-b971-381523d1c714","subnet":"172.16.44.0/22","updated_at":"2024-02-21T14:07:07.302001Z"},{"created_at":"2024-02-21T14:07:07.302001Z","id":"11028c1c-55a3-479a-9b49-91fc218420b5","subnet":"fd5f:519c:6d46:8ca9::/64","updated_at":"2024-02-21T14:07:07.302001Z"}],"tags":[],"updated_at":"2024-02-21T14:07:07.302001Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -4294,9 +4175,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:56 GMT
+      - Wed, 21 Feb 2024 14:08:24 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4304,7 +4185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b42ff04-c8d4-426e-8203-b431d736aaff
+      - 4fa79929-8c57-413e-9ed3-5d80ad85fcde
     status: 200 OK
     code: 200
     duration: ""
@@ -4313,23 +4194,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/040bfff2-f699-4d80-a039-76b58a209bac
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/515caa98-3a8f-4246-a5d0-085251445b23
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:48:46.207442Z","dhcp_enabled":true,"id":"040bfff2-f699-4d80-a039-76b58a209bac","name":"private_network_instance_02","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:48:46.207442Z","id":"785affe7-5a45-4707-9985-6f7a258fc428","subnet":"172.16.60.0/22","updated_at":"2023-10-27T07:48:46.207442Z"},{"created_at":"2023-10-27T07:48:46.207442Z","id":"6429a1b4-3860-4dc6-ada2-f58cc135077c","subnet":"fd46:78ab:30b8:f991::/64","updated_at":"2023-10-27T07:48:46.207442Z"}],"tags":[],"updated_at":"2023-10-27T07:48:46.207442Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:08:11.895318Z","dhcp_enabled":true,"id":"515caa98-3a8f-4246-a5d0-085251445b23","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:08:11.895318Z","id":"53071bab-15dd-4265-a127-c114ee9f7a82","subnet":"172.16.4.0/22","updated_at":"2024-02-21T14:08:11.895318Z"},{"created_at":"2024-02-21T14:08:11.895318Z","id":"12bc663d-1728-4782-9b39-94270e7e163f","subnet":"fd5f:519c:6d46:792a::/64","updated_at":"2024-02-21T14:08:11.895318Z"}],"tags":[],"updated_at":"2024-02-21T14:08:11.895318Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "728"
+      - "727"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:56 GMT
+      - Wed, 21 Feb 2024 14:08:24 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4337,7 +4218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29193047-0caf-41ca-96e0-0c3e8c80253c
+      - 4f682f1d-24d5-4187-9f07-581ea9a7c6c8
     status: 200 OK
     code: 200
     duration: ""
@@ -4346,29 +4227,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:49.955735+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing_error","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3171"
+      - "3197"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:57 GMT
+      - Wed, 21 Feb 2024 14:08:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4376,7 +4257,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c17ca85c-3302-4e5c-9ca4-381d97a8016d
+      - 1a1e8925-9f67-4138-a7b5-323efa505b6e
     status: 200 OK
     code: 200
     duration: ""
@@ -4385,9 +4266,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -4399,9 +4280,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:57 GMT
+      - Wed, 21 Feb 2024 14:08:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4409,7 +4290,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdaf6ccc-3b75-4856-88f8-6ee662218d87
+      - f0f072c4-56fb-4514-9140-883a2724f5d5
     status: 200 OK
     code: 200
     duration: ""
@@ -4418,26 +4299,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:49.955735+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing_error","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
-      - "385"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:57 GMT
+      - Wed, 21 Feb 2024 14:08:25 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4445,7 +4326,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 566742ac-fc9c-4c58-86b4-f71dfe8a8300
+      - 107cad61-20b4-411b-b0c8-63826cd49cac
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -4456,29 +4337,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:49.955735+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing_error","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3171"
+      - "3197"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:57 GMT
+      - Wed, 21 Feb 2024 14:08:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4486,7 +4367,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8351d77d-0b6c-4c69-8241-ac6bb14503c8
+      - 9716df63-24fd-4076-bea5-c597e37d89ef
     status: 200 OK
     code: 200
     duration: ""
@@ -4495,26 +4376,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:49.955735+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing_error","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
-      - "385"
+      - "381"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:57 GMT
+      - Wed, 21 Feb 2024 14:08:26 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4522,7 +4403,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0d7d8293-65d5-4c06-ab78-82d24a44b3b1
+      - 707b688c-f39c-49e3-8822-7ab4a20b4981
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -4533,29 +4414,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:49.955735+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing_error","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3171"
+      - "3197"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:57 GMT
+      - Wed, 21 Feb 2024 14:08:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4563,23 +4444,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82e35fec-db25-447a-aa55-7f894ccdba74
+      - 3ded05b2-29b3-452f-8c33-a13268528b85
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"161831c6-4081-4f6b-940c-6f059525f368"}'
+    body: '{"private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:48:58.016194+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:26.914244+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -4588,9 +4469,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:58 GMT
+      - Wed, 21 Feb 2024 14:08:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4598,7 +4479,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22ec2621-3969-45cb-8956-62729798b1f3
+      - 0cd21d5f-8dde-4a46-8c41-c881f7ffa609
     status: 201 Created
     code: 201
     duration: ""
@@ -4607,12 +4488,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/4c1a27e1-bd3a-4af2-8b2f-c2532f283a02
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/32cb6e8f-5a08-48cc-be3a-172c4cc1c27e
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:48:58.016194+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:26.914244+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -4621,9 +4502,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:48:58 GMT
+      - Wed, 21 Feb 2024 14:08:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4631,7 +4512,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa07825d-392b-49dc-b88e-be3fb8858ac0
+      - 03620902-1a47-4886-8452-6aaf196afdc9
     status: 200 OK
     code: 200
     duration: ""
@@ -4640,12 +4521,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/4c1a27e1-bd3a-4af2-8b2f-c2532f283a02
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/32cb6e8f-5a08-48cc-be3a-172c4cc1c27e
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -4654,9 +4535,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:03 GMT
+      - Wed, 21 Feb 2024 14:08:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4664,7 +4545,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b43128e-a3eb-49a1-80c0-a3f316ef10bf
+      - 1acc1b72-da7b-4dc4-8f17-fe4d95725c79
     status: 200 OK
     code: 200
     duration: ""
@@ -4673,12 +4554,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/4c1a27e1-bd3a-4af2-8b2f-c2532f283a02
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/32cb6e8f-5a08-48cc-be3a-172c4cc1c27e
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -4687,9 +4568,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:03 GMT
+      - Wed, 21 Feb 2024 14:08:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4697,48 +4578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae0a7a60-1005-4cf8-bc10-9f1a94f24030
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
-    method: PATCH
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:59.170835+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3530"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:49:03 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 84339b0a-57ed-44e6-b96d-1a2b1cbbf394
+      - 106fde1a-4c27-4e79-8e28-77f2693f4627
     status: 200 OK
     code: 200
     duration: ""
@@ -4747,29 +4587,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:59.170835+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3530"
+      - "3560"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:04 GMT
+      - Wed, 21 Feb 2024 14:08:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4777,7 +4617,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1bf99581-1c6c-455a-8ea0-78437b6c29a4
+      - fb839472-318a-43ad-ac45-36be5f992e2b
     status: 200 OK
     code: 200
     duration: ""
@@ -4786,29 +4626,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:59.170835+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3530"
+      - "3560"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:04 GMT
+      - Wed, 21 Feb 2024 14:08:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4816,7 +4656,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdd9e65a-b3ce-4b7b-97bd-8a18b874f78e
+      - d5ec8efb-98a9-45a4-87ca-cf971db2b4ea
     status: 200 OK
     code: 200
     duration: ""
@@ -4825,9 +4665,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -4839,9 +4679,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:04 GMT
+      - Wed, 21 Feb 2024 14:08:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4849,7 +4689,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6011bed4-ddcd-4605-ae9d-1d54ab4f3fcd
+      - 98b73663-39b9-42ce-a9da-70f1c9c954a0
     status: 200 OK
     code: 200
     duration: ""
@@ -4858,12 +4698,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:59.170835+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "744"
@@ -4872,12 +4712,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:04 GMT
+      - Wed, 21 Feb 2024 14:08:33 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4885,7 +4725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1fc03abd-f917-41ed-b7ad-5695f79b73af
+      - 5b981671-6428-4916-98f1-87e0c0949ad4
       X-Total-Count:
       - "2"
     status: 200 OK
@@ -4896,12 +4736,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:59.170835+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "744"
@@ -4910,12 +4750,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:04 GMT
+      - Wed, 21 Feb 2024 14:08:33 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4923,7 +4763,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d90a197f-32a2-4dd5-8d7d-80496413ef12
+      - f6777781-b3e9-4bcb-a2df-a15c91f72095
       X-Total-Count:
       - "2"
     status: 200 OK
@@ -4934,45 +4774,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/040bfff2-f699-4d80-a039-76b58a209bac
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2198d72d-9049-4382-8f70-57206fc6e529
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:48:46.207442Z","dhcp_enabled":true,"id":"040bfff2-f699-4d80-a039-76b58a209bac","name":"private_network_instance_02","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:48:46.207442Z","id":"785affe7-5a45-4707-9985-6f7a258fc428","subnet":"172.16.60.0/22","updated_at":"2023-10-27T07:48:46.207442Z"},{"created_at":"2023-10-27T07:48:46.207442Z","id":"6429a1b4-3860-4dc6-ada2-f58cc135077c","subnet":"fd46:78ab:30b8:f991::/64","updated_at":"2023-10-27T07:48:46.207442Z"}],"tags":[],"updated_at":"2023-10-27T07:48:46.207442Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
-    headers:
-      Content-Length:
-      - "728"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:49:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2b737a6f-81dd-42fd-93d8-3025e80059e9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/161831c6-4081-4f6b-940c-6f059525f368
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-27T07:47:49.166464Z","dhcp_enabled":true,"id":"161831c6-4081-4f6b-940c-6f059525f368","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:47:49.166464Z","id":"bd0e7733-5c20-45d4-8ddc-a28aea069d30","subnet":"172.16.68.0/22","updated_at":"2023-10-27T07:47:49.166464Z"},{"created_at":"2023-10-27T07:47:49.166464Z","id":"eb3af6ea-438f-4108-befb-90b1eb8a0ab7","subnet":"fd46:78ab:30b8:4672::/64","updated_at":"2023-10-27T07:47:49.166464Z"}],"tags":[],"updated_at":"2023-10-27T07:47:49.166464Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:07:07.302001Z","dhcp_enabled":true,"id":"2198d72d-9049-4382-8f70-57206fc6e529","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:07:07.302001Z","id":"c0868a98-2e30-4a6f-b971-381523d1c714","subnet":"172.16.44.0/22","updated_at":"2024-02-21T14:07:07.302001Z"},{"created_at":"2024-02-21T14:07:07.302001Z","id":"11028c1c-55a3-479a-9b49-91fc218420b5","subnet":"fd5f:519c:6d46:8ca9::/64","updated_at":"2024-02-21T14:07:07.302001Z"}],"tags":[],"updated_at":"2024-02-21T14:07:07.302001Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -4981,9 +4788,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:05 GMT
+      - Wed, 21 Feb 2024 14:08:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4991,7 +4798,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3aa1e259-2f64-490f-8d88-ff342e0f984f
+      - f4bee81e-9bb8-4901-9252-e0c879cd97e6
     status: 200 OK
     code: 200
     duration: ""
@@ -5000,29 +4807,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/515caa98-3a8f-4246-a5d0-085251445b23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:59.170835+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"created_at":"2024-02-21T14:08:11.895318Z","dhcp_enabled":true,"id":"515caa98-3a8f-4246-a5d0-085251445b23","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:08:11.895318Z","id":"53071bab-15dd-4265-a127-c114ee9f7a82","subnet":"172.16.4.0/22","updated_at":"2024-02-21T14:08:11.895318Z"},{"created_at":"2024-02-21T14:08:11.895318Z","id":"12bc663d-1728-4782-9b39-94270e7e163f","subnet":"fd5f:519c:6d46:792a::/64","updated_at":"2024-02-21T14:08:11.895318Z"}],"tags":[],"updated_at":"2024-02-21T14:08:11.895318Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "3530"
+      - "727"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:05 GMT
+      - Wed, 21 Feb 2024 14:08:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5030,7 +4831,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a20633c-9e4d-4bfd-bbbc-98d2bef0bd19
+      - 4ac640bb-1dcd-460e-8ff8-16c593c4991a
     status: 200 OK
     code: 200
     duration: ""
@@ -5039,9 +4840,48 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3560"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:08:34 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6154f7ef-e981-48a0-823c-1250cad53319
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -5053,9 +4893,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:05 GMT
+      - Wed, 21 Feb 2024 14:08:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5063,7 +4903,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59709a25-020e-47de-9fa1-b9a37e25daf3
+      - 03365a30-10ae-4c3e-8176-6db2a261613a
     status: 200 OK
     code: 200
     duration: ""
@@ -5072,12 +4912,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:59.170835+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "744"
@@ -5086,12 +4926,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:05 GMT
+      - Wed, 21 Feb 2024 14:08:34 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5099,7 +4939,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77a7d8f4-333b-4c01-84a6-dee2026b988e
+      - 23872e60-148c-48da-b2d1-d4143deabf31
       X-Total-Count:
       - "2"
     status: 200 OK
@@ -5110,23 +4950,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/040bfff2-f699-4d80-a039-76b58a209bac
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/515caa98-3a8f-4246-a5d0-085251445b23
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:48:46.207442Z","dhcp_enabled":true,"id":"040bfff2-f699-4d80-a039-76b58a209bac","name":"private_network_instance_02","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:48:46.207442Z","id":"785affe7-5a45-4707-9985-6f7a258fc428","subnet":"172.16.60.0/22","updated_at":"2023-10-27T07:48:46.207442Z"},{"created_at":"2023-10-27T07:48:46.207442Z","id":"6429a1b4-3860-4dc6-ada2-f58cc135077c","subnet":"fd46:78ab:30b8:f991::/64","updated_at":"2023-10-27T07:48:46.207442Z"}],"tags":[],"updated_at":"2023-10-27T07:48:46.207442Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:08:11.895318Z","dhcp_enabled":true,"id":"515caa98-3a8f-4246-a5d0-085251445b23","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:08:11.895318Z","id":"53071bab-15dd-4265-a127-c114ee9f7a82","subnet":"172.16.4.0/22","updated_at":"2024-02-21T14:08:11.895318Z"},{"created_at":"2024-02-21T14:08:11.895318Z","id":"12bc663d-1728-4782-9b39-94270e7e163f","subnet":"fd5f:519c:6d46:792a::/64","updated_at":"2024-02-21T14:08:11.895318Z"}],"tags":[],"updated_at":"2024-02-21T14:08:11.895318Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "728"
+      - "727"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:05 GMT
+      - Wed, 21 Feb 2024 14:08:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5134,7 +4974,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c27ce7ce-b1fb-4d0f-99e4-d11536f63386
+      - 0813d04c-7dba-4672-97d6-8d475d4a62ae
     status: 200 OK
     code: 200
     duration: ""
@@ -5143,12 +4983,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/161831c6-4081-4f6b-940c-6f059525f368
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2198d72d-9049-4382-8f70-57206fc6e529
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:47:49.166464Z","dhcp_enabled":true,"id":"161831c6-4081-4f6b-940c-6f059525f368","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:47:49.166464Z","id":"bd0e7733-5c20-45d4-8ddc-a28aea069d30","subnet":"172.16.68.0/22","updated_at":"2023-10-27T07:47:49.166464Z"},{"created_at":"2023-10-27T07:47:49.166464Z","id":"eb3af6ea-438f-4108-befb-90b1eb8a0ab7","subnet":"fd46:78ab:30b8:4672::/64","updated_at":"2023-10-27T07:47:49.166464Z"}],"tags":[],"updated_at":"2023-10-27T07:47:49.166464Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:07:07.302001Z","dhcp_enabled":true,"id":"2198d72d-9049-4382-8f70-57206fc6e529","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:07:07.302001Z","id":"c0868a98-2e30-4a6f-b971-381523d1c714","subnet":"172.16.44.0/22","updated_at":"2024-02-21T14:07:07.302001Z"},{"created_at":"2024-02-21T14:07:07.302001Z","id":"11028c1c-55a3-479a-9b49-91fc218420b5","subnet":"fd5f:519c:6d46:8ca9::/64","updated_at":"2024-02-21T14:07:07.302001Z"}],"tags":[],"updated_at":"2024-02-21T14:07:07.302001Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -5157,9 +4997,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:05 GMT
+      - Wed, 21 Feb 2024 14:08:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5167,7 +5007,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b68f3da3-6da7-4d93-9b7d-9d1c3320c29a
+      - 210964b8-9fdf-4d22-afcc-4914b13a7cf2
     status: 200 OK
     code: 200
     duration: ""
@@ -5176,29 +5016,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:59.170835+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3530"
+      - "3560"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:05 GMT
+      - Wed, 21 Feb 2024 14:08:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5206,7 +5046,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e69e7e7a-3c60-400f-9870-3bc18be42afe
+      - d5f4c01e-5709-4f11-a22f-f54015a366c0
     status: 200 OK
     code: 200
     duration: ""
@@ -5215,9 +5055,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -5229,9 +5069,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:05 GMT
+      - Wed, 21 Feb 2024 14:08:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5239,7 +5079,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75acbd0f-3d1b-4f85-84d1-9364402303cc
+      - 52948276-1145-4880-9eac-a236f208401c
     status: 200 OK
     code: 200
     duration: ""
@@ -5248,12 +5088,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:59.170835+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "744"
@@ -5262,12 +5102,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:05 GMT
+      - Wed, 21 Feb 2024 14:08:36 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5275,7 +5115,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 545e1045-ee7b-490a-985d-884a6d74a380
+      - 9478a7ee-4eec-4641-9cc4-ccd2823f0477
       X-Total-Count:
       - "2"
     status: 200 OK
@@ -5286,29 +5126,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:59.170835+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3530"
+      - "3560"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:06 GMT
+      - Wed, 21 Feb 2024 14:08:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5316,7 +5156,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c53db8c-9a18-44ce-9f5d-aa1a73c6adda
+      - de3742d7-ab8d-4f6c-850b-158fe9a7ec7e
     status: 200 OK
     code: 200
     duration: ""
@@ -5325,12 +5165,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:59.170835+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "744"
@@ -5339,12 +5179,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:06 GMT
+      - Wed, 21 Feb 2024 14:08:39 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=1&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5352,7 +5192,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0769605a-8702-45a1-af30-a17c9df79def
+      - d9a13a28-2521-474b-a6a5-7b2921e53951
       X-Total-Count:
       - "2"
     status: 200 OK
@@ -5363,29 +5203,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:59.170835+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"},{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3530"
+      - "3560"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:06 GMT
+      - Wed, 21 Feb 2024 14:08:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5393,7 +5233,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea2ace0e-14f1-49a1-8cdd-b9b13d280965
+      - f292f56b-531c-4187-8b62-5e1e68ccd7b5
     status: 200 OK
     code: 200
     duration: ""
@@ -5402,12 +5242,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/47b1fe3a-498e-40b4-b065-7df3f53c8aab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/68ce4593-dc7f-49fe-b670-2167088b6ba7
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:48.770285+00:00","id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","mac_address":"02:00:00:14:73:c3","modification_date":"2023-10-27T07:48:59.170835+00:00","private_network_id":"040bfff2-f699-4d80-a039-76b58a209bac","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:08:15.626821+00:00","id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","mac_address":"02:00:00:18:88:8d","modification_date":"2024-02-21T14:08:17.000989+00:00","private_network_id":"515caa98-3a8f-4246-a5d0-085251445b23","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -5416,9 +5256,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:06 GMT
+      - Wed, 21 Feb 2024 14:08:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5426,7 +5266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e26baa4-fc3c-44e7-aa25-300fd87567f1
+      - c3476553-6f50-49fe-84ca-056fe8ae41b6
     status: 200 OK
     code: 200
     duration: ""
@@ -5435,9 +5275,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/47b1fe3a-498e-40b4-b065-7df3f53c8aab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/68ce4593-dc7f-49fe-b670-2167088b6ba7
     method: DELETE
   response:
     body: ""
@@ -5445,9 +5285,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 27 Oct 2023 07:49:07 GMT
+      - Wed, 21 Feb 2024 14:08:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5455,7 +5295,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e47c3537-8ccd-42af-9411-96fd79759a1d
+      - 7f6fb146-16c8-4be6-8d19-244cb5d4d37c
     status: 204 No Content
     code: 204
     duration: ""
@@ -5464,12 +5304,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/47b1fe3a-498e-40b4-b065-7df3f53c8aab
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/68ce4593-dc7f-49fe-b670-2167088b6ba7
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"47b1fe3a-498e-40b4-b065-7df3f53c8aab","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"68ce4593-dc7f-49fe-b670-2167088b6ba7","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -5478,9 +5318,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:07 GMT
+      - Wed, 21 Feb 2024 14:08:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5488,7 +5328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c8c7225-e70b-480b-9a13-b049ca924648
+      - e465efc7-31e4-416a-9b46-38d089bc291b
     status: 404 Not Found
     code: 404
     duration: ""
@@ -5497,29 +5337,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3167"
+      - "3197"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:07 GMT
+      - Wed, 21 Feb 2024 14:08:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5527,7 +5367,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca646832-d0d6-4fe4-b357-1075f62e5fd7
+      - 7916038e-5d1c-4d73-be73-f84fe9f244eb
     status: 200 OK
     code: 200
     duration: ""
@@ -5536,12 +5376,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/4c1a27e1-bd3a-4af2-8b2f-c2532f283a02
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/32cb6e8f-5a08-48cc-be3a-172c4cc1c27e
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:48:58.016194+00:00","id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","mac_address":"02:00:00:14:73:c4","modification_date":"2023-10-27T07:49:00.018178+00:00","private_network_id":"161831c6-4081-4f6b-940c-6f059525f368","server_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-21T14:08:26.914244+00:00","id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","mac_address":"02:00:00:18:88:8e","modification_date":"2024-02-21T14:08:28.002445+00:00","private_network_id":"2198d72d-9049-4382-8f70-57206fc6e529","server_id":"b098331e-a548-48af-b451-7f8062029c4c","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -5550,9 +5390,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:07 GMT
+      - Wed, 21 Feb 2024 14:08:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5560,7 +5400,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7dc993b0-2b46-4601-848f-6e96ef8bb2d1
+      - d554d8aa-2ae5-4015-8a12-3eb8616a910f
     status: 200 OK
     code: 200
     duration: ""
@@ -5569,9 +5409,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/4c1a27e1-bd3a-4af2-8b2f-c2532f283a02
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/32cb6e8f-5a08-48cc-be3a-172c4cc1c27e
     method: DELETE
   response:
     body: ""
@@ -5579,9 +5419,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 27 Oct 2023 07:49:08 GMT
+      - Wed, 21 Feb 2024 14:08:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5589,7 +5429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 301be965-bfc5-49ed-bd93-10d67ba12000
+      - f776ddb7-fb91-4465-9dfa-fe347fc849dc
     status: 204 No Content
     code: 204
     duration: ""
@@ -5598,12 +5438,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics/4c1a27e1-bd3a-4af2-8b2f-c2532f283a02
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics/32cb6e8f-5a08-48cc-be3a-172c4cc1c27e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"4c1a27e1-bd3a-4af2-8b2f-c2532f283a02","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"32cb6e8f-5a08-48cc-be3a-172c4cc1c27e","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -5612,9 +5452,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:08 GMT
+      - Wed, 21 Feb 2024 14:08:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5622,79 +5462,38 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46a646d4-2548-4eaa-82b1-b71b6443bd8f
+      - 812ed2ea-341a-48e7-be58-ed8af99d813e
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
-    method: PATCH
-  response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2806"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:49:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6194c70a-970e-415c-b86d-f1fba88d43cc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2806"
+      - "2836"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:09 GMT
+      - Wed, 21 Feb 2024 14:08:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5702,7 +5501,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e13f56c2-2025-4fbe-ba4e-b0737e5895a4
+      - 9febacbe-52fb-4605-8e55-4fc8ab0d5994
     status: 200 OK
     code: 200
     duration: ""
@@ -5711,29 +5510,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2806"
+      - "2836"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:09 GMT
+      - Wed, 21 Feb 2024 14:08:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5741,7 +5540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c3b767c-233d-4acd-b0d1-a4f77ee5d359
+      - 860f87c6-04d9-4b90-98c2-ed74b9d3bf90
     status: 200 OK
     code: 200
     duration: ""
@@ -5750,9 +5549,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -5764,9 +5563,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:09 GMT
+      - Wed, 21 Feb 2024 14:08:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5774,7 +5573,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d00475dd-9a2e-4c90-8962-7a0cc42e7ca1
+      - cc0c0b2b-6ac3-47bb-9e4f-0e2ee266a94c
     status: 200 OK
     code: 200
     duration: ""
@@ -5783,9 +5582,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -5797,12 +5596,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:09 GMT
+      - Wed, 21 Feb 2024 14:08:42 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=0&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5810,7 +5609,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e47daf78-0783-4934-b2d0-d1df6fffd6c6
+      - 0c2b0bf5-c724-4b39-a76b-f85f010188ad
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -5821,29 +5620,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2806"
+      - "2836"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:09 GMT
+      - Wed, 21 Feb 2024 14:08:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5851,7 +5650,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4dadb01f-3280-4301-b7e7-41bfc97c4c84
+      - ac4f22e8-b789-42d0-9b87-fa5973feb1ea
     status: 200 OK
     code: 200
     duration: ""
@@ -5860,45 +5659,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/040bfff2-f699-4d80-a039-76b58a209bac
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2198d72d-9049-4382-8f70-57206fc6e529
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:48:46.207442Z","dhcp_enabled":true,"id":"040bfff2-f699-4d80-a039-76b58a209bac","name":"private_network_instance_02","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:48:46.207442Z","id":"785affe7-5a45-4707-9985-6f7a258fc428","subnet":"172.16.60.0/22","updated_at":"2023-10-27T07:48:46.207442Z"},{"created_at":"2023-10-27T07:48:46.207442Z","id":"6429a1b4-3860-4dc6-ada2-f58cc135077c","subnet":"fd46:78ab:30b8:f991::/64","updated_at":"2023-10-27T07:48:46.207442Z"}],"tags":[],"updated_at":"2023-10-27T07:48:46.207442Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
-    headers:
-      Content-Length:
-      - "728"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:49:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7a0f4768-05a1-47bc-aad2-f5f76e393238
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/161831c6-4081-4f6b-940c-6f059525f368
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-27T07:47:49.166464Z","dhcp_enabled":true,"id":"161831c6-4081-4f6b-940c-6f059525f368","name":"private_network_instance","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:47:49.166464Z","id":"bd0e7733-5c20-45d4-8ddc-a28aea069d30","subnet":"172.16.68.0/22","updated_at":"2023-10-27T07:47:49.166464Z"},{"created_at":"2023-10-27T07:47:49.166464Z","id":"eb3af6ea-438f-4108-befb-90b1eb8a0ab7","subnet":"fd46:78ab:30b8:4672::/64","updated_at":"2023-10-27T07:47:49.166464Z"}],"tags":[],"updated_at":"2023-10-27T07:47:49.166464Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-21T14:07:07.302001Z","dhcp_enabled":true,"id":"2198d72d-9049-4382-8f70-57206fc6e529","name":"private_network_instance","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:07:07.302001Z","id":"c0868a98-2e30-4a6f-b971-381523d1c714","subnet":"172.16.44.0/22","updated_at":"2024-02-21T14:07:07.302001Z"},{"created_at":"2024-02-21T14:07:07.302001Z","id":"11028c1c-55a3-479a-9b49-91fc218420b5","subnet":"fd5f:519c:6d46:8ca9::/64","updated_at":"2024-02-21T14:07:07.302001Z"}],"tags":[],"updated_at":"2024-02-21T14:07:07.302001Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "725"
@@ -5907,9 +5673,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:10 GMT
+      - Wed, 21 Feb 2024 14:08:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5917,7 +5683,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 80430b76-779a-4a20-84ef-d8f651ef8037
+      - 3a2e168e-7fec-4238-8455-6ca9e2f78bec
     status: 200 OK
     code: 200
     duration: ""
@@ -5926,29 +5692,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/515caa98-3a8f-4246-a5d0-085251445b23
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"created_at":"2024-02-21T14:08:11.895318Z","dhcp_enabled":true,"id":"515caa98-3a8f-4246-a5d0-085251445b23","name":"private_network_instance_02","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-21T14:08:11.895318Z","id":"53071bab-15dd-4265-a127-c114ee9f7a82","subnet":"172.16.4.0/22","updated_at":"2024-02-21T14:08:11.895318Z"},{"created_at":"2024-02-21T14:08:11.895318Z","id":"12bc663d-1728-4782-9b39-94270e7e163f","subnet":"fd5f:519c:6d46:792a::/64","updated_at":"2024-02-21T14:08:11.895318Z"}],"tags":[],"updated_at":"2024-02-21T14:08:11.895318Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "2806"
+      - "727"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:10 GMT
+      - Wed, 21 Feb 2024 14:08:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5956,7 +5716,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 386bc7b4-1883-4e6a-abe9-8cd80603cc81
+      - bd894d2e-45ef-4b1c-88e1-82508a784e88
     status: 200 OK
     code: 200
     duration: ""
@@ -5965,9 +5725,48 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2836"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:08:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 659fbac0-1055-4012-b1f7-60725c77327e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -5979,9 +5778,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:10 GMT
+      - Wed, 21 Feb 2024 14:08:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5989,7 +5788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a68733a0-fa68-4719-a63a-95af4e9e1561
+      - f763a037-fb89-4777-8ef4-38c3eeb2989c
     status: 200 OK
     code: 200
     duration: ""
@@ -5998,9 +5797,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -6012,12 +5811,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:10 GMT
+      - Wed, 21 Feb 2024 14:08:44 GMT
       Link:
-      - </servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/private_nics?page=0&per_page=50&>;
+      - </servers/b098331e-a548-48af-b451-7f8062029c4c/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6025,7 +5824,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d4a32363-645f-423f-935a-c44024c52ec9
+      - 52cb6538-1852-4ae7-a600-451d9ce11543
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -6036,29 +5835,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:48:05.939250+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:07:28.725466+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2806"
+      - "2836"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:11 GMT
+      - Wed, 21 Feb 2024 14:08:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6066,7 +5865,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b867e8b-5d81-48f5-abc9-faa18a270e16
+      - a741b614-d793-4f1b-ab8c-9c41d4830b2d
     status: 200 OK
     code: 200
     duration: ""
@@ -6077,12 +5876,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f/action","href_result":"/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","id":"814b489d-5067-4222-8f54-1dbcc9162e55","started_at":"2023-10-27T07:49:11.562665+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/b098331e-a548-48af-b451-7f8062029c4c/action","href_result":"/servers/b098331e-a548-48af-b451-7f8062029c4c","id":"a1ca8af8-f604-4e4e-931e-c500b6a6cd93","started_at":"2024-02-21T14:08:45.658006+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -6091,11 +5890,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:11 GMT
+      - Wed, 21 Feb 2024 14:08:45 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/814b489d-5067-4222-8f54-1dbcc9162e55
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/a1ca8af8-f604-4e4e-931e-c500b6a6cd93
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6103,7 +5902,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43a60f82-3319-4c51-8c01-fb4931cff939
+      - 994417bc-6d11-4078-8be4-158511cc4975
     status: 202 Accepted
     code: 202
     duration: ""
@@ -6112,29 +5911,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:49:11.215474+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:08:45.280993+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2774"
+      - "2804"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:11 GMT
+      - Wed, 21 Feb 2024 14:08:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6142,7 +5941,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - af854d25-b096-487e-9906-9852010022c5
+      - 1309979b-03fd-4c78-8b6c-5bb34d937fcb
     status: 200 OK
     code: 200
     duration: ""
@@ -6151,9 +5950,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/161831c6-4081-4f6b-940c-6f059525f368
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/2198d72d-9049-4382-8f70-57206fc6e529
     method: DELETE
   response:
     body: ""
@@ -6163,9 +5962,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:11 GMT
+      - Wed, 21 Feb 2024 14:08:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6173,7 +5972,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fb9480b-60df-4988-abc2-33ae062a0f96
+      - e6909869-cd43-4114-ab7e-9ae344d7f4e3
     status: 204 No Content
     code: 204
     duration: ""
@@ -6182,9 +5981,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/040bfff2-f699-4d80-a039-76b58a209bac
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/515caa98-3a8f-4246-a5d0-085251445b23
     method: DELETE
   response:
     body: ""
@@ -6194,9 +5993,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:11 GMT
+      - Wed, 21 Feb 2024 14:08:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6204,7 +6003,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94899024-aca4-46a1-845e-df5de607ff0a
+      - effd59ad-31f8-4d3e-bbfb-e4fb1e183d72
     status: 204 No Content
     code: 204
     duration: ""
@@ -6213,29 +6012,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:49:11.215474+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:08:45.280993+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2774"
+      - "2804"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:16 GMT
+      - Wed, 21 Feb 2024 14:08:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6243,7 +6042,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c00a5793-2b5c-416f-a678-65151922e0ea
+      - 7f89958d-8768-4255-ad27-7206c814fdee
     status: 200 OK
     code: 200
     duration: ""
@@ -6252,29 +6051,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:49:11.215474+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:08:45.280993+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2774"
+      - "2804"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:22 GMT
+      - Wed, 21 Feb 2024 14:08:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6282,7 +6081,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1c014813-f779-40ab-a6c5-60e9c7acf7c8
+      - cfc430cc-1955-40e7-b8ef-76cdad08ef33
     status: 200 OK
     code: 200
     duration: ""
@@ -6291,29 +6090,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"38","hypervisor_id":"301","node_id":"22","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:49:11.215474+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.69.8.43","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:08:45.280993+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2774"
+      - "2804"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:27 GMT
+      - Wed, 21 Feb 2024 14:09:01 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6321,7 +6120,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5dd56592-1d03-42b9-b4e2-6ca5fcf95273
+      - a1fe4300-9e6e-40b5-9f3d-631d7ea82970
     status: 200 OK
     code: 200
     duration: ""
@@ -6330,29 +6129,107 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:08:45.280993+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2804"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:09:07 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 091dd46e-3242-4ce9-8583-19e5f020c76b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"802","node_id":"14","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:08:45.280993+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.190.27","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2804"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:09:12 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3431be78-3930-4b51-a9eb-daf30e0f5b13
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:49:31.664670+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:09:14.066590+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2654"
+      - "2682"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:32 GMT
+      - Wed, 21 Feb 2024 14:09:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6360,7 +6237,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5db7e4db-cdc4-4149-b4a1-62dd5d93de61
+      - a438fc7b-cb0f-4df9-a150-4c447aeb22be
     status: 200 OK
     code: 200
     duration: ""
@@ -6369,29 +6246,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:47:50.306320+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-relaxed-aryabhata","id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:b8:fd","maintenances":[],"modification_date":"2023-10-27T07:49:31.664670+00:00","name":"tf-srv-relaxed-aryabhata","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:47:50.306320+00:00","export_uri":null,"id":"92478d70-56fe-43a8-aff7-17d96fbbfbda","modification_date":"2023-10-27T07:47:50.306320+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","name":"tf-srv-relaxed-aryabhata"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:07:09.028752+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-unruffled-heyrovsky","id":"b098331e-a548-48af-b451-7f8062029c4c","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:5b","maintenances":[],"modification_date":"2024-02-21T14:09:14.066590+00:00","name":"tf-srv-unruffled-heyrovsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:07:09.028752+00:00","export_uri":null,"id":"09405497-45da-4f9b-893b-9ef340ab640e","modification_date":"2024-02-21T14:07:09.028752+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"b098331e-a548-48af-b451-7f8062029c4c","name":"tf-srv-unruffled-heyrovsky"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2654"
+      - "2682"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:32 GMT
+      - Wed, 21 Feb 2024 14:09:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6399,7 +6276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a34e416-e0fa-474d-8a86-dd43c14849b7
+      - dd80462b-db13-42bc-96cc-765303ef6c07
     status: 200 OK
     code: 200
     duration: ""
@@ -6408,9 +6285,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: DELETE
   response:
     body: ""
@@ -6418,9 +6295,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 27 Oct 2023 07:49:32 GMT
+      - Wed, 21 Feb 2024 14:09:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6428,7 +6305,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4d4faec-ba5b-4186-8a64-6be0456a8e41
+      - d994a5e0-28c3-4552-94f9-996351c2f856
     status: 204 No Content
     code: 204
     duration: ""
@@ -6437,12 +6314,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"b098331e-a548-48af-b451-7f8062029c4c","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -6451,9 +6328,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:32 GMT
+      - Wed, 21 Feb 2024 14:09:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6461,7 +6338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 350d61af-21ab-4fc3-a39f-df6ad218f8b6
+      - 40141787-05e8-466a-a08e-d8e9df69100d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6470,9 +6347,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/92478d70-56fe-43a8-aff7-17d96fbbfbda
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/09405497-45da-4f9b-893b-9ef340ab640e
     method: DELETE
   response:
     body: ""
@@ -6480,9 +6357,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 27 Oct 2023 07:49:32 GMT
+      - Wed, 21 Feb 2024 14:09:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6490,7 +6367,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 961e64be-bd1e-4f0f-99af-99ce6a709e83
+      - 6e6b6789-32a2-484b-8b4d-582a50a074ea
     status: 204 No Content
     code: 204
     duration: ""
@@ -6499,12 +6376,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/6a5dd70f-90a6-4a78-9d6c-1f7039effa0f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/b098331e-a548-48af-b451-7f8062029c4c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"6a5dd70f-90a6-4a78-9d6c-1f7039effa0f","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"b098331e-a548-48af-b451-7f8062029c4c","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -6513,9 +6390,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:32 GMT
+      - Wed, 21 Feb 2024 14:09:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6523,7 +6400,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad04cc5f-6783-4675-b4e0-59f4ed225121
+      - 949bb9df-d98c-41fd-8610-61c4b5fdcea4
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-server-routed-ip-enable-with-ip.cassette.yaml
+++ b/scaleway/testdata/instance-server-routed-ip-enable-with-ip.cassette.yaml
@@ -13,20 +13,20 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"ip":{"address":"212.47.229.243","id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.156.107","id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "307"
+      - "325"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/edbfa1e8-130d-482c-be09-fdf27b719e6e
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c5a28591-d131-4352-b422-e29e111a2ddb
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5183f54-d9b5-453d-80a3-1ac160e7589d
+      - e28caf6c-6baa-4704-b27d-b18cb9fa8520
     status: 201 Created
     code: 201
     duration: ""
@@ -45,21 +45,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/edbfa1e8-130d-482c-be09-fdf27b719e6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c5a28591-d131-4352-b422-e29e111a2ddb
     method: GET
   response:
-    body: '{"ip":{"address":"212.47.229.243","id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.156.107","id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "307"
+      - "325"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -67,7 +67,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32f53302-51e0-4e10-ad5f-a30754784706
+      - ce83f2bc-d76a-4560-80ff-5ffa98efa4a8
     status: 200 OK
     code: 200
     duration: ""
@@ -81,18 +81,18 @@ interactions:
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","label":"ubuntu_jammy","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2d830ab7-b11c-435e-a582-f390ef11b1e2","label":"ubuntu_jammy","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"f0d486ff-f178-4941-ad62-8bbda478b53a","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"9467798a-e554-4658-a008-82a868d42a3b","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1179"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ecba6bf-2352-4a39-b5b1-8602ce3f6b84
+      - 1b6f9643-df91-484e-99cd-d7d1628834b2
     status: 200 OK
     code: 200
     duration: ""
@@ -114,21 +114,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38421"
+      - "38183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -136,9 +136,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98de08e5-b0a3-499b-beaf-6cd7db0c5af2
+      - f425458e-103d-45f4-a994-6fa579f2b700
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
@@ -152,21 +152,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4865"
+      - "8882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -174,14 +174,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a264cec3-2111-4bb3-8a65-b0a9fa7336ee
+      - 99351899-74ea-4bb5-b3bc-3cc4f22d4236
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-tests-instance-server-routedip-enable-with-ip","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"PRO2-XXS","image":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","volumes":{"0":{"boot":false,"volume_type":"b_ssd"}},"public_ip":"edbfa1e8-130d-482c-be09-fdf27b719e6e","boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-tests-instance-server-routedip-enable-with-ip","dynamic_ip_required":false,"commercial_type":"PRO2-XXS","image":"9467798a-e554-4658-a008-82a868d42a3b","volumes":{"0":{"boot":false,"volume_type":"b_ssd"}},"public_ip":"c5a28591-d131-4352-b422-e29e111a2ddb","boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -194,24 +194,24 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.686994+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2d","maintenances":[],"modification_date":"2023-11-03T10:00:59.686994+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.686994+00:00","export_uri":null,"id":"4c5d5819-7950-499c-b5da-cd096a67d08b","modification_date":"2023-11-03T10:00:59.686994+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.955747+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4b","maintenances":[],"modification_date":"2024-02-21T14:05:27.955747+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.955747+00:00","export_uri":null,"id":"2d0e445b-28eb-4f58-9ac7-1ec99047514d","modification_date":"2024-02-21T14:05:27.955747+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:00 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -219,7 +219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0accd7d9-ac4d-4554-9073-88c0a6d3babd
+      - 6facdeb2-3937-47eb-aa8a-5e68e8cb8ed9
     status: 201 Created
     code: 201
     duration: ""
@@ -230,27 +230,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.686994+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2d","maintenances":[],"modification_date":"2023-11-03T10:00:59.686994+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.686994+00:00","export_uri":null,"id":"4c5d5819-7950-499c-b5da-cd096a67d08b","modification_date":"2023-11-03T10:00:59.686994+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.955747+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4b","maintenances":[],"modification_date":"2024-02-21T14:05:27.955747+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.955747+00:00","export_uri":null,"id":"2d0e445b-28eb-4f58-9ac7-1ec99047514d","modification_date":"2024-02-21T14:05:27.955747+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:00 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -258,7 +258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec6c2c7b-8320-49d1-b4d0-6f7e624551ed
+      - 4fdc092f-47d1-4aa4-a1ac-cb2171b3a13e
     status: 200 OK
     code: 200
     duration: ""
@@ -269,27 +269,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.686994+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2d","maintenances":[],"modification_date":"2023-11-03T10:00:59.686994+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.686994+00:00","export_uri":null,"id":"4c5d5819-7950-499c-b5da-cd096a67d08b","modification_date":"2023-11-03T10:00:59.686994+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.955747+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4b","maintenances":[],"modification_date":"2024-02-21T14:05:27.955747+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.955747+00:00","export_uri":null,"id":"2d0e445b-28eb-4f58-9ac7-1ec99047514d","modification_date":"2024-02-21T14:05:27.955747+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:00 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -297,7 +297,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d545dc5-5b9f-483b-8305-dc6b97a0e2fa
+      - 8e443bf2-2c3d-4442-867d-82d41b8e796f
     status: 200 OK
     code: 200
     duration: ""
@@ -308,27 +308,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.686994+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2d","maintenances":[],"modification_date":"2023-11-03T10:00:59.686994+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.686994+00:00","export_uri":null,"id":"4c5d5819-7950-499c-b5da-cd096a67d08b","modification_date":"2023-11-03T10:00:59.686994+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.955747+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4b","maintenances":[],"modification_date":"2024-02-21T14:05:27.955747+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.955747+00:00","export_uri":null,"id":"2d0e445b-28eb-4f58-9ac7-1ec99047514d","modification_date":"2024-02-21T14:05:27.955747+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -336,7 +336,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ec6a7af-da1c-4768-8177-f7bc2e3809e0
+      - 6e183e54-4c5e-4ed5-abf8-73e291d04883
     status: 200 OK
     code: 200
     duration: ""
@@ -347,7 +347,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -359,9 +359,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -369,7 +369,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71f58358-4fc8-46aa-8e1a-18b3b31053fb
+      - 0e05c6cc-fe3a-4e69-9c38-ee83d9ceae79
     status: 200 OK
     code: 200
     duration: ""
@@ -380,7 +380,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -392,12 +392,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Link:
-      - </servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/private_nics?page=0&per_page=50&>;
+      - </servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -405,7 +405,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1c84115-55c6-4752-9e7a-532778397932
+      - 74636836-0759-40e5-8fb5-8c6c54de7666
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -418,7 +418,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -430,12 +430,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Link:
-      - </servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/private_nics?page=0&per_page=50&>;
+      - </servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -443,7 +443,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4e890f0a-d991-410c-9bd7-e7a577ee6bd0
+      - dda69e43-771a-4a0a-9191-e325e198000f
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -456,21 +456,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/edbfa1e8-130d-482c-be09-fdf27b719e6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c5a28591-d131-4352-b422-e29e111a2ddb
     method: GET
   response:
-    body: '{"ip":{"address":"212.47.229.243","id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.156.107","id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "409"
+      - "427"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -478,7 +478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57389444-6622-451b-9fde-4fcf8c94a616
+      - 7ee416f7-a3f1-458d-a79b-16142d9cb3c3
     status: 200 OK
     code: 200
     duration: ""
@@ -489,27 +489,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.686994+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2d","maintenances":[],"modification_date":"2023-11-03T10:00:59.686994+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.686994+00:00","export_uri":null,"id":"4c5d5819-7950-499c-b5da-cd096a67d08b","modification_date":"2023-11-03T10:00:59.686994+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.955747+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4b","maintenances":[],"modification_date":"2024-02-21T14:05:27.955747+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.955747+00:00","export_uri":null,"id":"2d0e445b-28eb-4f58-9ac7-1ec99047514d","modification_date":"2024-02-21T14:05:27.955747+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -517,7 +517,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ced92a3f-c0c6-4080-8b17-2e31f3f37a50
+      - 3662bc0c-ac10-4d5a-90ea-441e4c0f3961
     status: 200 OK
     code: 200
     duration: ""
@@ -528,7 +528,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -540,9 +540,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -550,7 +550,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8bcb1de8-c450-43a9-b030-ec1148eb6091
+      - b2414877-815f-4836-a24d-75ebec8b3bc6
     status: 200 OK
     code: 200
     duration: ""
@@ -561,7 +561,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -573,12 +573,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:02 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Link:
-      - </servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/private_nics?page=0&per_page=50&>;
+      - </servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -586,7 +586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1801c7f5-6585-443b-8ac5-d3d8a20141f7
+      - 554ec596-4a83-478d-989c-3cb493643ee3
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -599,21 +599,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/edbfa1e8-130d-482c-be09-fdf27b719e6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c5a28591-d131-4352-b422-e29e111a2ddb
     method: GET
   response:
-    body: '{"ip":{"address":"212.47.229.243","id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.156.107","id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "409"
+      - "427"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:02 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -621,7 +621,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb9e16e4-dabd-40d9-86d8-10efeb4608a4
+      - abae4f8d-4d16-460d-9815-8fab52cc31c7
     status: 200 OK
     code: 200
     duration: ""
@@ -632,27 +632,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.686994+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2d","maintenances":[],"modification_date":"2023-11-03T10:00:59.686994+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.686994+00:00","export_uri":null,"id":"4c5d5819-7950-499c-b5da-cd096a67d08b","modification_date":"2023-11-03T10:00:59.686994+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.955747+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4b","maintenances":[],"modification_date":"2024-02-21T14:05:27.955747+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.955747+00:00","export_uri":null,"id":"2d0e445b-28eb-4f58-9ac7-1ec99047514d","modification_date":"2024-02-21T14:05:27.955747+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:02 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -660,7 +660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63ee523a-79c1-476a-898c-88b7743d594a
+      - 67023d89-195e-4333-8ce2-d9f0b724000f
     status: 200 OK
     code: 200
     duration: ""
@@ -671,7 +671,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -683,9 +683,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:02 GMT
+      - Wed, 21 Feb 2024 14:05:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -693,7 +693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbd83b0e-bc1a-4945-bc4a-a035e18fc42c
+      - 0f6991c1-b9c6-4e04-af35-b6dd0a75fea8
     status: 200 OK
     code: 200
     duration: ""
@@ -704,7 +704,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -716,12 +716,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:02 GMT
+      - Wed, 21 Feb 2024 14:05:31 GMT
       Link:
-      - </servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/private_nics?page=0&per_page=50&>;
+      - </servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -729,7 +729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d0fb8008-c205-450e-a83c-ec596f8e7308
+      - f246d553-ae8b-4d58-92cb-326e862bc56f
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -742,27 +742,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.686994+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2d","maintenances":[],"modification_date":"2023-11-03T10:00:59.686994+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.686994+00:00","export_uri":null,"id":"4c5d5819-7950-499c-b5da-cd096a67d08b","modification_date":"2023-11-03T10:00:59.686994+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.955747+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4b","maintenances":[],"modification_date":"2024-02-21T14:05:27.955747+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.955747+00:00","export_uri":null,"id":"2d0e445b-28eb-4f58-9ac7-1ec99047514d","modification_date":"2024-02-21T14:05:27.955747+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:03 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -770,7 +770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ceaf53fa-63b7-4b78-93b6-c465d226485d
+      - 7cd3483f-5c23-424c-9891-7504c1e5199d
     status: 200 OK
     code: 200
     duration: ""
@@ -781,27 +781,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.686994+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2d","maintenances":[],"modification_date":"2023-11-03T10:00:59.686994+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.686994+00:00","export_uri":null,"id":"4c5d5819-7950-499c-b5da-cd096a67d08b","modification_date":"2023-11-03T10:00:59.686994+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.955747+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4b","maintenances":[],"modification_date":"2024-02-21T14:05:27.955747+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.955747+00:00","export_uri":null,"id":"2d0e445b-28eb-4f58-9ac7-1ec99047514d","modification_date":"2024-02-21T14:05:27.955747+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:03 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -809,7 +809,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 615330f7-ddd2-4d5a-9b39-3625b27537eb
+      - 02eb5c2e-6f6f-4729-bbc5-daa646902c6f
     status: 200 OK
     code: 200
     duration: ""
@@ -820,27 +820,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.686994+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2d","maintenances":[],"modification_date":"2023-11-03T10:00:59.686994+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.686994+00:00","export_uri":null,"id":"4c5d5819-7950-499c-b5da-cd096a67d08b","modification_date":"2023-11-03T10:00:59.686994+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.955747+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4b","maintenances":[],"modification_date":"2024-02-21T14:05:27.955747+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.955747+00:00","export_uri":null,"id":"2d0e445b-28eb-4f58-9ac7-1ec99047514d","modification_date":"2024-02-21T14:05:27.955747+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3150"
+      - "3208"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:03 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -848,7 +848,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb4a1b22-7f84-48b1-984d-5b8173c81be7
+      - 63aeb250-0dfd-4243-98d3-356b4d10029c
     status: 200 OK
     code: 200
     duration: ""
@@ -861,10 +861,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/action
     method: POST
   response:
-    body: '{"task":{"description":"server_enable_routed_ip","href_from":"/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/action","href_result":"/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5","id":"af15a653-87a2-4e0e-9931-95a3de084c77","started_at":"2023-11-03T10:01:04.062888+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_enable_routed_ip","href_from":"/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/action","href_result":"/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9","id":"a64e08c6-123f-42ce-bbcb-0d0c06ac9120","started_at":"2024-02-21T14:05:33.810736+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "325"
@@ -873,11 +873,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/af15a653-87a2-4e0e-9931-95a3de084c77
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/a64e08c6-123f-42ce-bbcb-0d0c06ac9120
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -885,7 +885,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3171d701-6eee-4d13-a540-d7ad79bc623c
+      - 72c778d3-e84c-41d0-a297-fc688aebd7d6
     status: 202 Accepted
     code: 202
     duration: ""
@@ -896,27 +896,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.686994+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:3b","maintenances":[],"modification_date":"2023-11-03T10:01:03.971054+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.686994+00:00","export_uri":null,"id":"4c5d5819-7950-499c-b5da-cd096a67d08b","modification_date":"2023-11-03T10:00:59.686994+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.955747+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4f","maintenances":[],"modification_date":"2024-02-21T14:05:33.972138+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.955747+00:00","export_uri":null,"id":"2d0e445b-28eb-4f58-9ac7-1ec99047514d","modification_date":"2024-02-21T14:05:27.955747+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3129"
+      - "3187"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -924,7 +924,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 856822bf-12dc-4c2e-aa78-42a9b5b4bd7b
+      - cca7ef69-97c1-46a9-8a0c-bde38c2f6dea
     status: 200 OK
     code: 200
     duration: ""
@@ -935,27 +935,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.686994+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:3b","maintenances":[],"modification_date":"2023-11-03T10:01:03.971054+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.686994+00:00","export_uri":null,"id":"4c5d5819-7950-499c-b5da-cd096a67d08b","modification_date":"2023-11-03T10:00:59.686994+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.955747+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4f","maintenances":[],"modification_date":"2024-02-21T14:05:33.972138+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":null,"id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.955747+00:00","export_uri":null,"id":"2d0e445b-28eb-4f58-9ac7-1ec99047514d","modification_date":"2024-02-21T14:05:27.955747+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3129"
+      - "3187"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -963,7 +963,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfff9828-be88-4e7b-bb0e-a05f9caedc85
+      - 256fa987-7a35-4007-8fa7-fa7be799af4f
     status: 200 OK
     code: 200
     duration: ""
@@ -974,7 +974,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -986,9 +986,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -996,7 +996,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 618e383b-af15-4e1b-a3d1-723b566fb3eb
+      - ae1eaae2-0db2-4193-931f-d722cd3398cb
     status: 200 OK
     code: 200
     duration: ""
@@ -1007,7 +1007,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1019,12 +1019,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Link:
-      - </servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/private_nics?page=0&per_page=50&>;
+      - </servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1032,7 +1032,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 384bafab-02e1-4a36-b501-bbe95ef900e4
+      - 95cf9c19-b2e1-467c-aa8c-03c062b7b783
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1045,7 +1045,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1057,12 +1057,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Link:
-      - </servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/private_nics?page=0&per_page=50&>;
+      - </servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1070,7 +1070,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ffa1b635-3368-4b9d-8cea-215737500c49
+      - 6cb97de2-137c-4349-8e3e-47d4a3199e3e
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1083,21 +1083,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/edbfa1e8-130d-482c-be09-fdf27b719e6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c5a28591-d131-4352-b422-e29e111a2ddb
     method: GET
   response:
-    body: '{"ip":{"address":"212.47.229.243","id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.156.107","id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":"5367bfec-7e2c-423f-93e5-f54573f67ab0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"state":"attached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "409"
+      - "469"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1105,7 +1105,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 611e9153-2327-4161-9bb8-1ba57e2356ad
+      - 5eacff25-e63a-4c5f-a6ea-95ac44123330
     status: 200 OK
     code: 200
     duration: ""
@@ -1116,27 +1116,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.686994+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:3b","maintenances":[],"modification_date":"2023-11-03T10:01:03.971054+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"212.47.229.243","dynamic":false,"family":"inet","gateway":null,"id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.686994+00:00","export_uri":null,"id":"4c5d5819-7950-499c-b5da-cd096a67d08b","modification_date":"2023-11-03T10:00:59.686994+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.955747+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4f","maintenances":[],"modification_date":"2024-02-21T14:05:33.972138+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":"5367bfec-7e2c-423f-93e5-f54573f67ab0","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"163.172.156.107","dynamic":false,"family":"inet","gateway":"62.210.0.1","id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":"5367bfec-7e2c-423f-93e5-f54573f67ab0","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.955747+00:00","export_uri":null,"id":"2d0e445b-28eb-4f58-9ac7-1ec99047514d","modification_date":"2024-02-21T14:05:27.955747+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3129"
+      - "3271"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1144,7 +1144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd518396-62b3-4004-ae3c-f04a27d7a5c6
+      - 0d6b2958-6e15-4a78-906e-7f8bcdc5b5df
     status: 200 OK
     code: 200
     duration: ""
@@ -1155,7 +1155,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1167,9 +1167,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1177,7 +1177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5981ba60-1e08-4d9c-8418-23be7494e79b
+      - 9e1d36e7-7f43-4d9b-978d-1486b5a30857
     status: 200 OK
     code: 200
     duration: ""
@@ -1188,7 +1188,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1200,12 +1200,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Link:
-      - </servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5/private_nics?page=0&per_page=50&>;
+      - </servers/255fabad-3402-43f8-ae10-4e2b059ad5b9/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1213,7 +1213,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 822b69c7-344b-470a-9a42-fc457d3d15d0
+      - 8eb90a1b-7abd-41d2-973e-75469873aad9
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1228,21 +1228,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/edbfa1e8-130d-482c-be09-fdf27b719e6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c5a28591-d131-4352-b422-e29e111a2ddb
     method: PATCH
   response:
-    body: '{"ip":{"address":"212.47.229.243","id":"edbfa1e8-130d-482c-be09-fdf27b719e6e","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"163.172.156.107","id":"c5a28591-d131-4352-b422-e29e111a2ddb","ipam_id":"5367bfec-7e2c-423f-93e5-f54573f67ab0","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"routed_ipv4","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "307"
+      - "367"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1250,7 +1250,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65b48a9e-3317-4f1a-94c0-51285a5d1286
+      - dd3e12c5-2242-4411-b134-4adf7072ac70
     status: 200 OK
     code: 200
     duration: ""
@@ -1261,27 +1261,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.686994+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:3b","maintenances":[],"modification_date":"2023-11-03T10:01:03.971054+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.686994+00:00","export_uri":null,"id":"4c5d5819-7950-499c-b5da-cd096a67d08b","modification_date":"2023-11-03T10:00:59.686994+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.955747+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4f","maintenances":[],"modification_date":"2024-02-21T14:05:33.972138+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.955747+00:00","export_uri":null,"id":"2d0e445b-28eb-4f58-9ac7-1ec99047514d","modification_date":"2024-02-21T14:05:27.955747+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2719"
+      - "2741"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:06 GMT
+      - Wed, 21 Feb 2024 14:05:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1289,7 +1289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae55b16d-3751-4f08-9e05-e3f3de8cf9b4
+      - a4e1952f-a3ee-4d7c-972d-2686e1447bd2
     status: 200 OK
     code: 200
     duration: ""
@@ -1300,27 +1300,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.686994+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:3b","maintenances":[],"modification_date":"2023-11-03T10:01:03.971054+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.686994+00:00","export_uri":null,"id":"4c5d5819-7950-499c-b5da-cd096a67d08b","modification_date":"2023-11-03T10:00:59.686994+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.955747+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip-enable-with-ip","id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4f","maintenances":[],"modification_date":"2024-02-21T14:05:33.972138+00:00","name":"tf-tests-instance-server-routedip-enable-with-ip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.955747+00:00","export_uri":null,"id":"2d0e445b-28eb-4f58-9ac7-1ec99047514d","modification_date":"2024-02-21T14:05:27.955747+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","name":"tf-tests-instance-server-routedip-enable-with-ip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2719"
+      - "2741"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:06 GMT
+      - Wed, 21 Feb 2024 14:05:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1328,7 +1328,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 833457a5-9a1d-4f56-ba5e-7b39919ab5b9
+      - 7410d5ed-4837-4847-bacf-3532b449df89
     status: 200 OK
     code: 200
     duration: ""
@@ -1339,7 +1339,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: DELETE
   response:
     body: ""
@@ -1347,9 +1347,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 03 Nov 2023 10:01:06 GMT
+      - Wed, 21 Feb 2024 14:05:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1357,7 +1357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec0d379b-3146-489d-9342-11de6b8ba08b
+      - 2198914b-2634-4c67-b437-1770c08200f4
     status: 204 No Content
     code: 204
     duration: ""
@@ -1368,10 +1368,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -1380,9 +1380,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:06 GMT
+      - Wed, 21 Feb 2024 14:05:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1390,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 334237a6-f86b-490a-8481-28d00e4392a7
+      - 2b02e395-95e9-4897-aa0c-5867dcfb5024
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1401,7 +1401,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/4c5d5819-7950-499c-b5da-cd096a67d08b
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/2d0e445b-28eb-4f58-9ac7-1ec99047514d
     method: DELETE
   response:
     body: ""
@@ -1409,9 +1409,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 03 Nov 2023 10:01:06 GMT
+      - Wed, 21 Feb 2024 14:05:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1419,7 +1419,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9df8618-c28d-46f5-9c33-9cfae1ff1150
+      - a8757b92-8454-4be1-b0bd-119a4aa3ed80
     status: 204 No Content
     code: 204
     duration: ""
@@ -1430,7 +1430,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/edbfa1e8-130d-482c-be09-fdf27b719e6e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c5a28591-d131-4352-b422-e29e111a2ddb
     method: DELETE
   response:
     body: ""
@@ -1438,9 +1438,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 03 Nov 2023 10:01:06 GMT
+      - Wed, 21 Feb 2024 14:05:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1448,7 +1448,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 78275a3b-0769-4183-90de-59d8a4a83e96
+      - 4310d58f-27ab-4a3c-bacd-e58d77323583
     status: 204 No Content
     code: 204
     duration: ""
@@ -1459,10 +1459,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/c488f4fa-59c5-4ed5-bc99-04b522ee23c5
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/255fabad-3402-43f8-ae10-4e2b059ad5b9
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"c488f4fa-59c5-4ed5-bc99-04b522ee23c5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"255fabad-3402-43f8-ae10-4e2b059ad5b9","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -1471,9 +1471,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:06 GMT
+      - Wed, 21 Feb 2024 14:05:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1481,7 +1481,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2259fe1-219e-4992-912c-dc92fbbad3b1
+      - d14a30a9-60fc-4c81-9cb6-e0660507cfd1
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-server-routed-ip-enable.cassette.yaml
+++ b/scaleway/testdata/instance-server-routed-ip-enable.cassette.yaml
@@ -11,18 +11,18 @@ interactions:
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","label":"ubuntu_jammy","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2d830ab7-b11c-435e-a582-f390ef11b1e2","label":"ubuntu_jammy","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"f0d486ff-f178-4941-ad62-8bbda478b53a","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"9467798a-e554-4658-a008-82a868d42a3b","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1179"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:58 GMT
+      - Wed, 21 Feb 2024 14:05:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -30,7 +30,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb82f66b-959a-4479-9c6f-d10873fff1fa
+      - 85b2ddac-68f9-41d5-b3a2-5bfcab1efe53
     status: 200 OK
     code: 200
     duration: ""
@@ -44,21 +44,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38421"
+      - "38183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:58 GMT
+      - Wed, 21 Feb 2024 14:05:26 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -66,9 +66,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d58c0120-8272-4b84-8b1b-f8deda9fcdc9
+      - d043b441-84ca-4da3-9475-e8913fa65fb0
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
@@ -82,21 +82,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4865"
+      - "8882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:58 GMT
+      - Wed, 21 Feb 2024 14:05:26 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -104,14 +104,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0880a4f-cafe-435d-a62f-40658bf4ea7e
+      - 2a6f5843-0a74-4978-a935-7574a38ba71b
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-tests-instance-server-routedip","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"PRO2-XXS","image":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","volumes":{"0":{"boot":false,"volume_type":"b_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-tests-instance-server-routedip","dynamic_ip_required":false,"commercial_type":"PRO2-XXS","image":"9467798a-e554-4658-a008-82a868d42a3b","volumes":{"0":{"boot":false,"volume_type":"b_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -124,24 +124,24 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.242607+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"833db45e-c524-4ec0-af53-959606ac6478","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2b","maintenances":[],"modification_date":"2023-11-03T10:00:59.242607+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.242607+00:00","export_uri":null,"id":"66f478f1-9e90-4aa9-bedd-c17d22b21e47","modification_date":"2023-11-03T10:00:59.242607+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"833db45e-c524-4ec0-af53-959606ac6478","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.248330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:45","maintenances":[],"modification_date":"2024-02-21T14:05:27.248330+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.248330+00:00","export_uri":null,"id":"cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3","modification_date":"2024-02-21T14:05:27.248330+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2695"
+      - "2717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:59 GMT
+      - Wed, 21 Feb 2024 14:05:27 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -149,7 +149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7afb598-5a42-44cd-826f-138aa52f67cf
+      - 89541538-cee8-4b05-8a14-662da25e635c
     status: 201 Created
     code: 201
     duration: ""
@@ -160,27 +160,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.242607+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"833db45e-c524-4ec0-af53-959606ac6478","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2b","maintenances":[],"modification_date":"2023-11-03T10:00:59.242607+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.242607+00:00","export_uri":null,"id":"66f478f1-9e90-4aa9-bedd-c17d22b21e47","modification_date":"2023-11-03T10:00:59.242607+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"833db45e-c524-4ec0-af53-959606ac6478","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.248330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:45","maintenances":[],"modification_date":"2024-02-21T14:05:27.248330+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.248330+00:00","export_uri":null,"id":"cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3","modification_date":"2024-02-21T14:05:27.248330+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2695"
+      - "2717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:59 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -188,7 +188,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1b5978df-49d7-4e76-bc5e-a35c8e141bf8
+      - f8d35485-ffb1-4774-91c5-42e1fb5d27b6
     status: 200 OK
     code: 200
     duration: ""
@@ -199,27 +199,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.242607+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"833db45e-c524-4ec0-af53-959606ac6478","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2b","maintenances":[],"modification_date":"2023-11-03T10:00:59.242607+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.242607+00:00","export_uri":null,"id":"66f478f1-9e90-4aa9-bedd-c17d22b21e47","modification_date":"2023-11-03T10:00:59.242607+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"833db45e-c524-4ec0-af53-959606ac6478","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.248330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:45","maintenances":[],"modification_date":"2024-02-21T14:05:27.248330+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.248330+00:00","export_uri":null,"id":"cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3","modification_date":"2024-02-21T14:05:27.248330+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2695"
+      - "2717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:00:59 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -227,7 +227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14bab5b0-1597-48f0-8675-141fbced600b
+      - 3f9db5c9-f4d7-4b2b-adc8-b951207ad153
     status: 200 OK
     code: 200
     duration: ""
@@ -238,27 +238,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.242607+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"833db45e-c524-4ec0-af53-959606ac6478","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2b","maintenances":[],"modification_date":"2023-11-03T10:00:59.242607+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.242607+00:00","export_uri":null,"id":"66f478f1-9e90-4aa9-bedd-c17d22b21e47","modification_date":"2023-11-03T10:00:59.242607+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"833db45e-c524-4ec0-af53-959606ac6478","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.248330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:45","maintenances":[],"modification_date":"2024-02-21T14:05:27.248330+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.248330+00:00","export_uri":null,"id":"cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3","modification_date":"2024-02-21T14:05:27.248330+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2695"
+      - "2717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:00 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -266,7 +266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71b6bf81-d193-4aa5-8c12-2dfd23da71af
+      - afe90904-000d-43d3-b0ca-d9a00f1b59bc
     status: 200 OK
     code: 200
     duration: ""
@@ -277,7 +277,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -289,9 +289,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:00 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -299,7 +299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef44c6d8-53d0-48cb-bf5a-4ae071fbd687
+      - 395f1764-aa62-435e-8396-0f9170d00013
     status: 200 OK
     code: 200
     duration: ""
@@ -310,7 +310,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -322,12 +322,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:00 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Link:
-      - </servers/833db45e-c524-4ec0-af53-959606ac6478/private_nics?page=0&per_page=50&>;
+      - </servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -335,7 +335,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c4b4383-eed1-4254-a5b1-3d24da625228
+      - bb39158e-7b37-4e05-b54d-bf8a6d6710b5
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -348,7 +348,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -360,12 +360,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:00 GMT
+      - Wed, 21 Feb 2024 14:05:28 GMT
       Link:
-      - </servers/833db45e-c524-4ec0-af53-959606ac6478/private_nics?page=0&per_page=50&>;
+      - </servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -373,7 +373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 586ee693-0501-4256-acbd-3a2bb6c3af68
+      - b1eef260-838e-4067-87d6-c1f01d96a596
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -386,27 +386,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.242607+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"833db45e-c524-4ec0-af53-959606ac6478","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2b","maintenances":[],"modification_date":"2023-11-03T10:00:59.242607+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.242607+00:00","export_uri":null,"id":"66f478f1-9e90-4aa9-bedd-c17d22b21e47","modification_date":"2023-11-03T10:00:59.242607+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"833db45e-c524-4ec0-af53-959606ac6478","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.248330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:45","maintenances":[],"modification_date":"2024-02-21T14:05:27.248330+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.248330+00:00","export_uri":null,"id":"cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3","modification_date":"2024-02-21T14:05:27.248330+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2695"
+      - "2717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -414,7 +414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e06765bb-150b-4f22-876d-e4515ab715bc
+      - 636a3f16-39f0-4630-b61d-6b5ba537c9e6
     status: 200 OK
     code: 200
     duration: ""
@@ -425,7 +425,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -437,9 +437,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -447,7 +447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f7a4306-f807-4bac-90b9-37268053b599
+      - 37b82ec5-36db-4b7b-90e6-5495bbbbbb37
     status: 200 OK
     code: 200
     duration: ""
@@ -458,7 +458,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -470,12 +470,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:29 GMT
       Link:
-      - </servers/833db45e-c524-4ec0-af53-959606ac6478/private_nics?page=0&per_page=50&>;
+      - </servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -483,7 +483,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ddae6e5-dd57-439d-9ae9-f7ab8e331138
+      - 9787ab88-1fd3-4c10-b45c-636d61d4b8b6
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -496,27 +496,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.242607+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"833db45e-c524-4ec0-af53-959606ac6478","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2b","maintenances":[],"modification_date":"2023-11-03T10:00:59.242607+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.242607+00:00","export_uri":null,"id":"66f478f1-9e90-4aa9-bedd-c17d22b21e47","modification_date":"2023-11-03T10:00:59.242607+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"833db45e-c524-4ec0-af53-959606ac6478","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.248330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:45","maintenances":[],"modification_date":"2024-02-21T14:05:27.248330+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.248330+00:00","export_uri":null,"id":"cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3","modification_date":"2024-02-21T14:05:27.248330+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2695"
+      - "2717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -524,7 +524,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 702f333e-67d9-4f40-968e-de0f6347daab
+      - 4cebfde6-319c-4ff6-8476-485fde70b8c4
     status: 200 OK
     code: 200
     duration: ""
@@ -535,7 +535,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -547,9 +547,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:01 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -557,7 +557,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81ea0d99-a449-476a-9dd9-9b93d4215c7f
+      - a281787d-ff58-4685-92a0-78a54c158eac
     status: 200 OK
     code: 200
     duration: ""
@@ -568,7 +568,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -580,12 +580,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:02 GMT
+      - Wed, 21 Feb 2024 14:05:30 GMT
       Link:
-      - </servers/833db45e-c524-4ec0-af53-959606ac6478/private_nics?page=0&per_page=50&>;
+      - </servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -593,7 +593,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ef36178-e4d3-4c28-be23-57493ff95389
+      - ccb36ce0-0ae8-4c6e-b519-43ee9d9a5fdd
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -606,27 +606,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.242607+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"833db45e-c524-4ec0-af53-959606ac6478","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2b","maintenances":[],"modification_date":"2023-11-03T10:00:59.242607+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.242607+00:00","export_uri":null,"id":"66f478f1-9e90-4aa9-bedd-c17d22b21e47","modification_date":"2023-11-03T10:00:59.242607+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"833db45e-c524-4ec0-af53-959606ac6478","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.248330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:45","maintenances":[],"modification_date":"2024-02-21T14:05:27.248330+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.248330+00:00","export_uri":null,"id":"cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3","modification_date":"2024-02-21T14:05:27.248330+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2695"
+      - "2717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:02 GMT
+      - Wed, 21 Feb 2024 14:05:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -634,7 +634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da064698-14b8-4765-b90c-c412314b35c5
+      - b96e74b9-8870-439e-a781-6688fdbe432e
     status: 200 OK
     code: 200
     duration: ""
@@ -645,27 +645,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.242607+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"833db45e-c524-4ec0-af53-959606ac6478","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2b","maintenances":[],"modification_date":"2023-11-03T10:00:59.242607+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.242607+00:00","export_uri":null,"id":"66f478f1-9e90-4aa9-bedd-c17d22b21e47","modification_date":"2023-11-03T10:00:59.242607+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"833db45e-c524-4ec0-af53-959606ac6478","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.248330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:45","maintenances":[],"modification_date":"2024-02-21T14:05:27.248330+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.248330+00:00","export_uri":null,"id":"cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3","modification_date":"2024-02-21T14:05:27.248330+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2695"
+      - "2717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:02 GMT
+      - Wed, 21 Feb 2024 14:05:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -673,7 +673,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 33911e67-75d0-4714-b15d-81076fd28544
+      - 9c880ac0-4669-4ec9-95ca-3d4de1685608
     status: 200 OK
     code: 200
     duration: ""
@@ -684,27 +684,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.242607+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"833db45e-c524-4ec0-af53-959606ac6478","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:2b","maintenances":[],"modification_date":"2023-11-03T10:00:59.242607+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.242607+00:00","export_uri":null,"id":"66f478f1-9e90-4aa9-bedd-c17d22b21e47","modification_date":"2023-11-03T10:00:59.242607+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"833db45e-c524-4ec0-af53-959606ac6478","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.248330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:45","maintenances":[],"modification_date":"2024-02-21T14:05:27.248330+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.248330+00:00","export_uri":null,"id":"cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3","modification_date":"2024-02-21T14:05:27.248330+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2695"
+      - "2717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:03 GMT
+      - Wed, 21 Feb 2024 14:05:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -712,7 +712,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48f06d62-17de-4bff-b35b-309c3e1972b5
+      - fedc06dc-0ae1-4990-9045-4fcc04a1f9e7
     status: 200 OK
     code: 200
     duration: ""
@@ -725,10 +725,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/action
     method: POST
   response:
-    body: '{"task":{"description":"server_enable_routed_ip","href_from":"/servers/833db45e-c524-4ec0-af53-959606ac6478/action","href_result":"/servers/833db45e-c524-4ec0-af53-959606ac6478","id":"89b990d8-c76f-40b7-98bb-7929ed4b92a0","started_at":"2023-11-03T10:01:03.508563+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_enable_routed_ip","href_from":"/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/action","href_result":"/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c","id":"3674bd97-1d0f-40d2-8bdd-dc8a0d074dc2","started_at":"2024-02-21T14:05:31.748344+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "325"
@@ -737,11 +737,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:03 GMT
+      - Wed, 21 Feb 2024 14:05:31 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/89b990d8-c76f-40b7-98bb-7929ed4b92a0
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3674bd97-1d0f-40d2-8bdd-dc8a0d074dc2
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -749,7 +749,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a49a80a-76e6-45e2-96a0-f1cee392a78f
+      - d35bea8e-1ed1-48b6-a226-6ee80d246135
     status: 202 Accepted
     code: 202
     duration: ""
@@ -760,27 +760,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.242607+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"833db45e-c524-4ec0-af53-959606ac6478","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:37","maintenances":[],"modification_date":"2023-11-03T10:01:03.379623+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.242607+00:00","export_uri":null,"id":"66f478f1-9e90-4aa9-bedd-c17d22b21e47","modification_date":"2023-11-03T10:00:59.242607+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"833db45e-c524-4ec0-af53-959606ac6478","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.248330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4d","maintenances":[],"modification_date":"2024-02-21T14:05:31.880100+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.248330+00:00","export_uri":null,"id":"cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3","modification_date":"2024-02-21T14:05:27.248330+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2674"
+      - "2696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:03 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -788,7 +788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5295f2e-25ef-495d-8d2d-78b016dbd282
+      - 96da28c8-bfe5-42df-8fcf-bac2f906b656
     status: 200 OK
     code: 200
     duration: ""
@@ -799,27 +799,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.242607+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"833db45e-c524-4ec0-af53-959606ac6478","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:37","maintenances":[],"modification_date":"2023-11-03T10:01:03.379623+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.242607+00:00","export_uri":null,"id":"66f478f1-9e90-4aa9-bedd-c17d22b21e47","modification_date":"2023-11-03T10:00:59.242607+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"833db45e-c524-4ec0-af53-959606ac6478","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.248330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4d","maintenances":[],"modification_date":"2024-02-21T14:05:31.880100+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.248330+00:00","export_uri":null,"id":"cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3","modification_date":"2024-02-21T14:05:27.248330+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2674"
+      - "2696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:03 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -827,7 +827,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76cb1965-141a-4a4a-bf03-439abe953c95
+      - 528dec54-c34c-44e1-9a44-0126b5590fe0
     status: 200 OK
     code: 200
     duration: ""
@@ -838,7 +838,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -850,9 +850,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:03 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -860,7 +860,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1eb63513-64b7-47fd-b075-ba10fc066e4d
+      - 20b75396-f06b-4c25-a9fa-45566e231aff
     status: 200 OK
     code: 200
     duration: ""
@@ -871,7 +871,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -883,12 +883,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Link:
-      - </servers/833db45e-c524-4ec0-af53-959606ac6478/private_nics?page=0&per_page=50&>;
+      - </servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -896,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff80613b-f7e8-4795-ad7a-348573ad8670
+      - e4cdd3ea-a024-4cdf-81c7-4af2cd56f1d5
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -909,7 +909,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -921,12 +921,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:33 GMT
       Link:
-      - </servers/833db45e-c524-4ec0-af53-959606ac6478/private_nics?page=0&per_page=50&>;
+      - </servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -934,7 +934,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b39b174-d30b-4b0d-9274-98d4bdc33d10
+      - c49ef5c5-b614-447d-ad5c-a45b73841a6f
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -947,27 +947,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.242607+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"833db45e-c524-4ec0-af53-959606ac6478","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:37","maintenances":[],"modification_date":"2023-11-03T10:01:03.379623+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.242607+00:00","export_uri":null,"id":"66f478f1-9e90-4aa9-bedd-c17d22b21e47","modification_date":"2023-11-03T10:00:59.242607+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"833db45e-c524-4ec0-af53-959606ac6478","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.248330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4d","maintenances":[],"modification_date":"2024-02-21T14:05:31.880100+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.248330+00:00","export_uri":null,"id":"cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3","modification_date":"2024-02-21T14:05:27.248330+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2674"
+      - "2696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -975,7 +975,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75a722ef-5d83-4636-bda2-ac0882fc418b
+      - 4f6aae31-b7e0-42ad-ae82-918fed1da68a
     status: 200 OK
     code: 200
     duration: ""
@@ -986,7 +986,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -998,9 +998,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1008,7 +1008,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94be2d19-4027-4bc8-a1af-370704b635b2
+      - ba08e2c9-2a49-45ff-83e4-681ce143a157
     status: 200 OK
     code: 200
     duration: ""
@@ -1019,7 +1019,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1031,12 +1031,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:04 GMT
+      - Wed, 21 Feb 2024 14:05:34 GMT
       Link:
-      - </servers/833db45e-c524-4ec0-af53-959606ac6478/private_nics?page=0&per_page=50&>;
+      - </servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1044,7 +1044,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 670cb7a9-79eb-4741-866e-0e73577c09a1
+      - e0eadcff-9517-4fc3-945a-95e9b8edb2fc
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1057,27 +1057,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.242607+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"833db45e-c524-4ec0-af53-959606ac6478","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:37","maintenances":[],"modification_date":"2023-11-03T10:01:03.379623+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.242607+00:00","export_uri":null,"id":"66f478f1-9e90-4aa9-bedd-c17d22b21e47","modification_date":"2023-11-03T10:00:59.242607+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"833db45e-c524-4ec0-af53-959606ac6478","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.248330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4d","maintenances":[],"modification_date":"2024-02-21T14:05:31.880100+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.248330+00:00","export_uri":null,"id":"cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3","modification_date":"2024-02-21T14:05:27.248330+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2674"
+      - "2696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1085,7 +1085,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 399c559f-86fb-4eab-b2ab-1efe9aedc7aa
+      - 6d2c82bd-bc54-4bd0-936a-ff8d347c8063
     status: 200 OK
     code: 200
     duration: ""
@@ -1096,27 +1096,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2023-11-03T10:00:59.242607+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"833db45e-c524-4ec0-af53-959606ac6478","image":{"arch":"x86_64","creation_date":"2023-08-08T13:35:09.293489+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"81b9475d-e1b5-43c2-ac48-4c1a3b640686","modification_date":"2023-08-08T13:35:09.293489+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"235f1b04-c3f6-4245-9530-43fb642ff96d","name":"Ubuntu
-      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:c1:37","maintenances":[],"modification_date":"2023-11-03T10:01:03.379623+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-03T10:00:59.242607+00:00","export_uri":null,"id":"66f478f1-9e90-4aa9-bedd-c17d22b21e47","modification_date":"2023-11-03T10:00:59.242607+00:00","name":"Ubuntu
-      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"833db45e-c524-4ec0-af53-959606ac6478","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PRO2-XXS","creation_date":"2024-02-21T14:05:27.248330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-tests-instance-server-routedip","id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","image":{"arch":"x86_64","creation_date":"2024-01-31T16:05:11.366989+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"9467798a-e554-4658-a008-82a868d42a3b","modification_date":"2024-01-31T16:05:11.366989+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"59235d23-138e-45ea-983d-5a2a58937164","name":"Ubuntu
+      22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e8:4d","maintenances":[],"modification_date":"2024-02-21T14:05:31.880100+00:00","name":"tf-tests-instance-server-routedip","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:05:27.248330+00:00","export_uri":null,"id":"cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3","modification_date":"2024-02-21T14:05:27.248330+00:00","name":"Ubuntu
+      22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","name":"tf-tests-instance-server-routedip"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2674"
+      - "2696"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1124,7 +1124,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cd175931-549f-42be-9030-5c029f48cac8
+      - f6760384-e1ef-46d6-9543-95c68e88f8d1
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,7 +1135,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: DELETE
   response:
     body: ""
@@ -1143,9 +1143,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1153,7 +1153,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f24ce5ea-f20e-46b4-b09c-9216d1289268
+      - 596f8830-ed27-4088-8e06-359361e17384
     status: 204 No Content
     code: 204
     duration: ""
@@ -1164,10 +1164,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"833db45e-c524-4ec0-af53-959606ac6478","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -1176,9 +1176,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1186,7 +1186,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e501fa62-cdf1-4e40-8778-e901e0783740
+      - 348d801b-a792-43ee-8b2e-ce76d225a51e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1197,7 +1197,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/66f478f1-9e90-4aa9-bedd-c17d22b21e47
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/cd4de5e9-e0fa-4a01-ac02-c4dd22e945d3
     method: DELETE
   response:
     body: ""
@@ -1205,9 +1205,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1215,7 +1215,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 715e35a4-a328-41aa-adeb-677c6892a320
+      - 5dab11e2-8b92-4196-9112-f21fe8a8d378
     status: 204 No Content
     code: 204
     duration: ""
@@ -1226,10 +1226,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/833db45e-c524-4ec0-af53-959606ac6478
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/5f15a5ef-23fa-4a35-8ca2-94920631c47c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"833db45e-c524-4ec0-af53-959606ac6478","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"5f15a5ef-23fa-4a35-8ca2-94920631c47c","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -1238,9 +1238,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 03 Nov 2023 10:01:05 GMT
+      - Wed, 21 Feb 2024 14:05:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1248,7 +1248,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5e90da2-bc0b-4acc-9639-26c39e2268dc
+      - a9622a11-9aa1-473d-a955-ee70df5d2d31
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-server-with-reserved-ip.cassette.yaml
+++ b/scaleway/testdata/instance-server-with-reserved-ip.cassette.yaml
@@ -13,20 +13,20 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"ip":{"address":"51.15.240.218","id":"392360b5-d951-45a3-b403-361589f27744","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.143.186","id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:01:06 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/392360b5-d951-45a3-b403-361589f27744
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ecc67639-88d7-446c-bca9-a3a9e32f0edb
+      - 9796dc38-f0e0-44ab-86c3-1e388b4fb762
     status: 201 Created
     code: 201
     duration: ""
@@ -45,21 +45,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/392360b5-d951-45a3-b403-361589f27744
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9
     method: GET
   response:
-    body: '{"ip":{"address":"51.15.240.218","id":"392360b5-d951-45a3-b403-361589f27744","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.143.186","id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:01:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -67,7 +67,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bd0e7011-9a36-4bdb-9c9a-076d7500052d
+      - 742362e5-5e81-4adf-adf8-42ba96b16f9b
     status: 200 OK
     code: 200
     duration: ""
@@ -81,18 +81,18 @@ interactions:
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"10b2d3c3-bfa7-42d4-910b-389e95f95ccb","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2f1f7a57-c508-4f72-9f7f-536b316f36e1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"5d083890-4354-47ab-b769-8b0de601eb3a","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1179"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:01:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea2f88bc-0752-4b2e-bcf4-30d1a391ca45
+      - 3dd9f032-fc4b-48b6-998c-a7ee1556fcfe
     status: 200 OK
     code: 200
     duration: ""
@@ -114,21 +114,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38421"
+      - "38183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:01:07 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -136,9 +136,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 05e43775-0d28-4f7f-8b74-13294d5e3a49
+      - 28e8a1a6-791a-49f0-aca1-ab7419f8b800
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
@@ -152,21 +152,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4865"
+      - "8882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Wed, 21 Feb 2024 14:01:07 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -174,14 +174,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 082950db-a615-4f29-8ae4-3bcbd699ec85
+      - c6d1be0f-a42e-49e5-a201-f5664679f020
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-fervent-rhodes","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"public_ip":"392360b5-d951-45a3-b403-361589f27744","boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","scaleway_instance_server","reserved_ip"]}'
+    body: '{"name":"tf-srv-priceless-edison","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5d083890-4354-47ab-b769-8b0de601eb3a","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"public_ip":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf","tags":["terraform-test","scaleway_instance_server","reserved_ip"]}'
     form: {}
     headers:
       Content-Type:
@@ -194,24 +194,24 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:01.920376+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:07.576206+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3112"
+      - "3174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:02 GMT
+      - Wed, 21 Feb 2024 14:01:08 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -219,7 +219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ee9573e-07ff-43b4-9c5f-8e9ff0bb7eab
+      - 7d15a1d6-928a-44ab-8d4b-ca018ab3c1d6
     status: 201 Created
     code: 201
     duration: ""
@@ -230,27 +230,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:01.920376+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:07.576206+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3112"
+      - "3174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:02 GMT
+      - Wed, 21 Feb 2024 14:01:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -258,7 +258,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 165e601d-6ff0-45b9-b983-f044bb97b102
+      - 250033b6-b631-42d7-b105-f746f1ec6959
     status: 200 OK
     code: 200
     duration: ""
@@ -269,27 +269,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:01.920376+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:07.576206+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3112"
+      - "3174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:02 GMT
+      - Wed, 21 Feb 2024 14:01:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -297,7 +297,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52768786-48db-4546-bff5-e7675400215d
+      - 38fcd1aa-1946-4d21-99cd-66f56762f453
     status: 200 OK
     code: 200
     duration: ""
@@ -310,10 +310,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/action","href_result":"/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688","id":"61fdec49-a62a-4582-8256-1a67c8e78071","started_at":"2023-10-31T14:31:03.094214+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/action","href_result":"/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32","id":"dc7d7c3d-dd52-4016-8ced-2e495cde8f38","started_at":"2024-02-21T14:01:08.740936+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -322,11 +322,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:03 GMT
+      - Wed, 21 Feb 2024 14:01:08 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/61fdec49-a62a-4582-8256-1a67c8e78071
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/dc7d7c3d-dd52-4016-8ced-2e495cde8f38
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -334,7 +334,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2819f83-ae6c-46a5-84ca-7035e23d2b54
+      - 23a4861f-7d33-48f9-9ca2-6e10be32a0f6
     status: 202 Accepted
     code: 202
     duration: ""
@@ -345,27 +345,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:02.803502+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:08.455304+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3134"
+      - "3196"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:03 GMT
+      - Wed, 21 Feb 2024 14:01:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -373,7 +373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1610204-75a0-445e-a875-550ef5beee86
+      - e28863a1-bd8b-4443-8d0c-2a569577eb09
     status: 200 OK
     code: 200
     duration: ""
@@ -384,27 +384,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:02.803502+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:08.455304+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3243"
+      - "3304"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:08 GMT
+      - Wed, 21 Feb 2024 14:01:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -412,7 +412,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 751ab87f-eac6-4e6a-bf76-3180207142be
+      - a114958f-c1d0-4964-8183-e0aa2486b608
     status: 200 OK
     code: 200
     duration: ""
@@ -423,27 +423,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:02.803502+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:08.455304+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3243"
+      - "3304"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:13 GMT
+      - Wed, 21 Feb 2024 14:01:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -451,7 +451,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 241be7be-64cc-4dc7-9522-54cb286d1ed6
+      - 68f92bba-6b09-44f7-a955-38d4c3eaca82
     status: 200 OK
     code: 200
     duration: ""
@@ -462,66 +462,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:02.803502+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3243"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:31:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 46a5a9f9-9815-45c6-8bad-dd98580257d7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:24 GMT
+      - Wed, 21 Feb 2024 14:01:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -529,7 +490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9a8ebcb9-99de-4a8c-ba18-0dd4d247088d
+      - 553c874a-69b6-4f58-80d2-29e423493400
     status: 200 OK
     code: 200
     duration: ""
@@ -540,27 +501,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:24 GMT
+      - Wed, 21 Feb 2024 14:01:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -568,7 +529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6fc39d0-131f-4586-a1a2-a1adf1e701aa
+      - d9b8b1ba-351e-4abe-841b-d06c60b95766
     status: 200 OK
     code: 200
     duration: ""
@@ -579,7 +540,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -591,9 +552,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:24 GMT
+      - Wed, 21 Feb 2024 14:01:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -601,7 +562,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5824b826-c029-4f1e-b098-778a6dc2e83f
+      - 71f65ace-096d-457c-8e94-f9434ebbcfe8
     status: 200 OK
     code: 200
     duration: ""
@@ -612,7 +573,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -624,12 +585,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:24 GMT
+      - Wed, 21 Feb 2024 14:01:30 GMT
       Link:
-      - </servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics?page=0&per_page=50&>;
+      - </servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -637,7 +598,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac0e4bba-e453-4846-9cfa-d04102ac913b
+      - d357b3e4-9c3e-4cd3-bbe7-b88bfa427f7c
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -650,27 +611,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:24 GMT
+      - Wed, 21 Feb 2024 14:01:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -678,7 +639,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5984419d-0a3c-4f27-8e5b-fa2abcb2b3f2
+      - ca606f3a-26dd-40b1-b735-e0a72ab43639
     status: 200 OK
     code: 200
     duration: ""
@@ -689,21 +650,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/392360b5-d951-45a3-b403-361589f27744
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9
     method: GET
   response:
-    body: '{"ip":{"address":"51.15.240.218","id":"392360b5-d951-45a3-b403-361589f27744","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.143.186","id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "381"
+      - "400"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:25 GMT
+      - Wed, 21 Feb 2024 14:01:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -711,7 +672,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74286c3e-6f6b-42dd-8187-f9ed845ff677
+      - ecab9441-52b8-4e20-bbf1-7ba440f326f6
     status: 200 OK
     code: 200
     duration: ""
@@ -722,27 +683,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:25 GMT
+      - Wed, 21 Feb 2024 14:01:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -750,7 +711,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5600f8ab-b97e-4522-a116-eec2b68439cf
+      - 9ec28db5-ee91-45b8-87a0-d1c5a013372b
     status: 200 OK
     code: 200
     duration: ""
@@ -761,7 +722,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -773,9 +734,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:25 GMT
+      - Wed, 21 Feb 2024 14:01:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -783,7 +744,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75610110-69db-400f-8f70-4c04461d662e
+      - fab28f0e-30ff-4a3c-b862-5bbd5cd11c73
     status: 200 OK
     code: 200
     duration: ""
@@ -794,7 +755,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -806,12 +767,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:25 GMT
+      - Wed, 21 Feb 2024 14:01:32 GMT
       Link:
-      - </servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics?page=0&per_page=50&>;
+      - </servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -819,7 +780,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec44e54e-91f3-4a01-a996-fe04ff5b7d8b
+      - b6b20151-4d72-4b54-8e6e-7977352b95bd
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -832,21 +793,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/392360b5-d951-45a3-b403-361589f27744
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9
     method: GET
   response:
-    body: '{"ip":{"address":"51.15.240.218","id":"392360b5-d951-45a3-b403-361589f27744","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.143.186","id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "381"
+      - "400"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:26 GMT
+      - Wed, 21 Feb 2024 14:01:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -854,7 +815,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6c6d229-aed6-45fd-9927-f9848bbb52aa
+      - 1712a3d9-62f3-4294-8c9c-322785dbc020
     status: 200 OK
     code: 200
     duration: ""
@@ -865,27 +826,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:26 GMT
+      - Wed, 21 Feb 2024 14:01:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -893,7 +854,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fc11f57-e28c-4131-80a8-c054240cf93b
+      - bec5cf39-13e6-4934-a900-75d0e66f350d
     status: 200 OK
     code: 200
     duration: ""
@@ -904,7 +865,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -916,9 +877,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:26 GMT
+      - Wed, 21 Feb 2024 14:01:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -926,7 +887,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 504f4c4b-ee83-4579-9452-b503d5dc21f3
+      - d94cc5e7-9f36-4f9d-8aee-a5cd1fc2787e
     status: 200 OK
     code: 200
     duration: ""
@@ -937,7 +898,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -949,12 +910,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:26 GMT
+      - Wed, 21 Feb 2024 14:01:37 GMT
       Link:
-      - </servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics?page=0&per_page=50&>;
+      - </servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -962,7 +923,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ba9b6aa-1a60-439d-8ff1-ebc831fda3b9
+      - ebfe7501-8e75-4ff3-9922-a5450aac1705
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -980,20 +941,20 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.116.35","id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:27 GMT
+      - Wed, 21 Feb 2024 14:01:38 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c0d3b27b-fc69-462a-9e2a-c71c5c0678b6
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1001,7 +962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c95be64-6813-4615-a194-6294549c6937
+      - e981dbd5-4c31-4d8b-8fef-66184e94a592
     status: 201 Created
     code: 201
     duration: ""
@@ -1012,21 +973,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c0d3b27b-fc69-462a-9e2a-c71c5c0678b6
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.116.35","id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:28 GMT
+      - Wed, 21 Feb 2024 14:01:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1034,7 +995,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f7ded34-bad7-4687-9ecb-cec3c46ae2be
+      - 983cf2c0-6679-49cc-8605-37a8d6f6935a
     status: 200 OK
     code: 200
     duration: ""
@@ -1045,27 +1006,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:28 GMT
+      - Wed, 21 Feb 2024 14:01:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1073,7 +1034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c05de034-4e36-4198-93a7-80d1cd061fef
+      - 3baff95a-b7dd-4e33-a9c3-21122f60f531
     status: 200 OK
     code: 200
     duration: ""
@@ -1084,27 +1045,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.240.218","dynamic":false,"family":"inet","gateway":null,"id":"392360b5-d951-45a3-b403-361589f27744","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.143.186","dynamic":false,"family":"inet","gateway":null,"id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:28 GMT
+      - Wed, 21 Feb 2024 14:01:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1112,7 +1073,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 327a4c07-9223-4d7f-8a64-8583c902bf20
+      - 95ef658c-7d1f-4428-bed4-e5b7972bf792
     status: 200 OK
     code: 200
     duration: ""
@@ -1125,21 +1086,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/392360b5-d951-45a3-b403-361589f27744
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9
     method: PATCH
   response:
-    body: '{"ip":{"address":"51.15.240.218","id":"392360b5-d951-45a3-b403-361589f27744","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.143.186","id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:28 GMT
+      - Wed, 21 Feb 2024 14:01:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1147,7 +1108,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f97d743a-6d6c-40d6-8187-cd5a22f57f68
+      - df805680-0e69-4adc-8fb8-088bc05cb888
     status: 200 OK
     code: 200
     duration: ""
@@ -1158,27 +1119,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2866"
+      - "2893"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:29 GMT
+      - Wed, 21 Feb 2024 14:01:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1186,7 +1147,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b2c9238-247b-4113-8df1-17ff97963fe4
+      - 79586f35-8073-40ae-93f3-5d1c1b309399
     status: 200 OK
     code: 200
     duration: ""
@@ -1197,27 +1158,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2866"
+      - "2893"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:29 GMT
+      - Wed, 21 Feb 2024 14:01:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1225,12 +1186,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6a980e7-f0ca-4fac-becd-73ed2e970ac0
+      - 7cd16193-2596-49a5-88f3-05ff8bc497e4
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"server":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688"}'
+    body: '{"server":"62423fc0-ff97-435d-9ed2-0ea41e02ac32"}'
     form: {}
     headers:
       Content-Type:
@@ -1238,21 +1199,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c0d3b27b-fc69-462a-9e2a-c71c5c0678b6
     method: PATCH
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.116.35","id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "381"
+      - "400"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:29 GMT
+      - Wed, 21 Feb 2024 14:01:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1260,7 +1221,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c691b48-c4f8-4c70-bb73-1420784fe725
+      - 1bb9e38b-3924-4f3c-a8a0-2c6b5068d4ad
     status: 200 OK
     code: 200
     duration: ""
@@ -1271,27 +1232,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:29 GMT
+      - Wed, 21 Feb 2024 14:01:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1299,7 +1260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3d7ba3a9-5e53-482f-ab5a-2b911d6bb870
+      - 9b1cdf9a-04a0-489e-8d46-cf5652301572
     status: 200 OK
     code: 200
     duration: ""
@@ -1310,27 +1271,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:30 GMT
+      - Wed, 21 Feb 2024 14:01:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1338,7 +1299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69a8b2db-778c-40de-a82d-303cb2587fc8
+      - 1c506518-0e98-4952-9868-7db39eb96e37
     status: 200 OK
     code: 200
     duration: ""
@@ -1349,27 +1310,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:30 GMT
+      - Wed, 21 Feb 2024 14:01:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1377,7 +1338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff181040-50e8-4d10-8818-388e148d11c9
+      - 93e47313-5f0c-45bd-b714-c7412ab44861
     status: 200 OK
     code: 200
     duration: ""
@@ -1388,7 +1349,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1400,9 +1361,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:30 GMT
+      - Wed, 21 Feb 2024 14:01:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1410,7 +1371,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a0f55846-6feb-4b0f-97ac-bce87d462ac1
+      - ca43fc0d-b32f-48a3-94ac-b66bda9ab96e
     status: 200 OK
     code: 200
     duration: ""
@@ -1421,7 +1382,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1433,12 +1394,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:30 GMT
+      - Wed, 21 Feb 2024 14:01:41 GMT
       Link:
-      - </servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics?page=0&per_page=50&>;
+      - </servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1446,7 +1407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76c09513-9dc8-4c54-9654-53b85aae2fc9
+      - 10450840-99db-45b3-a17d-1ce2bff3abc9
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1459,27 +1420,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:31 GMT
+      - Wed, 21 Feb 2024 14:01:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1487,7 +1448,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ade2fd2b-76bb-4a2d-99fb-9b36df500b88
+      - e6858109-6dda-4d5c-876b-87d5818dcf67
     status: 200 OK
     code: 200
     duration: ""
@@ -1498,27 +1459,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:31 GMT
+      - Wed, 21 Feb 2024 14:01:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1526,7 +1487,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abfc2449-f25f-4118-90ae-2a86c2e27bed
+      - c85c9bb9-2159-49a2-b4d3-3eedf03efd7f
     status: 200 OK
     code: 200
     duration: ""
@@ -1537,21 +1498,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c0d3b27b-fc69-462a-9e2a-c71c5c0678b6
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.116.35","id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "381"
+      - "400"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:31 GMT
+      - Wed, 21 Feb 2024 14:01:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1559,7 +1520,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc17fc3f-9ae5-4782-b313-e90dd4261877
+      - 8879e6ce-e7c5-4c72-a723-beac54cc0a1c
     status: 200 OK
     code: 200
     duration: ""
@@ -1570,21 +1531,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/392360b5-d951-45a3-b403-361589f27744
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c0d3b27b-fc69-462a-9e2a-c71c5c0678b6
     method: GET
   response:
-    body: '{"ip":{"address":"51.15.240.218","id":"392360b5-d951-45a3-b403-361589f27744","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.116.35","id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "400"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:32 GMT
+      - Wed, 21 Feb 2024 14:01:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1592,7 +1553,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24d09eb0-e579-414d-a0ac-92a2245b3a50
+      - b95d49af-b0bf-4fa9-86db-5f0f642f21ae
     status: 200 OK
     code: 200
     duration: ""
@@ -1603,21 +1564,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.143.186","id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "381"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:32 GMT
+      - Wed, 21 Feb 2024 14:01:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1625,7 +1586,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf6b7fd7-4be1-4d7c-b17b-f8e73662b0b5
+      - 53daebb2-9c6e-4d95-b364-ee6168131f63
     status: 200 OK
     code: 200
     duration: ""
@@ -1636,27 +1597,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:32 GMT
+      - Wed, 21 Feb 2024 14:01:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1664,7 +1625,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 483530a7-cda9-4eb2-8033-eb1dbd5578e8
+      - fc3d5e83-8eec-441a-9957-ad6e0dc308e3
     status: 200 OK
     code: 200
     duration: ""
@@ -1675,7 +1636,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1687,9 +1648,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:32 GMT
+      - Wed, 21 Feb 2024 14:01:45 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1697,7 +1658,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45f4aa7a-cc51-4072-89d2-bcbd927b402b
+      - fc710ab5-20c7-499d-9c6d-ddc4fca23d8d
     status: 200 OK
     code: 200
     duration: ""
@@ -1708,7 +1669,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1720,12 +1681,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:32 GMT
+      - Wed, 21 Feb 2024 14:01:45 GMT
       Link:
-      - </servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics?page=0&per_page=50&>;
+      - </servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1733,7 +1694,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1395b94a-7fe7-4479-a752-ba81c2c750a2
+      - c3db8b76-bfcd-4d45-9c0d-817ceecef222
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1746,21 +1707,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.143.186","id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "381"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:32 GMT
+      - Wed, 21 Feb 2024 14:01:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1768,7 +1729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7c362c9-86a6-4e8c-82d6-14845f29d217
+      - 47c9c8c2-08ac-4e0a-87d5-cd8418c8c619
     status: 200 OK
     code: 200
     duration: ""
@@ -1779,21 +1740,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/392360b5-d951-45a3-b403-361589f27744
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c0d3b27b-fc69-462a-9e2a-c71c5c0678b6
     method: GET
   response:
-    body: '{"ip":{"address":"51.15.240.218","id":"392360b5-d951-45a3-b403-361589f27744","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.116.35","id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"state":"attached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "400"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:32 GMT
+      - Wed, 21 Feb 2024 14:01:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1801,7 +1762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb91b1a3-944d-409b-a069-d601e18bbf13
+      - 56a62d32-a5c1-47bd-9112-8d98a6d360bf
     status: 200 OK
     code: 200
     duration: ""
@@ -1812,27 +1773,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:33 GMT
+      - Wed, 21 Feb 2024 14:01:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1840,7 +1801,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bee1267-e7b0-4f43-81d2-41fcbd4dcbe8
+      - d3ab77d2-17d7-4b70-b5d9-ffdeb7a28067
     status: 200 OK
     code: 200
     duration: ""
@@ -1851,7 +1812,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1863,9 +1824,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:33 GMT
+      - Wed, 21 Feb 2024 14:01:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1873,7 +1834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aa10b80b-870e-4506-8195-2112ed40999d
+      - 58c8c108-c105-4209-8d8d-7c3d215c0f5e
     status: 200 OK
     code: 200
     duration: ""
@@ -1884,7 +1845,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1896,12 +1857,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:33 GMT
+      - Wed, 21 Feb 2024 14:01:47 GMT
       Link:
-      - </servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics?page=0&per_page=50&>;
+      - </servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1909,7 +1870,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aea6fd6b-4dcd-4e0b-91eb-3c92939eeed6
+      - 6a20c204-6253-43de-9798-2224b78dd242
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1922,27 +1883,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:33 GMT
+      - Wed, 21 Feb 2024 14:01:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1950,7 +1911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0ef94a6e-353d-4eb8-a3e0-4039d4b01252
+      - fc85729c-92e5-48a6-8b0e-f0342b0e65e0
     status: 200 OK
     code: 200
     duration: ""
@@ -1961,27 +1922,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.70.246","dynamic":false,"family":"inet","gateway":null,"id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.116.35","dynamic":false,"family":"inet","gateway":null,"id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3274"
+      - "3327"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:34 GMT
+      - Wed, 21 Feb 2024 14:01:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1989,7 +1950,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7701750c-2c7d-4dca-9193-e41f690708d0
+      - e9c158ef-2094-4be6-8df7-84309c536a46
     status: 200 OK
     code: 200
     duration: ""
@@ -2002,21 +1963,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c0d3b27b-fc69-462a-9e2a-c71c5c0678b6
     method: PATCH
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.116.35","id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:34 GMT
+      - Wed, 21 Feb 2024 14:01:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2024,7 +1985,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a77bf57-8136-4c5b-8ffc-e248615f1971
+      - dd8e0c6a-bc95-489e-8f42-bc9f4c2d40a7
     status: 200 OK
     code: 200
     duration: ""
@@ -2035,27 +1996,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2866"
+      - "2885"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:34 GMT
+      - Wed, 21 Feb 2024 14:01:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2063,7 +2024,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3844a9f-940c-41be-b7c2-e58d42960e49
+      - 4cc433df-2d35-420a-b4d8-5dd72d51f0ee
     status: 200 OK
     code: 200
     duration: ""
@@ -2074,27 +2035,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2866"
+      - "2885"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:34 GMT
+      - Wed, 21 Feb 2024 14:01:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2102,7 +2063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0e83b3a-76ad-491f-a6fd-4f1108e71698
+      - 0ddd3e6d-4bb4-4c4a-b32a-11c8245b5970
     status: 200 OK
     code: 200
     duration: ""
@@ -2113,27 +2074,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2866"
+      - "2885"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:34 GMT
+      - Wed, 21 Feb 2024 14:01:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2141,7 +2102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12f1aae6-7b87-4102-8949-da290d2d80a6
+      - 7638a14b-5d98-4d06-97cb-1fe523539b81
     status: 200 OK
     code: 200
     duration: ""
@@ -2152,7 +2113,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2164,9 +2125,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:34 GMT
+      - Wed, 21 Feb 2024 14:01:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2174,7 +2135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2019c7ce-5d99-431c-945a-3f26d6c7fc32
+      - a2fb7d46-a180-40ad-8efb-88ffe51f60be
     status: 200 OK
     code: 200
     duration: ""
@@ -2185,7 +2146,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -2197,12 +2158,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:34 GMT
+      - Wed, 21 Feb 2024 14:01:51 GMT
       Link:
-      - </servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics?page=0&per_page=50&>;
+      - </servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2210,7 +2171,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c40013cd-bbde-441a-93ce-ef87b83bd743
+      - 1cb17970-25d2-4c9b-9ca6-63e40136c943
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -2223,27 +2184,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2866"
+      - "2885"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:35 GMT
+      - Wed, 21 Feb 2024 14:01:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2251,7 +2212,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34445668-b3d7-42b4-a503-9f0062666d19
+      - a220e740-31f2-4737-a37e-53a80c882d93
     status: 200 OK
     code: 200
     duration: ""
@@ -2262,27 +2223,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2866"
+      - "2885"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:35 GMT
+      - Wed, 21 Feb 2024 14:01:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2290,7 +2251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 711d3ccc-fc3b-4e60-9eb6-20c63421672f
+      - 6e907718-519f-4bfe-bac5-a30679e194da
     status: 200 OK
     code: 200
     duration: ""
@@ -2301,21 +2262,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c0d3b27b-fc69-462a-9e2a-c71c5c0678b6
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.116.35","id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:35 GMT
+      - Wed, 21 Feb 2024 14:01:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2323,7 +2284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3111c283-95a9-4149-843e-132e8ba08a9b
+      - 61ec569f-a318-483b-af42-54c5911281bf
     status: 200 OK
     code: 200
     duration: ""
@@ -2334,21 +2295,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/392360b5-d951-45a3-b403-361589f27744
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9
     method: GET
   response:
-    body: '{"ip":{"address":"51.15.240.218","id":"392360b5-d951-45a3-b403-361589f27744","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.143.186","id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:35 GMT
+      - Wed, 21 Feb 2024 14:01:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2356,7 +2317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44f2af25-7e0e-47d1-a51b-cee57a0ea909
+      - 74d19a5d-e543-4ab7-9272-d6633cfc8d2e
     status: 200 OK
     code: 200
     duration: ""
@@ -2367,27 +2328,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2866"
+      - "2885"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:36 GMT
+      - Wed, 21 Feb 2024 14:01:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2395,7 +2356,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b43bdb4-b9bc-40c2-acd4-e1547eb68e3b
+      - 2df46d9c-4939-405e-bd2d-8849b291a514
     status: 200 OK
     code: 200
     duration: ""
@@ -2406,7 +2367,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2418,9 +2379,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:36 GMT
+      - Wed, 21 Feb 2024 14:01:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2428,7 +2389,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e62b21e-7e27-45f6-8fc8-57d6ebc2011c
+      - 02c4be5d-d533-47b1-9426-bbaf807b1df4
     status: 200 OK
     code: 200
     duration: ""
@@ -2439,7 +2400,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -2451,12 +2412,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:36 GMT
+      - Wed, 21 Feb 2024 14:01:53 GMT
       Link:
-      - </servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics?page=0&per_page=50&>;
+      - </servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2464,7 +2425,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 164131f2-3097-407e-9ac0-08405bf8bba7
+      - 6c911e02-ea6c-4ff0-b400-14ec0188dccf
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -2477,21 +2438,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/392360b5-d951-45a3-b403-361589f27744
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9
     method: GET
   response:
-    body: '{"ip":{"address":"51.15.240.218","id":"392360b5-d951-45a3-b403-361589f27744","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.143.186","id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:36 GMT
+      - Wed, 21 Feb 2024 14:01:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2499,7 +2460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a349957-9754-42ed-9261-6038927318eb
+      - 2b9d57da-9519-4d62-9274-f70bdc133ef9
     status: 200 OK
     code: 200
     duration: ""
@@ -2510,60 +2471,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
-    method: GET
-  response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "306"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:31:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 949f4054-6ebd-44e0-94c5-d0492d64f9a7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2866"
+      - "2885"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:36 GMT
+      - Wed, 21 Feb 2024 14:01:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2571,7 +2499,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aed3704e-1a37-41e9-9853-94b5f2c21f2c
+      - 38dcbc2a-3aff-41cb-9909-889e9276eca6
     status: 200 OK
     code: 200
     duration: ""
@@ -2582,7 +2510,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c0d3b27b-fc69-462a-9e2a-c71c5c0678b6
+    method: GET
+  response:
+    body: '{"ip":{"address":"51.158.116.35","id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "323"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 21 Feb 2024 14:01:55 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d09c8a62-bae1-4a31-a5e3-1e221e1080cd
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2594,9 +2555,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:36 GMT
+      - Wed, 21 Feb 2024 14:01:55 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2604,7 +2565,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1388d089-2d74-4845-91f5-a739caa65398
+      - b0f1af6e-9a83-4b9d-bf24-6d4cd6645f1e
     status: 200 OK
     code: 200
     duration: ""
@@ -2615,7 +2576,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -2627,12 +2588,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:36 GMT
+      - Wed, 21 Feb 2024 14:01:55 GMT
       Link:
-      - </servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics?page=0&per_page=50&>;
+      - </servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2640,7 +2601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5aea5c60-1afa-417f-afac-e7ae82280f4b
+      - ab985104-dca6-413a-8837-2812fed919b4
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -2653,27 +2614,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:21.734654+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:23.922157+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2866"
+      - "2885"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:37 GMT
+      - Wed, 21 Feb 2024 14:01:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2681,7 +2642,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4da77a4-ac13-4664-b416-9698f45e6209
+      - bd3fbacd-47df-45a9-b878-8dde2d323b53
     status: 200 OK
     code: 200
     duration: ""
@@ -2694,27 +2655,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: PATCH
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:37.765962+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:56.561231+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":true,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":true,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3271"
+      - "3326"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:38 GMT
+      - Wed, 21 Feb 2024 14:01:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2722,7 +2683,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0400455-2987-4bba-a7b7-32c9fbe52c32
+      - eded0ffa-8ed1-4993-ad63-8a1e49d68294
     status: 200 OK
     code: 200
     duration: ""
@@ -2733,27 +2694,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:37.765962+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:56.561231+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":true,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":true,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3271"
+      - "3326"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:38 GMT
+      - Wed, 21 Feb 2024 14:01:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2761,7 +2722,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 629f0147-f4cc-4211-92df-cb80e17939f5
+      - fb08c100-2244-4600-a083-ffef5347aa8b
     status: 200 OK
     code: 200
     duration: ""
@@ -2772,27 +2733,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:37.765962+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:56.561231+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":true,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":true,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3271"
+      - "3326"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:38 GMT
+      - Wed, 21 Feb 2024 14:01:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2800,7 +2761,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d51b172d-6c23-4719-8125-b11bf055f4a9
+      - 484ca6b5-e1be-426a-96e7-c8628e485fae
     status: 200 OK
     code: 200
     duration: ""
@@ -2811,7 +2772,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2823,9 +2784,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:38 GMT
+      - Wed, 21 Feb 2024 14:01:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2833,7 +2794,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6be855f0-1f95-43de-82e0-7d523b766599
+      - 17ba018c-525c-41cd-a669-1b80ce5a8d33
     status: 200 OK
     code: 200
     duration: ""
@@ -2844,7 +2805,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -2856,12 +2817,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:38 GMT
+      - Wed, 21 Feb 2024 14:01:58 GMT
       Link:
-      - </servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics?page=0&per_page=50&>;
+      - </servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2869,7 +2830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ff595213-4842-48ff-9a7b-156986c24d9b
+      - dcac6a86-b73a-40ae-8f1c-c267eca785c0
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -2882,27 +2843,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:37.765962+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:56.561231+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":true,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":true,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3271"
+      - "3326"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:39 GMT
+      - Wed, 21 Feb 2024 14:01:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2910,7 +2871,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65a9dd95-c449-42fe-acf3-624e25f10d3a
+      - 2fb613ba-ac00-4be6-aea3-5e32fe69b3ad
     status: 200 OK
     code: 200
     duration: ""
@@ -2921,27 +2882,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:37.765962+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:56.561231+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":true,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":true,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3271"
+      - "3326"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:39 GMT
+      - Wed, 21 Feb 2024 14:01:58 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2949,7 +2910,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ca88309-fc90-4503-9bb5-6e35b173a9b3
+      - cbf396af-cecb-4807-b84e-88293d49df22
     status: 200 OK
     code: 200
     duration: ""
@@ -2960,21 +2921,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/392360b5-d951-45a3-b403-361589f27744
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9
     method: GET
   response:
-    body: '{"ip":{"address":"51.15.240.218","id":"392360b5-d951-45a3-b403-361589f27744","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.15.143.186","id":"05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:39 GMT
+      - Wed, 21 Feb 2024 14:01:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2982,7 +2943,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96cb21bf-140e-4377-9813-05602879cafa
+      - d3c6ab30-702d-4d2d-bcd2-dc6b075f41c3
     status: 200 OK
     code: 200
     duration: ""
@@ -2993,21 +2954,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c0d3b27b-fc69-462a-9e2a-c71c5c0678b6
     method: GET
   response:
-    body: '{"ip":{"address":"51.158.70.246","id":"4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f","organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
+    body: '{"ip":{"address":"51.158.116.35","id":"c0d3b27b-fc69-462a-9e2a-c71c5c0678b6","ipam_id":null,"organization":"105bdce1-64c0-48ab-899d-868455867ecf","prefix":null,"project":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":null,"server":null,"state":"detached","tags":[],"type":"nat","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "306"
+      - "323"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:39 GMT
+      - Wed, 21 Feb 2024 14:01:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3015,7 +2976,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c5c88e0-fa53-4cac-9da3-c8e0b49ca8a3
+      - 2bd8c59e-8fb9-4863-8066-dc272be5d222
     status: 200 OK
     code: 200
     duration: ""
@@ -3026,27 +2987,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:37.765962+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:56.561231+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":true,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":true,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3271"
+      - "3326"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:40 GMT
+      - Wed, 21 Feb 2024 14:01:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3054,7 +3015,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1969c90-5a29-4c0f-acab-7c7b5fc15adf
+      - 247b9943-3486-4d21-9e1c-39def4b65e2d
     status: 200 OK
     code: 200
     duration: ""
@@ -3065,7 +3026,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -3077,9 +3038,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:40 GMT
+      - Wed, 21 Feb 2024 14:01:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3087,7 +3048,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 125e4f9b-4220-4425-a067-d2af29e07c16
+      - 050c0b78-0acf-4a09-8f71-20dd359ed33b
     status: 200 OK
     code: 200
     duration: ""
@@ -3098,7 +3059,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -3110,12 +3071,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:40 GMT
+      - Wed, 21 Feb 2024 14:01:59 GMT
       Link:
-      - </servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/private_nics?page=0&per_page=50&>;
+      - </servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3123,7 +3084,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24fb8d00-09fd-43e2-97d2-43070aa62312
+      - c211137e-1167-4d37-84c3-7f59f91ddb56
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -3136,7 +3097,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/392360b5-d951-45a3-b403-361589f27744
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/05de83b9-dbd3-40d2-8f86-7b2e8f60d6e9
     method: DELETE
   response:
     body: ""
@@ -3144,9 +3105,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:31:40 GMT
+      - Wed, 21 Feb 2024 14:02:00 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3154,7 +3115,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07303357-413c-4c80-9fb8-99d166c2c9b3
+      - 2efc0073-53b4-434c-a022-14edc4af8ea9
     status: 204 No Content
     code: 204
     duration: ""
@@ -3165,7 +3126,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/4fa4e60f-f6cf-4c22-8fcb-bdd36821f33f
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/ips/c0d3b27b-fc69-462a-9e2a-c71c5c0678b6
     method: DELETE
   response:
     body: ""
@@ -3173,9 +3134,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:31:40 GMT
+      - Wed, 21 Feb 2024 14:02:00 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3183,7 +3144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2f8e721d-4a5b-437d-afc4-bc8d28d864e2
+      - 662b96b2-521f-40a3-95ee-45e3fd58da41
     status: 204 No Content
     code: 204
     duration: ""
@@ -3194,27 +3155,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:37.765962+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.15.215.100","dynamic":true,"family":"inet","gateway":null,"id":"4c16f5eb-f338-4fae-8f22-8b0d12d83ec7","netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:01:56.561231+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":{"address":"51.158.107.206","dynamic":true,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]},"public_ips":[{"address":"51.158.107.206","dynamic":true,"family":"inet","gateway":null,"id":"e1d5fc83-0d66-4437-bc70-799764b7457f","ipam_id":null,"netmask":"32","provisioning_mode":"dhcp","state":"attached","tags":[]}],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3271"
+      - "3326"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:40 GMT
+      - Wed, 21 Feb 2024 14:02:00 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3222,7 +3183,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f9d8434c-5bd9-4f65-b0da-c30d56581752
+      - 9630d66f-ebea-4efa-ba28-0bb600a71783
     status: 200 OK
     code: 200
     duration: ""
@@ -3235,10 +3196,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688/action","href_result":"/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688","id":"6545c469-28de-41d3-b8dc-a273ef8721e9","started_at":"2023-10-31T14:31:41.218657+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32/action","href_result":"/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32","id":"5df585ae-0248-423e-ac59-c67dd525a3bc","started_at":"2024-02-21T14:02:00.619498+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -3247,11 +3208,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:41 GMT
+      - Wed, 21 Feb 2024 14:02:00 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6545c469-28de-41d3-b8dc-a273ef8721e9
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/5df585ae-0248-423e-ac59-c67dd525a3bc
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3259,7 +3220,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a2a99c2-21e2-484d-9548-d006e4b0e1ab
+      - 566ee3af-3d40-4ba7-9891-e9211b9a10c0
     status: 202 Accepted
     code: 202
     duration: ""
@@ -3270,27 +3231,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:40.911738+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:02:00.432531+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2825"
+      - "2852"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:41 GMT
+      - Wed, 21 Feb 2024 14:02:01 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3298,7 +3259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09f15f3c-0b4f-4250-a35a-724db95755b6
+      - 664af586-3078-4a4f-a354-5b6c43ef5f43
     status: 200 OK
     code: 200
     duration: ""
@@ -3309,27 +3270,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:40.911738+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:02:00.432531+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2825"
+      - "2852"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:46 GMT
+      - Wed, 21 Feb 2024 14:02:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3337,7 +3298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a4e1f9f-41e6-448e-9385-2597c01ec21d
+      - dcc08fd9-57d6-4331-95e4-0d0299a833d9
     status: 200 OK
     code: 200
     duration: ""
@@ -3348,27 +3309,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:40.911738+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:02:00.432531+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2823"
+      - "2852"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:51 GMT
+      - Wed, 21 Feb 2024 14:02:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3376,7 +3337,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b2d4ab99-c991-47c7-a6d0-bd10f32a4a96
+      - 6e79b468-664f-4eeb-ba2d-a5b9fd4fb3c9
     status: 200 OK
     code: 200
     duration: ""
@@ -3387,27 +3348,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:40.911738+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:02:00.432531+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2823"
+      - "2852"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:57 GMT
+      - Wed, 21 Feb 2024 14:02:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3415,7 +3376,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2a5daca7-7f65-48cf-8f9e-241df9f7f91c
+      - 9c861a33-f82e-40a6-9b82-cadda4597bd5
     status: 200 OK
     code: 200
     duration: ""
@@ -3426,27 +3387,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:40.911738+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:02:00.432531+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2823"
+      - "2852"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:02 GMT
+      - Wed, 21 Feb 2024 14:02:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3454,7 +3415,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60acb53d-0029-4ae5-b914-f57305cc4bd5
+      - afff5c40-0538-4e10-94ef-fc41b6c5c14b
     status: 200 OK
     code: 200
     duration: ""
@@ -3465,27 +3426,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:40.911738+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:02:00.432531+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2823"
+      - "2852"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:07 GMT
+      - Wed, 21 Feb 2024 14:02:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3493,7 +3454,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e93eb87-8bee-41d7-bb97-e682b17dccf5
+      - 20abb8cf-6f37-4ab6-bd20-70703775f75c
     status: 200 OK
     code: 200
     duration: ""
@@ -3504,27 +3465,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:40.911738+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:02:00.432531+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2823"
+      - "2852"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:12 GMT
+      - Wed, 21 Feb 2024 14:02:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3532,7 +3493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 122ddbc5-0200-484a-99f4-1632cbc8a265
+      - 2e224a6b-4cc6-4784-b2ae-4d803c95c8b7
     status: 200 OK
     code: 200
     duration: ""
@@ -3543,27 +3504,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:40.911738+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"42","hypervisor_id":"702","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:02:00.432531+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.71.50.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2823"
+      - "2852"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:17 GMT
+      - Wed, 21 Feb 2024 14:02:44 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3571,7 +3532,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76c461fe-8622-4b84-8536-cc6b40bf02da
+      - 02dcdcc7-5dd7-4bbd-80d6-b6d156c2d3ff
     status: 200 OK
     code: 200
     duration: ""
@@ -3582,105 +3543,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:40.911738+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2823"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:32:22 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d4878887-cc74-4689-bdb1-9b4d81c2438e
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"34","hypervisor_id":"902","node_id":"43","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:31:40.911738+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.73.114.85","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"booted","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2823"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 31 Oct 2023 14:32:28 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2eea3e17-93de-4a1b-961a-b09598d14f42
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:32:30.172793+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:02:46.647838+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2703"
+      - "2731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:33 GMT
+      - Wed, 21 Feb 2024 14:02:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3688,7 +3571,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 15f2db4c-5dc1-48fc-962f-4e153038d9d4
+      - abbbfa7d-867c-4f28-bd9c-810efbda4399
     status: 200 OK
     code: 200
     duration: ""
@@ -3699,27 +3582,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.920376+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-fervent-rhodes","id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:0f","maintenances":[],"modification_date":"2023-10-31T14:32:30.172793+00:00","name":"tf-srv-fervent-rhodes","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.920376+00:00","export_uri":null,"id":"fff6d73b-a8c0-4921-9601-27f2cb2f4b77","modification_date":"2023-10-31T14:31:01.920376+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","name":"tf-srv-fervent-rhodes"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-21T14:01:07.576206+00:00","dynamic_ip_required":true,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-priceless-edison","id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:3f:e7:df","maintenances":[],"modification_date":"2024-02-21T14:02:46.647838+00:00","name":"tf-srv-priceless-edison","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":["terraform-test","scaleway_instance_server","reserved_ip"],"volumes":{"0":{"boot":false,"creation_date":"2024-02-21T14:01:07.576206+00:00","export_uri":null,"id":"f79f6d0d-f55a-4e94-afed-afbeaa699993","modification_date":"2024-02-21T14:01:07.576206+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","name":"tf-srv-priceless-edison"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2703"
+      - "2731"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:33 GMT
+      - Wed, 21 Feb 2024 14:02:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3727,7 +3610,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c95e0e42-8571-4692-9a08-19d1f2f8fa40
+      - d1601f26-1350-4454-8af4-87b17bcdd1d0
     status: 200 OK
     code: 200
     duration: ""
@@ -3738,7 +3621,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: DELETE
   response:
     body: ""
@@ -3746,9 +3629,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:32:33 GMT
+      - Wed, 21 Feb 2024 14:02:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3756,7 +3639,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 632918cb-b085-4e23-9204-b289cbce71a5
+      - 9d030215-2928-4b5a-ba30-7173bb5d32b3
     status: 204 No Content
     code: 204
     duration: ""
@@ -3767,10 +3650,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -3779,9 +3662,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:33 GMT
+      - Wed, 21 Feb 2024 14:02:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3789,7 +3672,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b2286b8-a9d4-4262-a586-d985ff77dfa9
+      - 7400d008-c6ec-40af-99ff-bf67e8627409
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3800,7 +3683,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/fff6d73b-a8c0-4921-9601-27f2cb2f4b77
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f79f6d0d-f55a-4e94-afed-afbeaa699993
     method: DELETE
   response:
     body: ""
@@ -3808,9 +3691,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:32:33 GMT
+      - Wed, 21 Feb 2024 14:02:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3818,7 +3701,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 022edabc-d6fd-4afa-801a-5318d876fca2
+      - 25614c9f-8c08-466e-928e-de7e9f9abdad
     status: 204 No Content
     code: 204
     duration: ""
@@ -3829,10 +3712,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/d2cd4c13-f1eb-4ffc-b032-4321ee32e688
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/62423fc0-ff97-435d-9ed2-0ea41e02ac32
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"d2cd4c13-f1eb-4ffc-b032-4321ee32e688","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"62423fc0-ff97-435d-9ed2-0ea41e02ac32","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -3841,9 +3724,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:33 GMT
+      - Wed, 21 Feb 2024 14:02:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-2;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3851,7 +3734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74efcb97-5b32-4e8b-9ad1-0dfabcb13525
+      - b09abc83-c1f4-4d1e-af6b-a16ed89e993c
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-snapshot-server-with-block-volume.cassette.yaml
+++ b/scaleway/testdata/instance-snapshot-server-with-block-volume.cassette.yaml
@@ -2,7 +2,7 @@
 version: 1
 interactions:
 - request:
-    body: '{"name":"tf-vol-reverent-perlman","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"b_ssd","size":10000000000}'
+    body: '{"name":"tf-vol-nice-minsky","project":"105bdce1-64c0-48ab-899d-868455867ecf","volume_type":"b_ssd","size":10000000000}'
     form: {}
     headers:
       Content-Type:
@@ -13,20 +13,20 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes
     method: POST
   response:
-    body: '{"volume":{"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:00.812510+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:02.443761+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "445"
+      - "440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:00 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0e400018-1aed-4a1c-b793-d7cc41c79406
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e8356aba-8766-4d11-8103-13e60483c316
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -34,7 +34,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d08e7361-3f09-4c71-ada5-2506d406aa7e
+      - 3a0e7ec6-48a6-44ac-aa18-a83cf14b746a
     status: 201 Created
     code: 201
     duration: ""
@@ -45,21 +45,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0e400018-1aed-4a1c-b793-d7cc41c79406
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e8356aba-8766-4d11-8103-13e60483c316
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:00.812510+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:02.443761+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "445"
+      - "440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:00 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -67,7 +67,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44e143a9-4a4c-4ebf-b868-aaad080840b1
+      - d02a5517-9c05-4878-8fba-63311dc717b2
     status: 200 OK
     code: 200
     duration: ""
@@ -78,21 +78,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0e400018-1aed-4a1c-b793-d7cc41c79406
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e8356aba-8766-4d11-8103-13e60483c316
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:00.812510+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:02.443761+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "445"
+      - "440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ca81bf45-4f63-4e46-a162-3a7725a63bc1
+      - 194cde10-7279-4734-8c46-62fd83ded7f5
     status: 200 OK
     code: 200
     duration: ""
@@ -114,18 +114,18 @@ interactions:
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"10b2d3c3-bfa7-42d4-910b-389e95f95ccb","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2f1f7a57-c508-4f72-9f7f-536b316f36e1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"5d083890-4354-47ab-b769-8b0de601eb3a","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1179"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -133,7 +133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8d2ea8c-741d-46f2-93ad-99889abc78a2
+      - f3b9099c-9736-46cc-8b26-04c489cabe9c
     status: 200 OK
     code: 200
     duration: ""
@@ -147,21 +147,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38421"
+      - "38183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -169,9 +169,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01fc48f7-984d-4109-922e-b975dfd712f6
+      - a6072957-d99c-4bd6-b3bd-ac79a8682b4b
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
@@ -185,21 +185,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4865"
+      - "8882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -207,9 +207,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cda6889e-4737-43d5-aec2-068b80d3802d
+      - e0a1350d-4ea1-470d-833f-616762c0727a
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
@@ -220,21 +220,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0e400018-1aed-4a1c-b793-d7cc41c79406
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e8356aba-8766-4d11-8103-13e60483c316
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:01.098674+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:02.443761+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "448"
+      - "440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -242,12 +242,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 449cb9d7-c6f4-4a92-b040-f1feb9433dff
+      - 2259e5e2-e138-4031-9608-dcda0cedf923
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-snap-busy-mestorf","volume_id":"0e400018-1aed-4a1c-b793-d7cc41c79406","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-snap-exciting-solomon","volume_id":"e8356aba-8766-4d11-8103-13e60483c316","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -258,18 +258,18 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","name":"tf-vol-reverent-perlman"},"creation_date":"2023-10-31T14:31:01.098674+00:00","error_details":null,"id":"913cfed6-26d6-4f75-b904-759064564d4d","modification_date":"2023-10-31T14:31:01.098674+00:00","name":"tf-snap-busy-mestorf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_913cfed6-26d6-4f75-b904-759064564d4d","href_from":"/snapshots","href_result":"snapshots/913cfed6-26d6-4f75-b904-759064564d4d","id":"f2ad681b-cd32-4c48-a887-dcf28ab3fddf","started_at":"2023-10-31T14:31:01.405584+00:00","status":"pending","terminated_at":null}}'
+    body: '{"snapshot":{"base_volume":{"id":"e8356aba-8766-4d11-8103-13e60483c316","name":"tf-vol-nice-minsky"},"creation_date":"2024-02-22T07:32:02.768971+00:00","error_details":null,"id":"d86f0507-d7f7-4707-a280-b48d273f1387","modification_date":"2024-02-22T07:32:02.768971+00:00","name":"tf-snap-exciting-solomon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_d86f0507-d7f7-4707-a280-b48d273f1387","href_from":"/snapshots","href_result":"snapshots/d86f0507-d7f7-4707-a280-b48d273f1387","id":"93d45961-cb18-4090-8c49-ec301292352e","started_at":"2024-02-22T07:32:03.091224+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
-      - "838"
+      - "837"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -277,7 +277,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ccb3b06c-e40c-4088-927c-1350f400fc96
+      - b97fb3a7-668b-42ff-a435-b8da325cf92c
     status: 201 Created
     code: 201
     duration: ""
@@ -288,21 +288,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/913cfed6-26d6-4f75-b904-759064564d4d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d86f0507-d7f7-4707-a280-b48d273f1387
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","name":"tf-vol-reverent-perlman"},"creation_date":"2023-10-31T14:31:01.098674+00:00","error_details":null,"id":"913cfed6-26d6-4f75-b904-759064564d4d","modification_date":"2023-10-31T14:31:01.098674+00:00","name":"tf-snap-busy-mestorf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"e8356aba-8766-4d11-8103-13e60483c316","name":"tf-vol-nice-minsky"},"creation_date":"2024-02-22T07:32:02.768971+00:00","error_details":null,"id":"d86f0507-d7f7-4707-a280-b48d273f1387","modification_date":"2024-02-22T07:32:02.768971+00:00","name":"tf-snap-exciting-solomon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "532"
+      - "531"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -310,12 +310,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86068a59-9678-43d7-9461-439cd48817a5
+      - 87feb46c-bf9f-40e3-8502-5bac0359c73d
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-charming-hodgkin","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","volumes":{"0":{"boot":false,"size":10000000000,"volume_type":"l_ssd"},"1":{"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","name":"tf-vol-reverent-perlman"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-srv-great-mirzakhani","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5d083890-4354-47ab-b769-8b0de601eb3a","volumes":{"0":{"boot":false,"size":10000000000,"volume_type":"l_ssd"},"1":{"id":"e8356aba-8766-4d11-8103-13e60483c316","name":"tf-vol-nice-minsky"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -328,24 +328,24 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:01.865561+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:03.113622+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3147"
+      - "3164"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:02 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -353,7 +353,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0907b29-9689-442c-8843-4163254396d2
+      - 6c6ae236-fe94-4500-a810-dc86e01c74e8
     status: 201 Created
     code: 201
     duration: ""
@@ -364,27 +364,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:01.865561+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:03.113622+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3147"
+      - "3164"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:02 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -392,7 +392,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09e9aab2-0f28-46e0-807f-f103dd066771
+      - 60faf6e3-7e44-48f2-8853-f84a7db2373d
     status: 200 OK
     code: 200
     duration: ""
@@ -403,27 +403,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":[],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:01.865561+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:03.113622+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3147"
+      - "3164"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:02 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -431,7 +431,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f60aed58-e112-4916-b238-c2bfc817c88a
+      - ad93764a-f4d8-4a94-9957-6f7d665305b5
     status: 200 OK
     code: 200
     duration: ""
@@ -442,21 +442,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0e400018-1aed-4a1c-b793-d7cc41c79406
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e8356aba-8766-4d11-8103-13e60483c316
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "525"
+      - "520"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:02 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -464,7 +464,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37cc2ea1-85a8-419f-975e-35f1284ac259
+      - b1d65512-fcc7-489e-b635-248db7273634
     status: 200 OK
     code: 200
     duration: ""
@@ -475,21 +475,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/913cfed6-26d6-4f75-b904-759064564d4d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d86f0507-d7f7-4707-a280-b48d273f1387
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","name":"tf-vol-reverent-perlman"},"creation_date":"2023-10-31T14:31:01.098674+00:00","error_details":null,"id":"913cfed6-26d6-4f75-b904-759064564d4d","modification_date":"2023-10-31T14:31:01.098674+00:00","name":"tf-snap-busy-mestorf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"e8356aba-8766-4d11-8103-13e60483c316","name":"tf-vol-nice-minsky"},"creation_date":"2024-02-22T07:32:02.768971+00:00","error_details":null,"id":"d86f0507-d7f7-4707-a280-b48d273f1387","modification_date":"2024-02-22T07:32:02.768971+00:00","name":"tf-snap-exciting-solomon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "532"
+      - "531"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:06 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -497,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67fad598-0a28-4350-9499-c07ebfb7a3ce
+      - 886b2388-fa0d-4bdd-b188-f49617501578
     status: 200 OK
     code: 200
     duration: ""
@@ -508,21 +508,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0e400018-1aed-4a1c-b793-d7cc41c79406
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e8356aba-8766-4d11-8103-13e60483c316
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"snapshotting","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "525"
+      - "520"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:07 GMT
+      - Thu, 22 Feb 2024 07:32:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -530,7 +530,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7257b312-00d7-4d28-bc89-f2daf894a288
+      - 9a0a1f32-1a26-44fa-a096-debd19793aac
     status: 200 OK
     code: 200
     duration: ""
@@ -541,21 +541,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/913cfed6-26d6-4f75-b904-759064564d4d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d86f0507-d7f7-4707-a280-b48d273f1387
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","name":"tf-vol-reverent-perlman"},"creation_date":"2023-10-31T14:31:01.098674+00:00","error_details":null,"id":"913cfed6-26d6-4f75-b904-759064564d4d","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-snap-busy-mestorf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"e8356aba-8766-4d11-8103-13e60483c316","name":"tf-vol-nice-minsky"},"creation_date":"2024-02-22T07:32:02.768971+00:00","error_details":null,"id":"d86f0507-d7f7-4707-a280-b48d273f1387","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-snap-exciting-solomon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "529"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:11 GMT
+      - Thu, 22 Feb 2024 07:32:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -563,7 +563,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8e7873f-9fbf-4579-8478-9648a59ac14f
+      - 9506d4bc-7e19-4664-861f-10532bcb1c2c
     status: 200 OK
     code: 200
     duration: ""
@@ -574,21 +574,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/913cfed6-26d6-4f75-b904-759064564d4d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d86f0507-d7f7-4707-a280-b48d273f1387
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","name":"tf-vol-reverent-perlman"},"creation_date":"2023-10-31T14:31:01.098674+00:00","error_details":null,"id":"913cfed6-26d6-4f75-b904-759064564d4d","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-snap-busy-mestorf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"e8356aba-8766-4d11-8103-13e60483c316","name":"tf-vol-nice-minsky"},"creation_date":"2024-02-22T07:32:02.768971+00:00","error_details":null,"id":"d86f0507-d7f7-4707-a280-b48d273f1387","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-snap-exciting-solomon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "529"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:11 GMT
+      - Thu, 22 Feb 2024 07:32:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -596,7 +596,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b8dbd009-c2b0-44e8-beda-e603c03bdb3a
+      - 034af986-bead-48b0-b016-bb72e6640a2f
     status: 200 OK
     code: 200
     duration: ""
@@ -607,21 +607,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0e400018-1aed-4a1c-b793-d7cc41c79406
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e8356aba-8766-4d11-8103-13e60483c316
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "522"
+      - "517"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:12 GMT
+      - Thu, 22 Feb 2024 07:32:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -629,7 +629,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7527aaa0-ff68-4412-9c8d-428af2798b6c
+      - 3debb663-7bee-4a48-9003-ac0f9da9bf42
     status: 200 OK
     code: 200
     duration: ""
@@ -642,10 +642,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee/action","href_result":"/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee","id":"ae84e306-bd8b-4b68-85a4-9f736d998cac","started_at":"2023-10-31T14:31:13.059172+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3/action","href_result":"/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3","id":"d94943fd-bded-4144-a752-b182a18e1ab3","started_at":"2024-02-22T07:32:15.134991+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -654,11 +654,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:13 GMT
+      - Thu, 22 Feb 2024 07:32:15 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/ae84e306-bd8b-4b68-85a4-9f736d998cac
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/d94943fd-bded-4144-a752-b182a18e1ab3
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -666,7 +666,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8714f3f1-ce55-4a1c-94c4-9b746bad187a
+      - edac057c-60ba-4d3d-bcb8-827c418c28af
     status: 202 Accepted
     code: 202
     duration: ""
@@ -677,27 +677,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:12.745161+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:14.716757+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3205"
+      - "3222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:13 GMT
+      - Thu, 22 Feb 2024 07:32:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -705,7 +705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4696a610-0af3-47ed-acea-c2b6776078a9
+      - f5ac8b17-47c4-4bca-90e4-b3caccdee73b
     status: 200 OK
     code: 200
     duration: ""
@@ -716,27 +716,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:12.745161+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:14.716757+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3314"
+      - "3222"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:18 GMT
+      - Thu, 22 Feb 2024 07:32:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -744,7 +744,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e06ac0d2-3859-4dc7-971c-945915e4f80a
+      - 8a625e50-052f-4437-96ae-7c39e11919b2
     status: 200 OK
     code: 200
     duration: ""
@@ -755,27 +755,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:12.745161+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:14.716757+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3314"
+      - "3329"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:23 GMT
+      - Thu, 22 Feb 2024 07:32:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -783,7 +783,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18611090-620d-40bc-bbde-9ee500fd2360
+      - 6b916419-be06-49c1-84f9-d2482fd28591
     status: 200 OK
     code: 200
     duration: ""
@@ -794,27 +794,66 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:14.716757+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3329"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6dfed078-1d29-4d5b-a456-5fd88fc434d6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:26.741047+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:33.282539+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3345"
+      - "3360"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:29 GMT
+      - Thu, 22 Feb 2024 07:32:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -822,7 +861,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c7f802d1-44de-4d86-9c60-0426823d4f49
+      - bf4121c2-1ef2-4cee-8d62-5d19a326b358
     status: 200 OK
     code: 200
     duration: ""
@@ -833,27 +872,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:26.741047+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:33.282539+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3345"
+      - "3360"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:29 GMT
+      - Thu, 22 Feb 2024 07:32:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -861,7 +900,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29a1a22d-ef00-4d2d-b2d7-74f6da263c72
+      - 9ce58610-1569-4da6-b7da-36a3d439bb07
     status: 200 OK
     code: 200
     duration: ""
@@ -872,7 +911,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -884,9 +923,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:29 GMT
+      - Thu, 22 Feb 2024 07:32:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -894,7 +933,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e38ee798-085b-4d0e-840e-0a7fb0e3b676
+      - 61defcf5-24fc-43cf-9144-b4b93070e2aa
     status: 200 OK
     code: 200
     duration: ""
@@ -905,7 +944,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -917,12 +956,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:29 GMT
+      - Thu, 22 Feb 2024 07:32:36 GMT
       Link:
-      - </servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee/private_nics?page=0&per_page=50&>;
+      - </servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -930,7 +969,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e208fd53-bd6f-475f-8d45-7b5b5700f35b
+      - d0939270-c416-489f-9da2-cbae51efa8b5
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -943,21 +982,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/913cfed6-26d6-4f75-b904-759064564d4d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d86f0507-d7f7-4707-a280-b48d273f1387
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","name":"tf-vol-reverent-perlman"},"creation_date":"2023-10-31T14:31:01.098674+00:00","error_details":null,"id":"913cfed6-26d6-4f75-b904-759064564d4d","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-snap-busy-mestorf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"e8356aba-8766-4d11-8103-13e60483c316","name":"tf-vol-nice-minsky"},"creation_date":"2024-02-22T07:32:02.768971+00:00","error_details":null,"id":"d86f0507-d7f7-4707-a280-b48d273f1387","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-snap-exciting-solomon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "529"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:29 GMT
+      - Thu, 22 Feb 2024 07:32:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -965,7 +1004,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fc8333b-4209-4ae9-bb92-6365b02eb3ba
+      - d950b6ea-9059-4a2e-afb2-27ce8c22e68c
     status: 200 OK
     code: 200
     duration: ""
@@ -976,21 +1015,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0e400018-1aed-4a1c-b793-d7cc41c79406
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e8356aba-8766-4d11-8103-13e60483c316
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "522"
+      - "517"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:30 GMT
+      - Thu, 22 Feb 2024 07:32:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -998,7 +1037,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1cf83743-2bd3-40b8-be6b-8a49e1cd45dc
+      - d194594d-5cf6-47a8-877a-772c3ccb2bab
     status: 200 OK
     code: 200
     duration: ""
@@ -1009,21 +1048,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/913cfed6-26d6-4f75-b904-759064564d4d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d86f0507-d7f7-4707-a280-b48d273f1387
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","name":"tf-vol-reverent-perlman"},"creation_date":"2023-10-31T14:31:01.098674+00:00","error_details":null,"id":"913cfed6-26d6-4f75-b904-759064564d4d","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-snap-busy-mestorf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"e8356aba-8766-4d11-8103-13e60483c316","name":"tf-vol-nice-minsky"},"creation_date":"2024-02-22T07:32:02.768971+00:00","error_details":null,"id":"d86f0507-d7f7-4707-a280-b48d273f1387","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-snap-exciting-solomon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "529"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:30 GMT
+      - Thu, 22 Feb 2024 07:32:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1031,7 +1070,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 837c0561-adcd-4f78-b7d8-b4c334f07149
+      - 9dce0ef3-2115-4ed4-8fae-793a3985c9be
     status: 200 OK
     code: 200
     duration: ""
@@ -1042,27 +1081,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:26.741047+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:33.282539+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3345"
+      - "3360"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:31 GMT
+      - Thu, 22 Feb 2024 07:32:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1070,7 +1109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9504b8c-a90b-4e5f-95a2-9649d44d3942
+      - 22915b18-f8b1-49a7-9507-3aff0564284a
     status: 200 OK
     code: 200
     duration: ""
@@ -1081,7 +1120,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1093,9 +1132,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:31 GMT
+      - Thu, 22 Feb 2024 07:32:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1103,7 +1142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 892c881f-0080-4b07-a2ee-985acb875db9
+      - 358a0cf5-012a-4273-823b-e81b0999114d
     status: 200 OK
     code: 200
     duration: ""
@@ -1114,7 +1153,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -1126,12 +1165,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:31 GMT
+      - Thu, 22 Feb 2024 07:32:37 GMT
       Link:
-      - </servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee/private_nics?page=0&per_page=50&>;
+      - </servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1139,7 +1178,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84653e9a-f691-475a-85ef-52eb529bd3f2
+      - 9d77601e-4255-4ce8-ae65-475d1bd63e26
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -1152,21 +1191,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/913cfed6-26d6-4f75-b904-759064564d4d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d86f0507-d7f7-4707-a280-b48d273f1387
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","name":"tf-vol-reverent-perlman"},"creation_date":"2023-10-31T14:31:01.098674+00:00","error_details":null,"id":"913cfed6-26d6-4f75-b904-759064564d4d","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-snap-busy-mestorf","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"e8356aba-8766-4d11-8103-13e60483c316","name":"tf-vol-nice-minsky"},"creation_date":"2024-02-22T07:32:02.768971+00:00","error_details":null,"id":"d86f0507-d7f7-4707-a280-b48d273f1387","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-snap-exciting-solomon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "529"
+      - "528"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:31 GMT
+      - Thu, 22 Feb 2024 07:32:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1174,7 +1213,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1a11dbcb-2770-4192-9adf-1ab362c4b5f1
+      - 2f07a9f4-69a3-47e2-b372-6ee9fc4e40f2
     status: 200 OK
     code: 200
     duration: ""
@@ -1185,27 +1224,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:26.741047+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:33.282539+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3345"
+      - "3360"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:31 GMT
+      - Thu, 22 Feb 2024 07:32:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1213,7 +1252,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09aa750d-997a-432f-b349-046e4b41ab71
+      - 03de103c-5456-48c4-b254-abe5e24c26dd
     status: 200 OK
     code: 200
     duration: ""
@@ -1224,7 +1263,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/913cfed6-26d6-4f75-b904-759064564d4d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d86f0507-d7f7-4707-a280-b48d273f1387
     method: DELETE
   response:
     body: ""
@@ -1232,9 +1271,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:31:31 GMT
+      - Thu, 22 Feb 2024 07:32:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1242,7 +1281,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5bc3c05a-f4c4-45a2-969b-50f3280bdd76
+      - c040c600-3c71-4bc9-bf12-f043d50209d5
     status: 204 No Content
     code: 204
     duration: ""
@@ -1253,10 +1292,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/913cfed6-26d6-4f75-b904-759064564d4d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d86f0507-d7f7-4707-a280-b48d273f1387
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"913cfed6-26d6-4f75-b904-759064564d4d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"d86f0507-d7f7-4707-a280-b48d273f1387","type":"not_found"}'
     headers:
       Content-Length:
       - "145"
@@ -1265,9 +1304,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:31 GMT
+      - Thu, 22 Feb 2024 07:32:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1275,7 +1314,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5c35580-01e4-41e7-9a03-3b47c0987031
+      - 9b295436-d06b-46c2-a451-e8b3aea117ba
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1288,10 +1327,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee/action","href_result":"/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee","id":"f95f31bf-f55a-4260-9c10-fdc99a8267d4","started_at":"2023-10-31T14:31:32.244797+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3/action","href_result":"/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3","id":"ded8b8e0-ef7a-465a-8372-f4d23d6f3598","started_at":"2024-02-22T07:32:38.448765+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -1300,11 +1339,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:32 GMT
+      - Thu, 22 Feb 2024 07:32:38 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/f95f31bf-f55a-4260-9c10-fdc99a8267d4
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/ded8b8e0-ef7a-465a-8372-f4d23d6f3598
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1312,7 +1351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 499b547e-f331-479f-b804-bc452521938f
+      - d2481e7b-8980-4576-ad95-8107782bd6cb
     status: 202 Accepted
     code: 202
     duration: ""
@@ -1323,27 +1362,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:31.936017+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:38.290070+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3305"
+      - "3320"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:32 GMT
+      - Thu, 22 Feb 2024 07:32:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1351,7 +1390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ceb8b9b-c5e1-4606-a25b-ccf9d1240ed3
+      - 51cd6b2c-366e-47b0-a9de-2b12558de42c
     status: 200 OK
     code: 200
     duration: ""
@@ -1362,27 +1401,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:31.936017+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:38.290070+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3305"
+      - "3320"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:37 GMT
+      - Thu, 22 Feb 2024 07:32:43 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1390,7 +1429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc1e4d99-fd7c-414b-bd05-df11194082e0
+      - 1e1299af-0e77-4950-985b-4530e4ddf5d4
     status: 200 OK
     code: 200
     duration: ""
@@ -1401,27 +1440,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:31.936017+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:38.290070+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3305"
+      - "3320"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:42 GMT
+      - Thu, 22 Feb 2024 07:32:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1429,7 +1468,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8de5d365-0ad4-4e97-9a05-0f9ba12b28b5
+      - 888df15c-098b-4c10-a28c-bf7ea40e4557
     status: 200 OK
     code: 200
     duration: ""
@@ -1440,27 +1479,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:31.936017+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:38.290070+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3305"
+      - "3318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:47 GMT
+      - Thu, 22 Feb 2024 07:32:54 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1468,7 +1507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0dd353a0-e969-4616-9074-62eb0fe75534
+      - 49e95dcd-5548-455c-9560-98e018a1b10d
     status: 200 OK
     code: 200
     duration: ""
@@ -1479,27 +1518,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:31.936017+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:38.290070+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3303"
+      - "3318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:53 GMT
+      - Thu, 22 Feb 2024 07:32:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1507,7 +1546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba270b9a-d0de-492a-b46c-2ff24ed5fba0
+      - 28a9074d-020f-48cc-a408-cf40bd7c2e5c
     status: 200 OK
     code: 200
     duration: ""
@@ -1518,27 +1557,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:31.936017+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:38.290070+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3303"
+      - "3318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:58 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1546,7 +1585,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1679f18-09de-4342-a24b-2e4cbf3ff01a
+      - 969e0bbb-e88d-4364-b905-76c429ce6076
     status: 200 OK
     code: 200
     duration: ""
@@ -1557,27 +1596,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:31.936017+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:38.290070+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3303"
+      - "3318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:03 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1585,7 +1624,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a47cb85-5ff0-4c2b-9456-f3d61571290d
+      - a0b2ed90-6b05-41b6-9128-d48f07cea133
     status: 200 OK
     code: 200
     duration: ""
@@ -1596,27 +1635,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:31.936017+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:38.290070+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3303"
+      - "3318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:09 GMT
+      - Thu, 22 Feb 2024 07:33:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1624,7 +1663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2203d54f-320a-4b91-acb8-aa57e937de41
+      - f4bc7a0d-ed38-44aa-a139-7aa4a998397b
     status: 200 OK
     code: 200
     duration: ""
@@ -1635,27 +1674,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:31.936017+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:38.290070+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3303"
+      - "3318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:14 GMT
+      - Thu, 22 Feb 2024 07:33:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1663,7 +1702,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03a656c6-2e4e-4ba0-9c03-089a0202bacb
+      - 8214ed41-76fe-4a8e-9953-2bb806dac0d8
     status: 200 OK
     code: 200
     duration: ""
@@ -1674,27 +1713,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1601","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:31:31.936017+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.65.44.31","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"93","hypervisor_id":"704","node_id":"6","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:32:38.290070+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.76.54.11","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3303"
+      - "3318"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:19 GMT
+      - Thu, 22 Feb 2024 07:33:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1702,7 +1741,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8de3386-eec1-4161-b111-bab2728b730d
+      - d4faa115-20a9-4f5b-916a-311b1c8e090c
     status: 200 OK
     code: 200
     duration: ""
@@ -1713,27 +1752,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:32:22.256342+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:33:28.477743+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3183"
+      - "3200"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:25 GMT
+      - Thu, 22 Feb 2024 07:33:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1741,7 +1780,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c38ee7e-c607-419f-aeba-7a205b270cdf
+      - e3c115be-1c3f-45d9-8f7b-e130db0a3fa7
     status: 200 OK
     code: 200
     duration: ""
@@ -1752,27 +1791,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.865561+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-charming-hodgkin","id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:0b","maintenances":[],"modification_date":"2023-10-31T14:32:22.256342+00:00","name":"tf-srv-charming-hodgkin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.865561+00:00","export_uri":null,"id":"a7d872ef-5df4-4b30-81ef-3b1ff66ed26c","modification_date":"2023-10-31T14:31:01.865561+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:31:10.640269+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","name":"tf-srv-charming-hodgkin"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.113622+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-great-mirzakhani","id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:ab","maintenances":[],"modification_date":"2024-02-22T07:33:28.477743+00:00","name":"tf-srv-great-mirzakhani","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.113622+00:00","export_uri":null,"id":"32fb89f3-550b-4c21-afd0-d64bb392f3c3","modification_date":"2024-02-22T07:32:03.113622+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"1":{"boot":false,"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:32:10.269110+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","name":"tf-srv-great-mirzakhani"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3183"
+      - "3200"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:25 GMT
+      - Thu, 22 Feb 2024 07:33:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1780,7 +1819,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42ad86d1-6b00-45f7-bd9d-99ae4a6c7b21
+      - 3c9cd939-9ace-4821-8843-71e90d407fd5
     status: 200 OK
     code: 200
     duration: ""
@@ -1791,7 +1830,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: DELETE
   response:
     body: ""
@@ -1799,9 +1838,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:32:25 GMT
+      - Thu, 22 Feb 2024 07:33:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1809,7 +1848,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 420c363d-bc6a-4a42-a9e8-05268143825d
+      - ebcb021f-7c05-4594-a11a-6fd43e9778e8
     status: 204 No Content
     code: 204
     duration: ""
@@ -1820,10 +1859,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -1832,9 +1871,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:25 GMT
+      - Thu, 22 Feb 2024 07:33:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1842,7 +1881,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9f4e507a-3af5-47d4-adf7-e844f6aaf0ed
+      - 2d28112b-4a15-4455-af23-016fc8714b3c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1853,7 +1892,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/a7d872ef-5df4-4b30-81ef-3b1ff66ed26c
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/32fb89f3-550b-4c21-afd0-d64bb392f3c3
     method: DELETE
   response:
     body: ""
@@ -1861,9 +1900,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:32:25 GMT
+      - Thu, 22 Feb 2024 07:33:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1871,7 +1910,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 135964c7-ed10-4087-ba3e-bb0630277c6d
+      - 5c185b51-28a8-4772-b98c-7bada020c51f
     status: 204 No Content
     code: 204
     duration: ""
@@ -1882,21 +1921,21 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0e400018-1aed-4a1c-b793-d7cc41c79406
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e8356aba-8766-4d11-8103-13e60483c316
     method: GET
   response:
-    body: '{"volume":{"creation_date":"2023-10-31T14:31:00.812510+00:00","export_uri":null,"id":"0e400018-1aed-4a1c-b793-d7cc41c79406","modification_date":"2023-10-31T14:32:25.287645+00:00","name":"tf-vol-reverent-perlman","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
+    body: '{"volume":{"creation_date":"2024-02-22T07:32:02.443761+00:00","export_uri":null,"id":"e8356aba-8766-4d11-8103-13e60483c316","modification_date":"2024-02-22T07:33:30.633426+00:00","name":"tf-vol-nice-minsky","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":null,"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "445"
+      - "440"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:25 GMT
+      - Thu, 22 Feb 2024 07:33:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1904,7 +1943,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11bbbf4d-ad00-4a59-b8ba-e096ddde17bf
+      - b98ae2d8-c070-4e46-a2a8-3b17a2efd493
     status: 200 OK
     code: 200
     duration: ""
@@ -1915,7 +1954,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0e400018-1aed-4a1c-b793-d7cc41c79406
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e8356aba-8766-4d11-8103-13e60483c316
     method: DELETE
   response:
     body: ""
@@ -1923,9 +1962,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:32:25 GMT
+      - Thu, 22 Feb 2024 07:33:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1933,7 +1972,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e1af5d0-4609-4d9d-847b-a6b2c213faf5
+      - 8a7e5e68-9f5f-4651-a9bb-a0a82139b9ea
     status: 204 No Content
     code: 204
     duration: ""
@@ -1944,10 +1983,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0e400018-1aed-4a1c-b793-d7cc41c79406
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/e8356aba-8766-4d11-8103-13e60483c316
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"0e400018-1aed-4a1c-b793-d7cc41c79406","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_volume","resource_id":"e8356aba-8766-4d11-8103-13e60483c316","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -1956,9 +1995,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:25 GMT
+      - Thu, 22 Feb 2024 07:33:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1966,7 +2005,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f679742f-d5e8-4689-8d47-11ec2e9e30f6
+      - bc97284f-17ac-4493-abe9-18416e0e6802
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1977,10 +2016,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/3436eb5c-2646-4a3f-831e-ab0297aa70ee
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1ee52f61-4acc-44fa-8aee-fdef968a4aa3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"3436eb5c-2646-4a3f-831e-ab0297aa70ee","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"1ee52f61-4acc-44fa-8aee-fdef968a4aa3","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -1989,9 +2028,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:26 GMT
+      - Thu, 22 Feb 2024 07:33:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1999,7 +2038,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3db4eccc-a75c-466e-8ab2-7f168739f7e3
+      - 85d39c0a-c512-48f0-adfc-e3aec38fd7d4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2010,10 +2049,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/913cfed6-26d6-4f75-b904-759064564d4d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d86f0507-d7f7-4707-a280-b48d273f1387
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"913cfed6-26d6-4f75-b904-759064564d4d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"d86f0507-d7f7-4707-a280-b48d273f1387","type":"not_found"}'
     headers:
       Content-Length:
       - "145"
@@ -2022,9 +2061,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:26 GMT
+      - Thu, 22 Feb 2024 07:33:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2032,7 +2071,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aed73cda-aa51-4cd8-ba11-2cfe6de3d197
+      - 4cfc67a1-188c-43bf-b79a-9773d6dd15fe
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/instance-snapshot-server.cassette.yaml
+++ b/scaleway/testdata/instance-snapshot-server.cassette.yaml
@@ -11,18 +11,18 @@ interactions:
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"10b2d3c3-bfa7-42d4-910b-389e95f95ccb","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2f1f7a57-c508-4f72-9f7f-536b316f36e1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"5d083890-4354-47ab-b769-8b0de601eb3a","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1179"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:00 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -30,7 +30,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 527003ef-dbec-4cf1-a4cf-a458da6263eb
+      - 12300fb6-17bc-4310-8e10-3b2d5e1c3be5
     status: 200 OK
     code: 200
     duration: ""
@@ -44,21 +44,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38421"
+      - "38183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:00 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -66,9 +66,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7fcea70-6b40-4741-a86a-fd7ba3e4abad
+      - b49af3b7-15a4-44b2-81bf-747db41f5619
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
@@ -82,21 +82,21 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4865"
+      - "8882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:00 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -104,14 +104,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1af13a1a-b806-44a6-b68f-572db1085c0c
+      - 578f4804-fe45-432e-b098-4ca6ffb30107
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-lucid-cannon","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-srv-vigilant-bell","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5d083890-4354-47ab-b769-8b0de601eb3a","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -124,24 +124,24 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:01.157301+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:01.157301+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:02.693365+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:02.693365+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2639"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -149,7 +149,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c01ad837-b1a1-498f-b182-9d1056eee046
+      - c390d64e-0c28-4f3a-8a0e-92042cbea1cd
     status: 201 Created
     code: 201
     duration: ""
@@ -160,27 +160,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:01.157301+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:01.157301+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:02.693365+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:02.693365+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2639"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -188,7 +188,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 29656064-510f-4580-afb1-5dd23f8f3246
+      - 07c16e71-9a1c-4a29-84ac-d45bb2291296
     status: 200 OK
     code: 200
     duration: ""
@@ -199,27 +199,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:01.157301+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:01.157301+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:02.693365+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:02.693365+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2639"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:01 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -227,7 +227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73642158-aaca-42f4-88d2-732bf6cc8c12
+      - 139ee41e-08d6-4beb-9eb9-2b3f69504200
     status: 200 OK
     code: 200
     duration: ""
@@ -240,10 +240,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/0141521a-5a65-461a-82be-a0344451af9a/action","href_result":"/servers/0141521a-5a65-461a-82be-a0344451af9a","id":"67b4c71e-6d05-4c04-8ed1-26f06464cae9","started_at":"2023-10-31T14:31:02.088350+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b/action","href_result":"/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b","id":"c484208f-4cf4-40da-9a4e-dd959172aa40","started_at":"2024-02-22T07:32:03.707954+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -252,11 +252,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:02 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/67b4c71e-6d05-4c04-8ed1-26f06464cae9
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/c484208f-4cf4-40da-9a4e-dd959172aa40
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -264,7 +264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e4b0836-c0e8-465b-b78b-954385a1d2d6
+      - 3e125123-9120-4741-b96c-75ad0b1e0b6e
     status: 202 Accepted
     code: 202
     duration: ""
@@ -275,27 +275,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:01.800002+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:01.157301+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:03.483334+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:02.693365+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2661"
+      - "2686"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:02 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -303,7 +303,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7c843db-36b4-4b03-b34a-9a7dab25051e
+      - 5892ba34-53ea-4e0a-8a06-576202013341
     status: 200 OK
     code: 200
     duration: ""
@@ -314,27 +314,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"2002","node_id":"33","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:01.800002+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.158.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:01.157301+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:03.483334+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:02.693365+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2771"
+      - "2792"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:07 GMT
+      - Thu, 22 Feb 2024 07:32:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -342,7 +342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40c9a492-32d3-4c0f-afb3-13ae8aeb82d8
+      - f0d80da3-ef3a-4ed1-8fdf-6affe74a3d86
     status: 200 OK
     code: 200
     duration: ""
@@ -353,27 +353,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"2002","node_id":"33","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:01.800002+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.158.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:01.157301+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:03.483334+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:02.693365+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2771"
+      - "2792"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:12 GMT
+      - Thu, 22 Feb 2024 07:32:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -381,7 +381,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b1f087e7-5a3a-4ee4-bd1e-a3531046f8f1
+      - 775ee66e-cb3a-47d8-8ab1-7af3a2d17b71
     status: 200 OK
     code: 200
     duration: ""
@@ -392,27 +392,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"2002","node_id":"33","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:01.800002+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.158.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:01.157301+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:03.483334+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:02.693365+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2771"
+      - "2792"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:17 GMT
+      - Thu, 22 Feb 2024 07:32:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -420,7 +420,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e7fb7666-48fd-4780-93d2-676a9bbe17db
+      - c348328d-56c6-4e3d-ab90-4517821c2e26
     status: 200 OK
     code: 200
     duration: ""
@@ -431,27 +431,66 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:03.483334+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:02.693365+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2792"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:24 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c6dd701a-5a91-4303-b093-1a1d8ea50e56
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"2002","node_id":"33","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:21.630626+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.158.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:01.157301+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:25.766494+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:02.693365+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2802"
+      - "2823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:23 GMT
+      - Thu, 22 Feb 2024 07:32:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -459,7 +498,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04754efb-b776-4685-a07a-40d24e2bfd4d
+      - f5f51a3b-8462-4100-a261-3d3dec5c27a3
     status: 200 OK
     code: 200
     duration: ""
@@ -470,27 +509,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"2002","node_id":"33","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:21.630626+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.158.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:01.157301+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:25.766494+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:02.693365+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2802"
+      - "2823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:24 GMT
+      - Thu, 22 Feb 2024 07:32:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -498,7 +537,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec5996d6-813f-419f-80ee-fbd8e5750110
+      - f5ab036f-9658-4624-b7f2-b9bdba8dce62
     status: 200 OK
     code: 200
     duration: ""
@@ -509,7 +548,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -521,9 +560,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:24 GMT
+      - Thu, 22 Feb 2024 07:32:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -531,7 +570,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2dfdfb4e-66f2-4ece-8d71-21ba0bf0ba8e
+      - fd9f2215-8b23-4b11-b66e-2b1f53a82f46
     status: 200 OK
     code: 200
     duration: ""
@@ -542,7 +581,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -554,12 +593,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:24 GMT
+      - Thu, 22 Feb 2024 07:32:30 GMT
       Link:
-      - </servers/0141521a-5a65-461a-82be-a0344451af9a/private_nics?page=0&per_page=50&>;
+      - </servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -567,14 +606,14 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 565295ee-43e6-4774-99df-08c3a5cc1dd0
+      - 1f36c3dc-0009-447b-84d8-b054f2fc98c0
       X-Total-Count:
       - "0"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-snap-cranky-hofstadter","volume_id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    body: '{"name":"tf-snap-modest-franklin","volume_id":"792e6007-e1cf-41f4-ab13-f202f01afb88","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
@@ -585,19 +624,19 @@ interactions:
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots
     method: POST
   response:
-    body: '{"snapshot":{"base_volume":{"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-10-31T14:31:24.285328+00:00","error_details":null,"id":"72a33057-e815-4bd7-9f69-be3c5003d924","modification_date":"2023-10-31T14:31:24.285328+00:00","name":"tf-snap-cranky-hofstadter","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_72a33057-e815-4bd7-9f69-be3c5003d924","href_from":"/snapshots","href_result":"snapshots/72a33057-e815-4bd7-9f69-be3c5003d924","id":"98fcc923-af72-4d3a-8cef-88a9d61fe2f5","started_at":"2023-10-31T14:31:25.008853+00:00","status":"pending","terminated_at":null}}'
+    body: '{"snapshot":{"base_volume":{"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:30.479813+00:00","error_details":null,"id":"d8e1513a-2988-4165-b940-8c6417029fd8","modification_date":"2024-02-22T07:32:30.479813+00:00","name":"tf-snap-modest-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"},"task":{"description":"snapshot_d8e1513a-2988-4165-b940-8c6417029fd8","href_from":"/snapshots","href_result":"snapshots/d8e1513a-2988-4165-b940-8c6417029fd8","id":"11f05fe2-90ed-4e53-87ec-6cff1e2387ee","started_at":"2024-02-22T07:32:30.916706+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
-      - "844"
+      - "842"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:25 GMT
+      - Thu, 22 Feb 2024 07:32:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -605,7 +644,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4e3b64d-2767-4d7c-864d-c746aefdddfd
+      - f100d99e-0191-47a5-a8cc-05de8dc53133
     status: 201 Created
     code: 201
     duration: ""
@@ -616,22 +655,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/72a33057-e815-4bd7-9f69-be3c5003d924
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d8e1513a-2988-4165-b940-8c6417029fd8
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-10-31T14:31:24.285328+00:00","error_details":null,"id":"72a33057-e815-4bd7-9f69-be3c5003d924","modification_date":"2023-10-31T14:31:24.285328+00:00","name":"tf-snap-cranky-hofstadter","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:30.479813+00:00","error_details":null,"id":"d8e1513a-2988-4165-b940-8c6417029fd8","modification_date":"2024-02-22T07:32:30.479813+00:00","name":"tf-snap-modest-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "538"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:25 GMT
+      - Thu, 22 Feb 2024 07:32:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -639,7 +678,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f56019c3-fd95-48fe-a128-c9289c07b223
+      - 03ad044a-bedf-4c7a-8af5-9194c7d84086
     status: 200 OK
     code: 200
     duration: ""
@@ -650,22 +689,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/72a33057-e815-4bd7-9f69-be3c5003d924
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d8e1513a-2988-4165-b940-8c6417029fd8
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-10-31T14:31:24.285328+00:00","error_details":null,"id":"72a33057-e815-4bd7-9f69-be3c5003d924","modification_date":"2023-10-31T14:31:24.285328+00:00","name":"tf-snap-cranky-hofstadter","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:30.479813+00:00","error_details":null,"id":"d8e1513a-2988-4165-b940-8c6417029fd8","modification_date":"2024-02-22T07:32:30.479813+00:00","name":"tf-snap-modest-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "538"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:30 GMT
+      - Thu, 22 Feb 2024 07:32:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -673,7 +712,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9afe104f-f4b0-4c8a-9b6b-51f72c70f4bd
+      - 3e9288b9-83be-4e36-83a1-296217088ef5
     status: 200 OK
     code: 200
     duration: ""
@@ -684,22 +723,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/72a33057-e815-4bd7-9f69-be3c5003d924
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d8e1513a-2988-4165-b940-8c6417029fd8
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-10-31T14:31:24.285328+00:00","error_details":null,"id":"72a33057-e815-4bd7-9f69-be3c5003d924","modification_date":"2023-10-31T14:31:24.285328+00:00","name":"tf-snap-cranky-hofstadter","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:30.479813+00:00","error_details":null,"id":"d8e1513a-2988-4165-b940-8c6417029fd8","modification_date":"2024-02-22T07:32:30.479813+00:00","name":"tf-snap-modest-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "538"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:35 GMT
+      - Thu, 22 Feb 2024 07:32:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -707,7 +746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f819dfe-3e78-4333-847e-d28c8633e9e2
+      - 690e29e8-958a-4b4b-b8ad-b4bd860c1ffb
     status: 200 OK
     code: 200
     duration: ""
@@ -718,22 +757,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/72a33057-e815-4bd7-9f69-be3c5003d924
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d8e1513a-2988-4165-b940-8c6417029fd8
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-10-31T14:31:24.285328+00:00","error_details":null,"id":"72a33057-e815-4bd7-9f69-be3c5003d924","modification_date":"2023-10-31T14:31:24.285328+00:00","name":"tf-snap-cranky-hofstadter","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:30.479813+00:00","error_details":null,"id":"d8e1513a-2988-4165-b940-8c6417029fd8","modification_date":"2024-02-22T07:32:30.479813+00:00","name":"tf-snap-modest-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"snapshotting","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "538"
+      - "536"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:40 GMT
+      - Thu, 22 Feb 2024 07:32:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -741,7 +780,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe8d24a0-05db-44c5-9aa4-30d2c08eb3d2
+      - 103fa1a8-3ae7-4fad-91cf-22492c655a72
     status: 200 OK
     code: 200
     duration: ""
@@ -752,22 +791,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/72a33057-e815-4bd7-9f69-be3c5003d924
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d8e1513a-2988-4165-b940-8c6417029fd8
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-10-31T14:31:24.285328+00:00","error_details":null,"id":"72a33057-e815-4bd7-9f69-be3c5003d924","modification_date":"2023-10-31T14:31:45.376703+00:00","name":"tf-snap-cranky-hofstadter","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:30.479813+00:00","error_details":null,"id":"d8e1513a-2988-4165-b940-8c6417029fd8","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"tf-snap-modest-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "535"
+      - "533"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:46 GMT
+      - Thu, 22 Feb 2024 07:32:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -775,7 +814,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8831c2db-e867-4845-b637-75ce2653d7e9
+      - 4bf24d45-5ba3-46ac-b63b-4042ffc017df
     status: 200 OK
     code: 200
     duration: ""
@@ -786,22 +825,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/72a33057-e815-4bd7-9f69-be3c5003d924
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d8e1513a-2988-4165-b940-8c6417029fd8
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-10-31T14:31:24.285328+00:00","error_details":null,"id":"72a33057-e815-4bd7-9f69-be3c5003d924","modification_date":"2023-10-31T14:31:45.376703+00:00","name":"tf-snap-cranky-hofstadter","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:30.479813+00:00","error_details":null,"id":"d8e1513a-2988-4165-b940-8c6417029fd8","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"tf-snap-modest-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "535"
+      - "533"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:46 GMT
+      - Thu, 22 Feb 2024 07:32:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -809,7 +848,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d8fa88d1-a2e3-457e-be00-0e95ba77aba5
+      - 5376316e-8cb0-44d3-8e25-89ee00cb5f2c
     status: 200 OK
     code: 200
     duration: ""
@@ -820,22 +859,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/72a33057-e815-4bd7-9f69-be3c5003d924
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d8e1513a-2988-4165-b940-8c6417029fd8
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-10-31T14:31:24.285328+00:00","error_details":null,"id":"72a33057-e815-4bd7-9f69-be3c5003d924","modification_date":"2023-10-31T14:31:45.376703+00:00","name":"tf-snap-cranky-hofstadter","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:30.479813+00:00","error_details":null,"id":"d8e1513a-2988-4165-b940-8c6417029fd8","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"tf-snap-modest-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "535"
+      - "533"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:46 GMT
+      - Thu, 22 Feb 2024 07:32:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -843,7 +882,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49d88844-02d7-4a75-9b13-cb9c7ab500f8
+      - 5917b5b7-6deb-4102-97c1-98f49d079016
     status: 200 OK
     code: 200
     duration: ""
@@ -854,27 +893,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"2002","node_id":"33","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:21.630626+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.158.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:45.376703+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:25.766494+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2802"
+      - "2815"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:46 GMT
+      - Thu, 22 Feb 2024 07:32:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -882,7 +921,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 40e01f98-96e4-44ae-96bd-0287dcf25554
+      - a7b602bc-0a4d-4aa7-aa00-e3d14bc42053
     status: 200 OK
     code: 200
     duration: ""
@@ -893,7 +932,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -905,9 +944,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:46 GMT
+      - Thu, 22 Feb 2024 07:32:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -915,7 +954,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0fa81d09-6fe5-4ff5-8658-12f2f7a388d6
+      - 1fb24f6a-ccd0-46dc-832d-60e4dde26822
     status: 200 OK
     code: 200
     duration: ""
@@ -926,7 +965,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b/private_nics
     method: GET
   response:
     body: '{"private_nics":[]}'
@@ -938,12 +977,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:46 GMT
+      - Thu, 22 Feb 2024 07:32:52 GMT
       Link:
-      - </servers/0141521a-5a65-461a-82be-a0344451af9a/private_nics?page=0&per_page=50&>;
+      - </servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b/private_nics?page=0&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -951,7 +990,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 670637bc-ed23-48d6-9e23-1325b1c04caf
+      - d25dc038-5ec3-414f-90d8-3eb4b7831a58
       X-Total-Count:
       - "0"
     status: 200 OK
@@ -964,22 +1003,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/72a33057-e815-4bd7-9f69-be3c5003d924
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d8e1513a-2988-4165-b940-8c6417029fd8
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-10-31T14:31:24.285328+00:00","error_details":null,"id":"72a33057-e815-4bd7-9f69-be3c5003d924","modification_date":"2023-10-31T14:31:45.376703+00:00","name":"tf-snap-cranky-hofstadter","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:30.479813+00:00","error_details":null,"id":"d8e1513a-2988-4165-b940-8c6417029fd8","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"tf-snap-modest-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "535"
+      - "533"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:46 GMT
+      - Thu, 22 Feb 2024 07:32:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -987,7 +1026,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da99ca7c-502e-408c-97d6-4b6181d745bb
+      - 43047cfe-9874-45fa-93c9-fc0601c8e7ab
     status: 200 OK
     code: 200
     duration: ""
@@ -998,22 +1037,22 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/72a33057-e815-4bd7-9f69-be3c5003d924
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d8e1513a-2988-4165-b940-8c6417029fd8
     method: GET
   response:
-    body: '{"snapshot":{"base_volume":{"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","name":"Ubuntu
-      20.04 Focal Fossa"},"creation_date":"2023-10-31T14:31:24.285328+00:00","error_details":null,"id":"72a33057-e815-4bd7-9f69-be3c5003d924","modification_date":"2023-10-31T14:31:45.376703+00:00","name":"tf-snap-cranky-hofstadter","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
+    body: '{"snapshot":{"base_volume":{"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","name":"Ubuntu
+      20.04 Focal Fossa"},"creation_date":"2024-02-22T07:32:30.479813+00:00","error_details":null,"id":"d8e1513a-2988-4165-b940-8c6417029fd8","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"tf-snap-modest-franklin","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "535"
+      - "533"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:47 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1021,7 +1060,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d48a3fcd-9a0b-4e83-be43-c602caf2f114
+      - cde30bf8-0cc7-4784-a87c-5c9352e50c8b
     status: 200 OK
     code: 200
     duration: ""
@@ -1032,7 +1071,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/72a33057-e815-4bd7-9f69-be3c5003d924
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d8e1513a-2988-4165-b940-8c6417029fd8
     method: DELETE
   response:
     body: ""
@@ -1040,9 +1079,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:31:47 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1050,7 +1089,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 697879aa-4b31-4a03-b87a-17ac767bd15d
+      - 7b2b52f2-bb85-4463-a364-8f9347d4da70
     status: 204 No Content
     code: 204
     duration: ""
@@ -1061,10 +1100,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/72a33057-e815-4bd7-9f69-be3c5003d924
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/snapshots/d8e1513a-2988-4165-b940-8c6417029fd8
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"72a33057-e815-4bd7-9f69-be3c5003d924","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_snapshot","resource_id":"d8e1513a-2988-4165-b940-8c6417029fd8","type":"not_found"}'
     headers:
       Content-Length:
       - "145"
@@ -1073,9 +1112,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:47 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1083,7 +1122,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5df794ba-b5b0-4595-8d6b-8f2431c51c5c
+      - 34bc0f30-58f1-4adb-80d4-298bc6ba2803
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1094,27 +1133,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"2002","node_id":"33","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:21.630626+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.158.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:45.376703+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:25.766494+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2794"
+      - "2815"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:47 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1122,7 +1161,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab3390af-0feb-41d9-9be8-ea7155424cba
+      - cbbeddfd-5043-4ea7-9935-6be06f222c84
     status: 200 OK
     code: 200
     duration: ""
@@ -1135,10 +1174,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/0141521a-5a65-461a-82be-a0344451af9a/action","href_result":"/servers/0141521a-5a65-461a-82be-a0344451af9a","id":"67bb512f-beee-4cb8-b25b-fca3ef847435","started_at":"2023-10-31T14:31:48.124226+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b/action","href_result":"/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b","id":"790faf4c-0b69-4bbb-85e7-ebce2d8eb1aa","started_at":"2024-02-22T07:32:53.577448+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -1147,11 +1186,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:48 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/67bb512f-beee-4cb8-b25b-fca3ef847435
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/790faf4c-0b69-4bbb-85e7-ebce2d8eb1aa
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1159,7 +1198,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 888d107a-47a7-4e56-9b40-d61ef7679425
+      - 17547d9f-c475-4f06-a81b-2623fdce5a36
     status: 202 Accepted
     code: 202
     duration: ""
@@ -1170,27 +1209,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"2002","node_id":"33","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:47.852267+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.158.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:45.376703+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:53.438182+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2762"
+      - "2783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:48 GMT
+      - Thu, 22 Feb 2024 07:32:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1198,7 +1237,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3ae3a07-cced-402a-926b-d590a2a18eb6
+      - b0abe9b6-8787-42b7-b0e0-3b8fb53641d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1209,27 +1248,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"2002","node_id":"33","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:47.852267+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.158.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:45.376703+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:53.438182+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2762"
+      - "2783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:53 GMT
+      - Thu, 22 Feb 2024 07:32:59 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1237,7 +1276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5da750f8-62f1-4fcf-8ed3-c7f1bc9ddbdd
+      - 7376ec04-fd47-4e14-9267-b1f28fffbef4
     status: 200 OK
     code: 200
     duration: ""
@@ -1248,27 +1287,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"2002","node_id":"33","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:47.852267+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.158.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:45.376703+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:53.438182+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2762"
+      - "2783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:31:58 GMT
+      - Thu, 22 Feb 2024 07:33:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1276,7 +1315,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7cb3fc91-c9cb-4365-a01f-5ce996565502
+      - 0e256315-2334-4bed-a41c-8d7babfc96d5
     status: 200 OK
     code: 200
     duration: ""
@@ -1287,27 +1326,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"2002","node_id":"33","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:47.852267+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.158.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:45.376703+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:53.438182+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2762"
+      - "2783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:03 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1315,7 +1354,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a828a7e-cb13-4be7-bd91-55c17d4b0111
+      - dc7e20e4-3187-475a-8f6b-b990415f2f74
     status: 200 OK
     code: 200
     duration: ""
@@ -1326,27 +1365,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"41","hypervisor_id":"2002","node_id":"33","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:31:47.852267+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":"10.70.158.65","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:45.376703+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:53.438182+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2762"
+      - "2783"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:09 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1354,7 +1393,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 868b6712-0fcb-40e5-b361-b4674de2afb0
+      - 0d2e9d0a-ef2a-4fe5-a577-6307ef2f8345
     status: 200 OK
     code: 200
     duration: ""
@@ -1365,27 +1404,261 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:53.438182+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2783"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:19 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 698e435c-43ac-46f8-a3bc-862aebcb6f0e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:53.438182+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2783"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:24 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 33ddcbda-074f-49f5-8a97-69b1266ed25a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:53.438182+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2783"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c7b5d1f5-4a75-49ef-a3b9-f234470d0a7c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:53.438182+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2783"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a233ce48-450f-44e4-8e80-9e53103c843c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:53.438182+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2783"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:40 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 11fdd6e7-928a-4766-ab84-0c350dcf9e9e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"16","hypervisor_id":"502","node_id":"4","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:32:53.438182+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.98.7","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2783"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8abbfc52-93df-447c-87f8-db51a2d095f4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:32:10.259789+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:45.376703+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:33:46.139305+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2639"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:14 GMT
+      - Thu, 22 Feb 2024 07:33:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1393,7 +1666,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8da68bfa-d696-4bd1-ae52-613cfffaab09
+      - e2617ec8-3b2c-4975-80a8-1fb79c9569f3
     status: 200 OK
     code: 200
     duration: ""
@@ -1404,27 +1677,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-31T14:31:01.157301+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-lucid-cannon","id":"0141521a-5a65-461a-82be-a0344451af9a","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2b:5a:01","maintenances":[],"modification_date":"2023-10-31T14:32:10.259789+00:00","name":"tf-srv-lucid-cannon","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-31T14:31:01.157301+00:00","export_uri":null,"id":"1eb03ae4-dad9-4d5f-b568-35657f94fcf4","modification_date":"2023-10-31T14:31:45.376703+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0141521a-5a65-461a-82be-a0344451af9a","name":"tf-srv-lucid-cannon"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:02.693365+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-vigilant-bell","id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:a1","maintenances":[],"modification_date":"2024-02-22T07:33:46.139305+00:00","name":"tf-srv-vigilant-bell","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:02.693365+00:00","export_uri":null,"id":"792e6007-e1cf-41f4-ab13-f202f01afb88","modification_date":"2024-02-22T07:32:47.733899+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","name":"tf-srv-vigilant-bell"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2639"
+      - "2664"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:15 GMT
+      - Thu, 22 Feb 2024 07:33:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1432,7 +1705,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0dca08dc-13ac-4fc1-b264-59ea474c24a3
+      - a59f66f1-bda1-45a6-9985-9f7f6c02b53b
     status: 200 OK
     code: 200
     duration: ""
@@ -1443,7 +1716,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: DELETE
   response:
     body: ""
@@ -1451,9 +1724,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:32:15 GMT
+      - Thu, 22 Feb 2024 07:33:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1461,7 +1734,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 34494fba-3a0d-4913-9bbc-16a6363537aa
+      - cfaddf9a-3afb-4592-990a-7a251534badd
     status: 204 No Content
     code: 204
     duration: ""
@@ -1472,10 +1745,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0141521a-5a65-461a-82be-a0344451af9a
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/0bf38487-e59e-4386-bdbd-b4fbce15db6b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"0141521a-5a65-461a-82be-a0344451af9a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"0bf38487-e59e-4386-bdbd-b4fbce15db6b","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -1484,9 +1757,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 31 Oct 2023 14:32:15 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1494,7 +1767,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 60047b31-fb50-4b1e-a9cb-8e29ce728adc
+      - ac4a2dad-de58-4f5e-b0e1-599b3045f263
     status: 404 Not Found
     code: 404
     duration: ""
@@ -1505,7 +1778,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1eb03ae4-dad9-4d5f-b568-35657f94fcf4
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/792e6007-e1cf-41f4-ab13-f202f01afb88
     method: DELETE
   response:
     body: ""
@@ -1513,9 +1786,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Tue, 31 Oct 2023 14:32:15 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1523,7 +1796,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3d6d393-8748-4d74-9776-49417a0512b2
+      - aac16bc5-ed5d-4152-8339-46c8e83baddc
     status: 204 No Content
     code: 204
     duration: ""

--- a/scaleway/testdata/lblb-with-private-networks-on-dhcp-config.cassette.yaml
+++ b/scaleway/testdata/lblb-with-private-networks-on-dhcp-config.cassette.yaml
@@ -2,53 +2,18 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","subnet":"10.0.0.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","is_ipv6":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
-    method: POST
-  response:
-    body: '{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "574"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:49:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 391d88a2-80db-49f0-b65f-93e8b6845f22
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":null,"organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    body: '{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "285"
@@ -57,9 +22,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:57 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -67,21 +32,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9c85b02-ee70-4ce7-85bc-8a582b830e44
+      - 9934bbcf-c147-40b6-ac8f-203d1b8db8e3
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"10.0.0.0/24"}'
     form: {}
     headers:
+      Content-Type:
+      - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/08a8311b-adb1-49b3-96ff-c011ee058db5
-    method: GET
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
+    method: POST
   response:
-    body: '{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "574"
@@ -90,9 +57,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:57 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -100,7 +67,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0f90802-b429-4a2d-9c3d-320256e52f72
+      - 64f9c258-eb74-4860-9c3a-f640af988e81
     status: 200 OK
     code: 200
     duration: ""
@@ -109,12 +76,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/534c546e-f2a8-44f2-8b89-86559c0307ea
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/c523270c-3905-4dd2-9c1c-66d600e21f56
     method: GET
   response:
-    body: '{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":null,"organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "574"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ca1a9dc0-dc99-4f88-a8cb-a55333b83f08
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/7f585740-724f-4d8b-b45c-7c19677824c7
+    method: GET
+  response:
+    body: '{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "285"
@@ -123,9 +123,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:57 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -133,92 +133,24 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df9c7da1-f2cc-4fe5-b19f-07e1fc0bc6b5
+      - 77ed03ff-3385-42f7-b161-d241f17a1865
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null}'
+    body: '{"name":"private network with a DHCP config","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
-    method: POST
-  response:
-    body: '{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":null,"id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "367"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:49:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - aaa41443-6b30-4c67-a1c5-31db17331e1f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/08e1a5d6-e11f-445d-896f-f9f5884517f7
-    method: GET
-  response:
-    body: '{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":null,"id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "367"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:49:57 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - d772ce3f-0ab5-4c1a-9fa3-139019d97119
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"private network with a DHCP config","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null,"vpc_id":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-10-27T07:49:57.265805Z","dhcp_enabled":true,"id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","name":"private
-      network with a DHCP config","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:49:57.265805Z","id":"4649bb05-cf93-42ab-8e55-e04b8638f73c","subnet":"172.16.68.0/22","updated_at":"2023-10-27T07:49:57.265805Z"},{"created_at":"2023-10-27T07:49:57.265805Z","id":"40176091-f218-4c1c-af64-e34e2fe4cae1","subnet":"fd46:78ab:30b8:4bb6::/64","updated_at":"2023-10-27T07:49:57.265805Z"}],"tags":[],"updated_at":"2023-10-27T07:49:57.265805Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-22T07:32:02.380969Z","dhcp_enabled":true,"id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","name":"private
+      network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.380969Z","id":"5779d7be-c4b4-4b85-8413-f6a8a486f057","subnet":"172.16.84.0/22","updated_at":"2024-02-22T07:32:02.380969Z"},{"created_at":"2024-02-22T07:32:02.380969Z","id":"afa401c7-8c1e-4532-9119-84627241c6fd","subnet":"fd5f:519c:6d46:80ab::/64","updated_at":"2024-02-22T07:32:02.380969Z"}],"tags":[],"updated_at":"2024-02-22T07:32:02.380969Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "735"
@@ -227,9 +159,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:57 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -237,7 +169,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52ae99c4-4630-4df9-99d1-c88c02886051
+      - 7e47adce-328d-43fd-b1c2-45521bfbc3f1
     status: 200 OK
     code: 200
     duration: ""
@@ -246,13 +178,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6258f488-3864-4a3b-b3c2-9d9840ed4a45
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4aa37999-88a7-4f2a-bc80-a33793c83c57
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:49:57.265805Z","dhcp_enabled":true,"id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","name":"private
-      network with a DHCP config","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:49:57.265805Z","id":"4649bb05-cf93-42ab-8e55-e04b8638f73c","subnet":"172.16.68.0/22","updated_at":"2023-10-27T07:49:57.265805Z"},{"created_at":"2023-10-27T07:49:57.265805Z","id":"40176091-f218-4c1c-af64-e34e2fe4cae1","subnet":"fd46:78ab:30b8:4bb6::/64","updated_at":"2023-10-27T07:49:57.265805Z"}],"tags":[],"updated_at":"2023-10-27T07:49:57.265805Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-22T07:32:02.380969Z","dhcp_enabled":true,"id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","name":"private
+      network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.380969Z","id":"5779d7be-c4b4-4b85-8413-f6a8a486f057","subnet":"172.16.84.0/22","updated_at":"2024-02-22T07:32:02.380969Z"},{"created_at":"2024-02-22T07:32:02.380969Z","id":"afa401c7-8c1e-4532-9119-84627241c6fd","subnet":"fd5f:519c:6d46:80ab::/64","updated_at":"2024-02-22T07:32:02.380969Z"}],"tags":[],"updated_at":"2024-02-22T07:32:02.380969Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
       - "735"
@@ -261,9 +193,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:57 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -271,42 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb82fceb-efed-4476-bf0d-994bf3020add
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"tf-test-public-gw","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
-    method: POST
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T07:49:58.005592Z","gateway_networks":[],"id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","ip":{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"},"is_legacy":false,"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T07:49:58.005592Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "980"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:49:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 465c19b4-f8e0-4715-b0f8-e4b827704ec6
+      - a3a003e5-d77e-4cda-a521-68c06cd18279
     status: 200 OK
     code: 200
     duration: ""
@@ -315,56 +212,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/11059644-d3c3-4d95-bdc3-4b41c4e2b52d
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T07:49:58.005592Z","gateway_networks":[],"id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","ip":{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"},"is_legacy":false,"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T07:49:58.005592Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "980"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:49:58 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - a3990e6f-49c9-4015-9978-25fabf0b062d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=debian_bullseye&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","label":"debian_bullseye","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"7691a260-ab4a-4692-8c54-862e08826deb","label":"debian_bullseye","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","label":"debian_bullseye","type":"instance_local","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"75b9767f-ccfd-49ed-bb8a-6bcd717e3eaa","label":"debian_bullseye","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1262"
+      - "1266"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:58 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -372,7 +236,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 843a77bc-224b-42d2-b367-f59d9e9cfd4a
+      - 311244b2-ddd9-4210-9ee2-43fb4ba7b3ca
     status: 200 OK
     code: 200
     duration: ""
@@ -381,26 +245,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38421"
+      - "38183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:58 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -408,9 +272,44 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c1dc1a1-8f51-4946-bd3b-9cb9c32527b3
+      - 5226c0d7-6c2e-4997-b572-045a355b4d84
       X-Total-Count:
-      - "56"
+      - "61"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
+    method: POST
+  response:
+    body: '{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":null,"id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "367"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 235d4d5a-1b7c-4f40-8aa8-11d5fa0a24e8
     status: 200 OK
     code: 200
     duration: ""
@@ -419,26 +318,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4865"
+      - "8882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:58 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -446,46 +345,147 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3228dd1b-9aae-4cc6-8dc5-f7538c6bd716
+      - a2e2b207-85e3-4cab-aa40-d44dc2f25782
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"Scaleway Terraform Provider","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"92e694e8-5f29-420f-b48d-c3cb88de283d","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/11718cdd-9ffa-4cd1-80d9-9daa99774418
+    method: GET
+  response:
+    body: '{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":null,"id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "367"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8a1ac1e6-4a8d-40c8-9f5e-03c8b58ec3db
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"tf-test-public-gw","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","enable_smtp":false,"enable_bastion":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
+    method: POST
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.247774Z","gateway_networks":[],"id":"a27469f4-739a-4368-b269-e7f37cd80742","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:03.247774Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1009"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 79418675-79bd-43d4-8d1b-bd671431cb33
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.247774Z","gateway_networks":[],"id":"a27469f4-739a-4368-b269-e7f37cd80742","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:03.247774Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1009"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a9aa4ea1-d624-4255-a5cb-7aaf970bd58f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"Scaleway Terraform Provider","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2636"
+      - "2658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:58 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -493,7 +493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3494457d-f074-42a9-821d-20d5c88751dd
+      - a0a19627-a99a-43fe-be2e-63e27ed7696f
     status: 201 Created
     code: 201
     duration: ""
@@ -502,31 +502,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2636"
+      - "2658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:59 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -534,7 +534,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 866bc21a-b7eb-4900-b3c1-fe455465511d
+      - f85d9839-5ebf-4e50-a6b8-9d751dcb0d14
     status: 200 OK
     code: 200
     duration: ""
@@ -543,31 +543,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2636"
+      - "2658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:49:59 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -575,7 +575,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b1f6665-8d84-4c9b-adce-8cbfc281e816
+      - e72ed3bd-97f4-497f-955f-c4adbb1ffa50
     status: 200 OK
     code: 200
     duration: ""
@@ -586,12 +586,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/action","href_result":"/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8","id":"a2445964-d09e-43ad-8712-9faeb29cae6c","started_at":"2023-10-27T07:49:59.997084+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/action","href_result":"/servers/814291e7-5ff7-4ae1-9615-20243b1c876e","id":"1113b56b-3b05-400b-aa9d-e960e3b24a6a","started_at":"2024-02-22T07:32:04.914692+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -600,11 +600,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:00 GMT
+      - Thu, 22 Feb 2024 07:32:05 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/a2445964-d09e-43ad-8712-9faeb29cae6c
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/1113b56b-3b05-400b-aa9d-e960e3b24a6a
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -612,7 +612,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dff0c2b8-c83e-4f0a-b129-3a13d5970527
+      - 62f43ec9-0323-4aeb-83d2-8e7a2b5688ce
     status: 202 Accepted
     code: 202
     duration: ""
@@ -621,31 +621,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:49:59.165453+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:32:04.767306+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2658"
+      - "2680"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:00 GMT
+      - Thu, 22 Feb 2024 07:32:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -653,7 +653,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d67c335c-1fba-4e9d-94a7-91a93b986193
+      - 1281241b-f912-4112-8a28-96b1940a34b8
     status: 200 OK
     code: 200
     duration: ""
@@ -662,23 +662,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/11059644-d3c3-4d95-bdc3-4b41c4e2b52d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T07:49:58.005592Z","gateway_networks":[],"id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","ip":{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"},"is_legacy":false,"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T07:49:58.579965Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.247774Z","gateway_networks":[],"id":"a27469f4-739a-4368-b269-e7f37cd80742","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.484032Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "980"
+      - "1009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:03 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -686,7 +686,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c5956f30-fb0f-4fc8-9d32-01821c782a3d
+      - 6d6ceeae-f70d-4231-a0f6-60174f78a124
     status: 200 OK
     code: 200
     duration: ""
@@ -695,23 +695,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/11059644-d3c3-4d95-bdc3-4b41c4e2b52d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T07:49:58.005592Z","gateway_networks":[],"id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","ip":{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"},"is_legacy":false,"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T07:49:58.579965Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.247774Z","gateway_networks":[],"id":"a27469f4-739a-4368-b269-e7f37cd80742","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.484032Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "980"
+      - "1009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:03 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -719,7 +719,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb8c8e1b-41d4-438e-b603-3bafb2fb6666
+      - d239770f-cdcf-4ba1-b47d-49d17eb67f8a
     status: 200 OK
     code: 200
     duration: ""
@@ -728,23 +728,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/11059644-d3c3-4d95-bdc3-4b41c4e2b52d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T07:49:58.005592Z","gateway_networks":[],"id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","ip":{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"},"is_legacy":false,"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T07:49:58.579965Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.247774Z","gateway_networks":[],"id":"a27469f4-739a-4368-b269-e7f37cd80742","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.484032Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "980"
+      - "1009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:03 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -752,23 +752,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 015bdf7c-ec5f-40a1-a0a1-1b41f8d1592a
+      - 8e465e21-8243-4f55-9d13-408c844e2091
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"test-lb-with-private-network-configs","description":"","ip_id":"534c546e-f2a8-44f2-8b89-86559c0307ea","assign_flexible_ip":null,"tags":null,"type":"LB-S","ssl_compatibility_level":"ssl_compatibility_level_intermediate"}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test-lb-with-private-network-configs","description":"","ip_id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_ids":null,"tags":null,"type":"LB-S","ssl_compatibility_level":"ssl_compatibility_level_intermediate"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs
     method: POST
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-27T07:50:03.272666510Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:03.272666510Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164356Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:08.503164356Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "913"
@@ -777,9 +777,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:03 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -787,7 +787,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d68a0130-4c1a-4302-966e-602da9980c22
+      - d074e1eb-5816-4177-9b82-49ab5c1d84ab
     status: 200 OK
     code: 200
     duration: ""
@@ -796,23 +796,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[{"created_at":"2023-10-27T06:12:43.533028Z","id":"f89670ea-9a9b-4e33-a255-72d8ae66ca0a","ip_address":"","region":"fr-par","status":"unknown","updated_at":"2023-10-27T07:50:03.501563Z","zone":"fr-par-1"}],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"creating","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:03.510893Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_create","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:08.503164Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1114"
+      - "907"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:03 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -820,7 +820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dba1442d-48a1-424e-b2d8-28ce4b5aab3c
+      - 1d0f3d6c-f2db-48e1-933f-d04c2e3fa679
     status: 200 OK
     code: 200
     duration: ""
@@ -829,31 +829,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:49:59.165453+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.65.46.9","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:32:04.767306+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2765"
+      - "2680"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:05 GMT
+      - Thu, 22 Feb 2024 07:32:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -861,23 +861,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36f28da8-6756-418c-8e10-7ad73b999d3f
+      - 1da2d5af-5541-4a90-898c-cf73a99bd3a1
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"08a8311b-adb1-49b3-96ff-c011ee058db5"}'
+    body: '{"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"c523270c-3905-4dd2-9c1c-66d600e21f56"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-10-27T07:50:05.640274Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"9d22e710-2b17-439c-bc74-0aaece0025c1","ipam_config":null,"mac_address":null,"private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"created","updated_at":"2023-10-27T07:50:05.640274Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.809037Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","ipam_config":null,"mac_address":null,"private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"created","updated_at":"2024-02-22T07:32:10.809037Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "971"
@@ -886,9 +886,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:05 GMT
+      - Thu, 22 Feb 2024 07:32:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -896,7 +896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - facfd295-7fde-4379-b5cc-babe83cf2c9c
+      - e7832b80-a7b2-47b0-9391-b7b9d43d887e
     status: 200 OK
     code: 200
     duration: ""
@@ -905,23 +905,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/11059644-d3c3-4d95-bdc3-4b41c4e2b52d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T07:49:58.005592Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T07:50:05.640274Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"9d22e710-2b17-439c-bc74-0aaece0025c1","ipam_config":null,"mac_address":null,"private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"created","updated_at":"2023-10-27T07:50:05.640274Z","zone":"fr-par-1"}],"id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","ip":{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"},"is_legacy":true,"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T07:50:05.788713Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.247774Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.809037Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","ipam_config":null,"mac_address":null,"private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"created","updated_at":"2024-02-22T07:32:10.809037Z","zone":"fr-par-1"}],"id":"a27469f4-739a-4368-b269-e7f37cd80742","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:10.966036Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1954"
+      - "1983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:05 GMT
+      - Thu, 22 Feb 2024 07:32:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -929,7 +929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49191fd9-5d6f-4bf2-9aa6-094713c55bd4
+      - 18cb9daf-a4ff-4601-8414-02d40e4b95d2
     status: 200 OK
     code: 200
     duration: ""
@@ -938,31 +938,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:49:59.165453+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.65.46.9","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:32:04.767306+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2765"
+      - "2790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:10 GMT
+      - Thu, 22 Feb 2024 07:32:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -970,7 +970,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c03ccb61-9cbc-4777-8930-cec0188fcae8
+      - 4dacdb28-93b5-43f2-b7e7-52b6ce662f23
     status: 200 OK
     code: 200
     duration: ""
@@ -979,23 +979,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/11059644-d3c3-4d95-bdc3-4b41c4e2b52d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T07:49:58.005592Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T07:50:05.640274Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"9d22e710-2b17-439c-bc74-0aaece0025c1","ipam_config":null,"mac_address":"02:00:00:14:73:C6","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"ready","updated_at":"2023-10-27T07:50:08.215893Z","zone":"fr-par-1"}],"id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","ip":{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"},"is_legacy":true,"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T07:50:08.312724Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.247774Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.809037Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","ipam_config":null,"mac_address":null,"private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"created","updated_at":"2024-02-22T07:32:10.809037Z","zone":"fr-par-1"}],"id":"a27469f4-739a-4368-b269-e7f37cd80742","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:10.966036Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1963"
+      - "1983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:10 GMT
+      - Thu, 22 Feb 2024 07:32:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1003,7 +1003,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72c181ec-9189-4165-b0ea-9c59a715739b
+      - bac8579b-4f75-4775-bf2f-18ed94d8f88e
     status: 200 OK
     code: 200
     duration: ""
@@ -1012,23 +1012,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9d22e710-2b17-439c-bc74-0aaece0025c1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T07:50:05.640274Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"9d22e710-2b17-439c-bc74-0aaece0025c1","ipam_config":null,"mac_address":"02:00:00:14:73:C6","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"ready","updated_at":"2023-10-27T07:50:08.215893Z","zone":"fr-par-1"}'
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:32:04.767306+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
+      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "984"
+      - "2790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:10 GMT
+      - Thu, 22 Feb 2024 07:32:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1036,7 +1044,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e2f3daf2-54c5-447f-831c-c0cd79ef7e46
+      - 4df948f9-e390-449b-846e-21d4caae47e6
     status: 200 OK
     code: 200
     duration: ""
@@ -1045,23 +1053,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9d22e710-2b17-439c-bc74-0aaece0025c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T07:50:05.640274Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"9d22e710-2b17-439c-bc74-0aaece0025c1","ipam_config":null,"mac_address":"02:00:00:14:73:C6","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"ready","updated_at":"2023-10-27T07:50:08.215893Z","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.247774Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.809037Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","ipam_config":null,"mac_address":"02:00:00:18:8B:AC","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"ready","updated_at":"2024-02-22T07:32:19.846150Z","zone":"fr-par-1"}],"id":"a27469f4-739a-4368-b269-e7f37cd80742","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:19.958865Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "984"
+      - "1992"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:11 GMT
+      - Thu, 22 Feb 2024 07:32:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1069,7 +1077,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4dcbff1-148c-4c10-8f21-13ccd54d445f
+      - 53c2f7d3-bdd0-4898-935c-9ffa1087f170
     status: 200 OK
     code: 200
     duration: ""
@@ -1078,45 +1086,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/11059644-d3c3-4d95-bdc3-4b41c4e2b52d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b06dffa0-7631-4fcc-8988-e8f2902e7c59
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T07:49:58.005592Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T07:50:05.640274Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"9d22e710-2b17-439c-bc74-0aaece0025c1","ipam_config":null,"mac_address":"02:00:00:14:73:C6","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"ready","updated_at":"2023-10-27T07:50:08.215893Z","zone":"fr-par-1"}],"id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","ip":{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"},"is_legacy":true,"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T07:50:08.312724Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1963"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:50:11 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5b8d08e0-4640-4e67-96f6-cc3398de4c6c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9d22e710-2b17-439c-bc74-0aaece0025c1
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-10-27T07:50:05.640274Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"9d22e710-2b17-439c-bc74-0aaece0025c1","ipam_config":null,"mac_address":"02:00:00:14:73:C6","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"ready","updated_at":"2023-10-27T07:50:08.215893Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.809037Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","ipam_config":null,"mac_address":"02:00:00:18:8B:AC","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"ready","updated_at":"2024-02-22T07:32:19.846150Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -1125,9 +1100,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:11 GMT
+      - Thu, 22 Feb 2024 07:32:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1135,7 +1110,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4121b3ea-c3b5-48b5-9809-17562cd269e9
+      - bb1f0490-b8c6-4184-9cc6-0bfbc2041fab
     status: 200 OK
     code: 200
     duration: ""
@@ -1144,31 +1119,171 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b06dffa0-7631-4fcc-8988-e8f2902e7c59
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.809037Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","ipam_config":null,"mac_address":"02:00:00:18:8B:AC","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"ready","updated_at":"2024-02-22T07:32:19.846150Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e3731306-ece6-4536-a8d7-1ef5cee2d1e3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.247774Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.809037Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","ipam_config":null,"mac_address":"02:00:00:18:8B:AC","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"ready","updated_at":"2024-02-22T07:32:19.846150Z","zone":"fr-par-1"}],"id":"a27469f4-739a-4368-b269-e7f37cd80742","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:19.958865Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1992"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 728501fa-bbb3-445d-8deb-1c83a5ebf80d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b06dffa0-7631-4fcc-8988-e8f2902e7c59
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.809037Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","ipam_config":null,"mac_address":"02:00:00:18:8B:AC","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"ready","updated_at":"2024-02-22T07:32:19.846150Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - bac5435e-9658-4c0c-b89e-cec4b1730bc2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:32:04.767306+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
+      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2790"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:25 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8a1010e2-4ec8-416a-ba58-696f9fd97c8e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:50:11.708409+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.65.46.9","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:32:29.428327+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2796"
+      - "2821"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:15 GMT
+      - Thu, 22 Feb 2024 07:32:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1176,7 +1291,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5b6c8712-a755-4ff0-a05f-efa5b6a1048c
+      - 65bd3715-e6f1-404d-9a07-fd603121a24f
     status: 200 OK
     code: 200
     duration: ""
@@ -1185,13 +1300,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6258f488-3864-4a3b-b3c2-9d9840ed4a45
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4aa37999-88a7-4f2a-bc80-a33793c83c57
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:49:57.265805Z","dhcp_enabled":true,"id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","name":"private
-      network with a DHCP config","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:49:57.265805Z","id":"4649bb05-cf93-42ab-8e55-e04b8638f73c","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:50:03.948947Z"},{"created_at":"2023-10-27T07:49:57.265805Z","id":"40176091-f218-4c1c-af64-e34e2fe4cae1","subnet":"fd46:78ab:30b8:4bb6::/64","updated_at":"2023-10-27T07:50:03.961572Z"}],"tags":[],"updated_at":"2023-10-27T07:50:07.898856Z","vpc_id":"efa5b723-b070-430a-8631-f3d487bacf8b"}'
+    body: '{"created_at":"2024-02-22T07:32:02.380969Z","dhcp_enabled":true,"id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","name":"private
+      network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.380969Z","id":"5779d7be-c4b4-4b85-8413-f6a8a486f057","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:08.845568Z"},{"created_at":"2024-02-22T07:32:02.380969Z","id":"afa401c7-8c1e-4532-9119-84627241c6fd","subnet":"fd5f:519c:6d46:80ab::/64","updated_at":"2024-02-22T07:32:08.848446Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.054451Z","vpc_id":"3fef7212-775c-4eee-bb08-aeb09ede1e2b"}'
     headers:
       Content-Length:
       - "732"
@@ -1200,9 +1315,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:15 GMT
+      - Thu, 22 Feb 2024 07:32:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1210,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16239ad1-a661-4001-be3f-69939512b2b5
+      - d5ded9b8-7121-4086-a3ce-ba9c79d7291d
     status: 200 OK
     code: 200
     duration: ""
@@ -1219,31 +1334,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:50:11.708409+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.65.46.9","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:32:29.428327+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2796"
+      - "2821"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:15 GMT
+      - Thu, 22 Feb 2024 07:32:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1251,23 +1366,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91dff9e6-6155-498b-aad3-bc9738555e65
+      - 77eb6925-bd20-4a77-b9b6-1f416b8bd25a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45"}'
+    body: '{"private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:15.733547+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:32:31.193385+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1276,9 +1391,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:16 GMT
+      - Thu, 22 Feb 2024 07:32:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1286,7 +1401,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0dba6911-141b-4cf2-9098-bb55a4876b51
+      - cce03bd5-ef52-4a11-b703-e00ef26df392
     status: 201 Created
     code: 201
     duration: ""
@@ -1295,12 +1410,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics/1676de75-0790-49c2-89ce-471583a6dfb1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics/c13014c7-3d58-4657-87ef-8817eb917c5b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:15.733547+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:32:31.193385+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1309,9 +1424,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:16 GMT
+      - Thu, 22 Feb 2024 07:32:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1319,7 +1434,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7a699f2-d999-4b7c-98ed-697a9d09c6e9
+      - 5629a20e-59a0-4643-9da5-8b2908e18819
     status: 200 OK
     code: 200
     duration: ""
@@ -1328,12 +1443,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics/1676de75-0790-49c2-89ce-471583a6dfb1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics/c13014c7-3d58-4657-87ef-8817eb917c5b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:16.560034+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:32:32.004424+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1342,9 +1457,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:21 GMT
+      - Thu, 22 Feb 2024 07:32:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1352,7 +1467,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e304752-f2e4-4e4b-a9fc-dde20ab6e150
+      - 98ff654a-9374-47e6-bb5a-743bbc70c2ab
     status: 200 OK
     code: 200
     duration: ""
@@ -1361,78 +1476,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics/1676de75-0790-49c2-89ce-471583a6dfb1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:16.560034+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:50:26 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f752fe73-b59b-4180-9f83-dd7d6bafe07a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics/1676de75-0790-49c2-89ce-471583a6dfb1
-    method: GET
-  response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:16.560034+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "376"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:50:31 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4b25f86a-af90-4873-a018-acfc29864e8d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d
-    method: GET
-  response:
-    body: '{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[{"created_at":"2023-10-27T06:12:43.533028Z","id":"f89670ea-9a9b-4e33-a255-72d8ae66ca0a","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-27T07:50:08.079727Z","zone":"fr-par-1"}],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":0,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:09.331766Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[{"created_at":"2024-02-22T07:16:06.849551Z","id":"e3622af2-3b01-43c6-95e7-78f7852ebc8e","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:13.944476Z","zone":"fr-par-1"}],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":0,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:15.232010Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "1109"
@@ -1441,9 +1490,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:33 GMT
+      - Thu, 22 Feb 2024 07:32:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1451,23 +1500,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cb726386-5857-45d9-96ec-23cd30ab5924
+      - ae098510-ada3-4586-80b7-0433b3e3ef12
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{}'
+    body: '{"dhcp_config":{}}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d/private-networks/6258f488-3864-4a3b-b3c2-9d9840ed4a45/attach
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4/private-networks/4aa37999-88a7-4f2a-bc80-a33793c83c57/attach
     method: POST
   response:
-    body: '{"created_at":"2023-10-27T07:50:33.802250665Z","dhcp_config":{"ip_id":null},"ipam_ids":[],"lb":{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[{"created_at":"2023-10-27T06:12:43.533028Z","id":"f89670ea-9a9b-4e33-a255-72d8ae66ca0a","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-27T07:50:08.079727Z","zone":"fr-par-1"}],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:09.331766Z","zone":"fr-par-1"},"private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"pending","updated_at":"2023-10-27T07:50:33.802250665Z"}'
+    body: '{"created_at":"2024-02-22T07:32:39.051641889Z","dhcp_config":{"ip_id":null},"ipam_ids":[],"lb":{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[{"created_at":"2024-02-22T07:16:06.849551Z","id":"e3622af2-3b01-43c6-95e7-78f7852ebc8e","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:13.944476Z","zone":"fr-par-1"}],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:15.232010Z","zone":"fr-par-1"},"private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"pending","updated_at":"2024-02-22T07:32:39.051641889Z"}'
     headers:
       Content-Length:
       - "1336"
@@ -1476,9 +1525,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:33 GMT
+      - Thu, 22 Feb 2024 07:32:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1486,7 +1535,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64d4556b-bc3f-4e97-8200-4f3100c3e3ce
+      - 77ac2c7d-3491-4577-9f85-56a7a7c60e09
     status: 200 OK
     code: 200
     duration: ""
@@ -1495,12 +1544,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d/private-networks?order_by=created_at_asc
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4/private-networks?order_by=created_at_asc
     method: GET
   response:
-    body: '{"private_network":[{"created_at":"2023-10-27T07:50:33.802251Z","dhcp_config":{"ip_id":null},"ipam_ids":[],"lb":{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:09.331766Z","zone":"fr-par-1"},"private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"pending","updated_at":"2023-10-27T07:50:33.802251Z"}],"total_count":1}'
+    body: '{"private_network":[{"created_at":"2024-02-22T07:32:39.051642Z","dhcp_config":{"ip_id":null},"ipam_ids":[],"lb":{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:15.232010Z","zone":"fr-par-1"},"private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"pending","updated_at":"2024-02-22T07:32:39.051642Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "1163"
@@ -1509,9 +1558,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:34 GMT
+      - Thu, 22 Feb 2024 07:32:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1519,7 +1568,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9be409d1-0d30-4ec2-abe8-16d3c357034a
+      - 7253f972-0941-4e78-b269-5677e7a2af88
     status: 200 OK
     code: 200
     duration: ""
@@ -1528,12 +1577,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics/1676de75-0790-49c2-89ce-471583a6dfb1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics/c13014c7-3d58-4657-87ef-8817eb917c5b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:16.560034+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:32:32.004424+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1542,9 +1591,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:36 GMT
+      - Thu, 22 Feb 2024 07:32:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1552,7 +1601,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3900a0cc-a1ba-423a-ae55-08bf25ebe1f1
+      - 654237ca-4b33-465a-a316-0a0f98c486b1
     status: 200 OK
     code: 200
     duration: ""
@@ -1561,12 +1610,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics/1676de75-0790-49c2-89ce-471583a6dfb1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics/c13014c7-3d58-4657-87ef-8817eb917c5b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:16.560034+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:32:32.004424+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1575,9 +1624,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:41 GMT
+      - Thu, 22 Feb 2024 07:32:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1585,7 +1634,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 716c5766-fc58-4342-be63-758625af9e46
+      - 61ee872f-f4f6-4691-b7d5-4916e421c33a
     status: 200 OK
     code: 200
     duration: ""
@@ -1594,12 +1643,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics/1676de75-0790-49c2-89ce-471583a6dfb1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics/c13014c7-3d58-4657-87ef-8817eb917c5b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:16.560034+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:32:32.004424+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1608,9 +1657,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:46 GMT
+      - Thu, 22 Feb 2024 07:32:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1618,7 +1667,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81c36720-cfc0-490d-96fa-a8e3854f93f3
+      - d02e3bd7-c9a5-4a2a-b448-be38e6783aaf
     status: 200 OK
     code: 200
     duration: ""
@@ -1627,12 +1676,78 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics/1676de75-0790-49c2-89ce-471583a6dfb1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics/c13014c7-3d58-4657-87ef-8817eb917c5b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:32:32.004424+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "376"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:57 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4aa7e4cc-9b59-4d34-853b-d47b0ecbef65
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics/c13014c7-3d58-4657-87ef-8817eb917c5b
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:32:32.004424+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "376"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c878f874-6359-45ff-9251-54d8b838385b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics/c13014c7-3d58-4657-87ef-8817eb917c5b
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1641,9 +1756,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:51 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1651,7 +1766,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 621c35ca-5076-466a-9e9b-b6245384ca95
+      - cc2b7a9f-1ce2-4478-97fe-6df47a07b187
     status: 200 OK
     code: 200
     duration: ""
@@ -1660,12 +1775,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics/1676de75-0790-49c2-89ce-471583a6dfb1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics/c13014c7-3d58-4657-87ef-8817eb917c5b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1674,9 +1789,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:51 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1684,7 +1799,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0b8dc666-31b3-47c5-a9ab-ba59ee97a94a
+      - 6b7c1018-c656-4a98-a21d-e7e35235cd41
     status: 200 OK
     code: 200
     duration: ""
@@ -1693,31 +1808,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:50:11.708409+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.65.46.9","private_nics":[{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:32:29.428327+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3149"
+      - "3174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:52 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1725,7 +1840,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 536f0494-7b2b-4d31-877d-1d28d5a7c8e1
+      - 7e5cc799-b742-4a1c-9ed0-57c6ceb45e4c
     status: 200 OK
     code: 200
     duration: ""
@@ -1734,9 +1849,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1748,9 +1863,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:52 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1758,7 +1873,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1008952-2009-4a6b-95c3-fb07da15cb54
+      - 9bb2b2bd-bf0e-4ba3-832d-64c1e0ff8a0c
     status: 200 OK
     code: 200
     duration: ""
@@ -1767,12 +1882,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1781,12 +1896,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:50:52 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Link:
-      - </servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics?page=1&per_page=50&>;
+      - </servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1794,7 +1909,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 347cb969-eb3c-45da-b831-a7419ccc7d77
+      - d7f10b5a-8dfd-413c-b689-3db3cdf2b18c
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1805,12 +1920,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d/private-networks?order_by=created_at_asc
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4/private-networks?order_by=created_at_asc
     method: GET
   response:
-    body: '{"private_network":[{"created_at":"2023-10-27T07:50:33.802251Z","dhcp_config":{"ip_id":"09bd22a7-33be-49b2-9908-7ac791b4b54f"},"ipam_ids":["09bd22a7-33be-49b2-9908-7ac791b4b54f"],"lb":{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:09.331766Z","zone":"fr-par-1"},"private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"ready","updated_at":"2023-10-27T07:50:42.801155Z"}],"total_count":1}'
+    body: '{"private_network":[{"created_at":"2024-02-22T07:32:39.051642Z","dhcp_config":{"ip_id":"24db878c-f664-4382-86c8-acd3ea4559f0"},"ipam_ids":["24db878c-f664-4382-86c8-acd3ea4559f0"],"lb":{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:15.232010Z","zone":"fr-par-1"},"private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"ready","updated_at":"2024-02-22T07:32:47.203782Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "1233"
@@ -1819,9 +1934,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:04 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1829,7 +1944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5920af1b-14ef-4b00-ab91-848a7bac7497
+      - 983fd444-fa3d-4462-a129-18dd56d6b6f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1838,12 +1953,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[{"created_at":"2023-10-27T06:12:43.533028Z","id":"f89670ea-9a9b-4e33-a255-72d8ae66ca0a","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-27T07:50:42.510387Z","zone":"fr-par-1"}],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:09.331766Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[{"created_at":"2024-02-22T07:16:06.849551Z","id":"e3622af2-3b01-43c6-95e7-78f7852ebc8e","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:46.868617Z","zone":"fr-par-1"}],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:15.232010Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "1109"
@@ -1852,9 +1967,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:04 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1862,7 +1977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68737b11-edb1-4da1-865f-214cc2f36f05
+      - 867ea6b4-e9dc-4173-b942-520099191d53
     status: 200 OK
     code: 200
     duration: ""
@@ -1871,12 +1986,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[{"created_at":"2023-10-27T06:12:43.533028Z","id":"f89670ea-9a9b-4e33-a255-72d8ae66ca0a","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-27T07:50:42.510387Z","zone":"fr-par-1"}],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:09.331766Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[{"created_at":"2024-02-22T07:16:06.849551Z","id":"e3622af2-3b01-43c6-95e7-78f7852ebc8e","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:46.868617Z","zone":"fr-par-1"}],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:15.232010Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "1109"
@@ -1885,9 +2000,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:04 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1895,7 +2010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86def5f3-2d4a-4859-a8b4-ff37b41b5fc5
+      - aaf8ff63-9bd6-49dc-a10a-9e861885cb83
     status: 200 OK
     code: 200
     duration: ""
@@ -1904,12 +2019,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d/private-networks?order_by=created_at_asc
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4/private-networks?order_by=created_at_asc
     method: GET
   response:
-    body: '{"private_network":[{"created_at":"2023-10-27T07:50:33.802251Z","dhcp_config":{"ip_id":"09bd22a7-33be-49b2-9908-7ac791b4b54f"},"ipam_ids":["09bd22a7-33be-49b2-9908-7ac791b4b54f"],"lb":{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:09.331766Z","zone":"fr-par-1"},"private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"ready","updated_at":"2023-10-27T07:50:42.801155Z"}],"total_count":1}'
+    body: '{"private_network":[{"created_at":"2024-02-22T07:32:39.051642Z","dhcp_config":{"ip_id":"24db878c-f664-4382-86c8-acd3ea4559f0"},"ipam_ids":["24db878c-f664-4382-86c8-acd3ea4559f0"],"lb":{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:15.232010Z","zone":"fr-par-1"},"private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"ready","updated_at":"2024-02-22T07:32:47.203782Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "1233"
@@ -1918,9 +2033,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:04 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1928,7 +2043,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0dc5edb4-b312-4b80-a8c3-efd1e4f18257
+      - d8a64044-17a4-414a-9f07-42a676cb7f4e
     status: 200 OK
     code: 200
     duration: ""
@@ -1937,12 +2052,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[{"created_at":"2023-10-27T06:12:43.533028Z","id":"f89670ea-9a9b-4e33-a255-72d8ae66ca0a","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-27T07:50:42.510387Z","zone":"fr-par-1"}],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:09.331766Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[{"created_at":"2024-02-22T07:16:06.849551Z","id":"e3622af2-3b01-43c6-95e7-78f7852ebc8e","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:46.868617Z","zone":"fr-par-1"}],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:15.232010Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "1109"
@@ -1951,9 +2066,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:04 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1961,7 +2076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f729a92-8595-4a78-a2cc-adc78a24e7fe
+      - 24401ac8-abf8-4673-80de-a4077a47a24f
     status: 200 OK
     code: 200
     duration: ""
@@ -1970,12 +2085,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/534c546e-f2a8-44f2-8b89-86559c0307ea
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/7f585740-724f-4d8b-b45c-7c19677824c7
     method: GET
   response:
-    body: '{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    body: '{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "319"
@@ -1984,9 +2099,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:04 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1994,7 +2109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d4b959c-1d28-43c1-85b5-8e959f266e80
+      - 3e11d77c-a292-493d-8684-5a50e325c744
     status: 200 OK
     code: 200
     duration: ""
@@ -2003,12 +2118,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/08e1a5d6-e11f-445d-896f-f9f5884517f7
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/11718cdd-9ffa-4cd1-80d9-9daa99774418
     method: GET
   response:
-    body: '{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"}'
+    body: '{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "401"
@@ -2017,9 +2132,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:04 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2027,7 +2142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 01408f9a-9e11-46de-bd84-fae949826f10
+      - f3bb156c-ac39-4010-94b1-a16d7489d113
     status: 200 OK
     code: 200
     duration: ""
@@ -2036,12 +2151,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/08a8311b-adb1-49b3-96ff-c011ee058db5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/c523270c-3905-4dd2-9c1c-66d600e21f56
     method: GET
   response:
-    body: '{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "574"
@@ -2050,9 +2165,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:04 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2060,7 +2175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e3d3b4c7-2c41-4103-bd7b-060e54c09b85
+      - b6f21b5b-92eb-4322-a9ee-0fa586eaf15a
     status: 200 OK
     code: 200
     duration: ""
@@ -2069,13 +2184,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6258f488-3864-4a3b-b3c2-9d9840ed4a45
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4aa37999-88a7-4f2a-bc80-a33793c83c57
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T07:49:57.265805Z","dhcp_enabled":true,"id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","name":"private
-      network with a DHCP config","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T07:49:57.265805Z","id":"4649bb05-cf93-42ab-8e55-e04b8638f73c","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:50:03.948947Z"},{"created_at":"2023-10-27T07:49:57.265805Z","id":"40176091-f218-4c1c-af64-e34e2fe4cae1","subnet":"fd46:78ab:30b8:4bb6::/64","updated_at":"2023-10-27T07:50:03.961572Z"}],"tags":[],"updated_at":"2023-10-27T07:50:07.898856Z","vpc_id":"efa5b723-b070-430a-8631-f3d487bacf8b"}'
+    body: '{"created_at":"2024-02-22T07:32:02.380969Z","dhcp_enabled":true,"id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","name":"private
+      network with a DHCP config","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.380969Z","id":"5779d7be-c4b4-4b85-8413-f6a8a486f057","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:08.845568Z"},{"created_at":"2024-02-22T07:32:02.380969Z","id":"afa401c7-8c1e-4532-9119-84627241c6fd","subnet":"fd5f:519c:6d46:80ab::/64","updated_at":"2024-02-22T07:32:08.848446Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.054451Z","vpc_id":"3fef7212-775c-4eee-bb08-aeb09ede1e2b"}'
     headers:
       Content-Length:
       - "732"
@@ -2084,9 +2199,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:04 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2094,7 +2209,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37c21920-e7ea-41ad-be6e-7fb9bacca635
+      - 2eadfdb9-2703-40c0-b57a-685cd849d4f1
     status: 200 OK
     code: 200
     duration: ""
@@ -2103,12 +2218,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/534c546e-f2a8-44f2-8b89-86559c0307ea
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742
     method: GET
   response:
-    body: '{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.247774Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.809037Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","ipam_config":null,"mac_address":"02:00:00:18:8B:AC","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"ready","updated_at":"2024-02-22T07:32:19.846150Z","zone":"fr-par-1"}],"id":"a27469f4-739a-4368-b269-e7f37cd80742","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:19.958865Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1992"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:10 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d33e810a-6ac9-4184-9bc3-2c00f05129f4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/7f585740-724f-4d8b-b45c-7c19677824c7
+    method: GET
+  response:
+    body: '{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "319"
@@ -2117,9 +2265,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:04 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2127,7 +2275,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb983e61-59f5-44c2-99ea-3977acc2cda5
+      - 10df51cb-2da6-4eb0-b583-f8b858419fa5
     status: 200 OK
     code: 200
     duration: ""
@@ -2136,78 +2284,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/11059644-d3c3-4d95-bdc3-4b41c4e2b52d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b06dffa0-7631-4fcc-8988-e8f2902e7c59
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T07:49:58.005592Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T07:50:05.640274Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"9d22e710-2b17-439c-bc74-0aaece0025c1","ipam_config":null,"mac_address":"02:00:00:14:73:C6","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"ready","updated_at":"2023-10-27T07:50:08.215893Z","zone":"fr-par-1"}],"id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","ip":{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"},"is_legacy":true,"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T07:50:08.312724Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1963"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9bb15bac-c15e-4537-8b90-e60f3de5f4fe
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d
-    method: GET
-  response:
-    body: '{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[{"created_at":"2023-10-27T06:12:43.533028Z","id":"f89670ea-9a9b-4e33-a255-72d8ae66ca0a","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-27T07:50:42.510387Z","zone":"fr-par-1"}],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:09.331766Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1109"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f058727a-fd06-4e9f-a4bc-8506688c1b69
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9d22e710-2b17-439c-bc74-0aaece0025c1
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-10-27T07:50:05.640274Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"9d22e710-2b17-439c-bc74-0aaece0025c1","ipam_config":null,"mac_address":"02:00:00:14:73:C6","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"ready","updated_at":"2023-10-27T07:50:08.215893Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.809037Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","ipam_config":null,"mac_address":"02:00:00:18:8B:AC","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"ready","updated_at":"2024-02-22T07:32:19.846150Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -2216,9 +2298,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2226,7 +2308,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee436cd8-7645-48ff-8d09-bdf994abcdf6
+      - bc420a22-da82-43ad-8ef7-00d3e49e041d
     status: 200 OK
     code: 200
     duration: ""
@@ -2235,23 +2317,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/11059644-d3c3-4d95-bdc3-4b41c4e2b52d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T07:49:58.005592Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T07:50:05.640274Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"9d22e710-2b17-439c-bc74-0aaece0025c1","ipam_config":null,"mac_address":"02:00:00:14:73:C6","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"ready","updated_at":"2023-10-27T07:50:08.215893Z","zone":"fr-par-1"}],"id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","ip":{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"},"is_legacy":true,"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T07:50:08.312724Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.247774Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:10.809037Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","ipam_config":null,"mac_address":"02:00:00:18:8B:AC","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"ready","updated_at":"2024-02-22T07:32:19.846150Z","zone":"fr-par-1"}],"id":"a27469f4-739a-4368-b269-e7f37cd80742","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:19.958865Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1963"
+      - "1992"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2259,7 +2341,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03fd8399-baa2-4455-a705-9ae1da0353e4
+      - c75a14b8-4180-4dd6-8fc1-0853f5b082f6
     status: 200 OK
     code: 200
     duration: ""
@@ -2268,12 +2350,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[{"created_at":"2023-10-27T06:12:43.533028Z","id":"f89670ea-9a9b-4e33-a255-72d8ae66ca0a","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-27T07:50:42.510387Z","zone":"fr-par-1"}],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:09.331766Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[{"created_at":"2024-02-22T07:16:06.849551Z","id":"e3622af2-3b01-43c6-95e7-78f7852ebc8e","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:46.868617Z","zone":"fr-par-1"}],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:15.232010Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "1109"
@@ -2282,9 +2364,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2292,7 +2374,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 03280321-a53c-473b-a8ad-36ca60a860a4
+      - 6042b0a4-fcb8-4718-9713-9dc16dd7c295
     status: 200 OK
     code: 200
     duration: ""
@@ -2301,31 +2383,64 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b06dffa0-7631-4fcc-8988-e8f2902e7c59
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.809037Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","ipam_config":null,"mac_address":"02:00:00:18:8B:AC","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"ready","updated_at":"2024-02-22T07:32:19.846150Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:10 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 665d6d85-013d-4003-a72e-113d89573c15
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:50:11.708409+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.65.46.9","private_nics":[{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:32:29.428327+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3149"
+      - "3174"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2333,7 +2448,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ac42ed14-fe72-4d1d-8641-396b7e2a7e6c
+      - 10aa4bf9-97ac-4987-aa95-ee19c2301912
     status: 200 OK
     code: 200
     duration: ""
@@ -2342,23 +2457,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9d22e710-2b17-439c-bc74-0aaece0025c1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T07:50:05.640274Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"9d22e710-2b17-439c-bc74-0aaece0025c1","ipam_config":null,"mac_address":"02:00:00:14:73:C6","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"ready","updated_at":"2023-10-27T07:50:08.215893Z","zone":"fr-par-1"}'
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[{"created_at":"2024-02-22T07:16:06.849551Z","id":"e3622af2-3b01-43c6-95e7-78f7852ebc8e","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:46.868617Z","zone":"fr-par-1"}],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:15.232010Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "984"
+      - "1109"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2366,7 +2481,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86a5ace4-769f-4768-8fb7-0b3746c9c945
+      - 7b33c78d-d543-4764-a53f-a7a48f4f9775
     status: 200 OK
     code: 200
     duration: ""
@@ -2375,9 +2490,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2389,9 +2504,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2399,7 +2514,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f37c007b-3729-4905-af51-c51028f92802
+      - 9913c5df-0a08-4a66-a10c-23cef4066082
     status: 200 OK
     code: 200
     duration: ""
@@ -2408,45 +2523,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d/private-networks?order_by=created_at_asc
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics
     method: GET
   response:
-    body: '{"private_network":[{"created_at":"2023-10-27T07:50:33.802251Z","dhcp_config":{"ip_id":"09bd22a7-33be-49b2-9908-7ac791b4b54f"},"ipam_ids":["09bd22a7-33be-49b2-9908-7ac791b4b54f"],"lb":{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:09.331766Z","zone":"fr-par-1"},"private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"ready","updated_at":"2023-10-27T07:50:42.801155Z"}],"total_count":1}'
-    headers:
-      Content-Length:
-      - "1233"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3babb8fb-9027-4fa0-97dc-532232107b5d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics
-    method: GET
-  response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2455,12 +2537,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Link:
-      - </servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics?page=1&per_page=50&>;
+      - </servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2468,7 +2550,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 87913a41-d42f-40d6-9c03-b46c69188d79
+      - 3bdfb037-0b94-47dd-8c3d-8d40deb76770
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2479,78 +2561,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9d22e710-2b17-439c-bc74-0aaece0025c1
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4/private-networks?order_by=created_at_asc
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T07:50:05.640274Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"9d22e710-2b17-439c-bc74-0aaece0025c1","ipam_config":null,"mac_address":"02:00:00:14:73:C6","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"ready","updated_at":"2023-10-27T07:50:08.215893Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "984"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 54cd2f38-9386-4b3e-9b02-35b1280031fb
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d
-    method: GET
-  response:
-    body: '{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[{"created_at":"2023-10-27T06:12:43.533028Z","id":"f89670ea-9a9b-4e33-a255-72d8ae66ca0a","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-27T07:50:42.510387Z","zone":"fr-par-1"}],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:09.331766Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1109"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3511cf66-cb94-49c3-a974-9b46077af77b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d/private-networks?order_by=created_at_asc
-    method: GET
-  response:
-    body: '{"private_network":[{"created_at":"2023-10-27T07:50:33.802251Z","dhcp_config":{"ip_id":"09bd22a7-33be-49b2-9908-7ac791b4b54f"},"ipam_ids":["09bd22a7-33be-49b2-9908-7ac791b4b54f"],"lb":{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:09.331766Z","zone":"fr-par-1"},"private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"ready","updated_at":"2023-10-27T07:50:42.801155Z"}],"total_count":1}'
+    body: '{"private_network":[{"created_at":"2024-02-22T07:32:39.051642Z","dhcp_config":{"ip_id":"24db878c-f664-4382-86c8-acd3ea4559f0"},"ipam_ids":["24db878c-f664-4382-86c8-acd3ea4559f0"],"lb":{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:15.232010Z","zone":"fr-par-1"},"private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"ready","updated_at":"2024-02-22T07:32:47.203782Z"}],"total_count":1}'
     headers:
       Content-Length:
       - "1233"
@@ -2559,9 +2575,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2569,7 +2585,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93a4bb4e-5028-4bda-beb4-dca7789d03a1
+      - bc5a2a8b-44e2-41ab-8ce9-41b01b10ffc8
     status: 200 OK
     code: 200
     duration: ""
@@ -2578,31 +2594,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b06dffa0-7631-4fcc-8988-e8f2902e7c59
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:50:11.708409+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.65.46.9","private_nics":[{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
-      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.809037Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","ipam_config":null,"mac_address":"02:00:00:18:8B:AC","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"ready","updated_at":"2024-02-22T07:32:19.846150Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "3149"
+      - "984"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2610,7 +2618,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ba5a88e3-87d0-47d8-ba3b-36c8e70b4379
+      - cdf1bbc7-c578-46c5-aba4-3b782b83143d
     status: 200 OK
     code: 200
     duration: ""
@@ -2619,9 +2627,42 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9d22e710-2b17-439c-bc74-0aaece0025c1?cleanup_dhcp=true
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4
+    method: GET
+  response:
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[{"created_at":"2024-02-22T07:16:06.849551Z","id":"e3622af2-3b01-43c6-95e7-78f7852ebc8e","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:46.868617Z","zone":"fr-par-1"}],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:15.232010Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1109"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:11 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ad5417dd-bcd6-47f3-bd15-0920a2cb7968
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b06dffa0-7631-4fcc-8988-e8f2902e7c59?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -2631,9 +2672,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2641,7 +2682,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84f661ec-8137-437e-9632-7f4dec40847a
+      - c139b33e-514b-4f48-a988-ef5c17f747be
     status: 204 No Content
     code: 204
     duration: ""
@@ -2650,12 +2691,53 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9d22e710-2b17-439c-bc74-0aaece0025c1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T07:50:05.640274Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T07:49:57.272395Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"08a8311b-adb1-49b3-96ff-c011ee058db5","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T07:49:57.272395Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"9d22e710-2b17-439c-bc74-0aaece0025c1","ipam_config":null,"mac_address":"02:00:00:14:73:C6","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","status":"detaching","updated_at":"2023-10-27T07:51:05.907601Z","zone":"fr-par-1"}'
+    body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:32:29.428327+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
+      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3174"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:11 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e8ab2a86-efed-4e15-b008-b4deec7cc1dc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b06dffa0-7631-4fcc-8988-e8f2902e7c59
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:10.809037Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.423028Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"c523270c-3905-4dd2-9c1c-66d600e21f56","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.423028Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","ipam_config":null,"mac_address":"02:00:00:18:8B:AC","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"detaching","updated_at":"2024-02-22T07:33:11.778422Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "988"
@@ -2664,9 +2746,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:05 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2674,65 +2756,32 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab59c6f6-11fb-4e77-85a1-30458551a518
+      - cf22fbab-ca26-4beb-ad48-3d0730ee03dc
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d/private-networks/6258f488-3864-4a3b-b3c2-9d9840ed4a45/detach
-    method: POST
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7b41ea8e-8a93-41bc-87ca-4f3f25d03a5c
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
     body: ""
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4/private-networks?order_by=created_at_asc
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[{"created_at":"2023-10-27T06:12:43.533028Z","id":"f89670ea-9a9b-4e33-a255-72d8ae66ca0a","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-27T07:50:42.510387Z","zone":"fr-par-1"}],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:50:09.331766Z","zone":"fr-par-1"}'
+    body: '{"private_network":[{"created_at":"2024-02-22T07:32:39.051642Z","dhcp_config":{"ip_id":"24db878c-f664-4382-86c8-acd3ea4559f0"},"ipam_ids":["24db878c-f664-4382-86c8-acd3ea4559f0"],"lb":{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:15.232010Z","zone":"fr-par-1"},"private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","status":"ready","updated_at":"2024-02-22T07:32:47.203782Z"}],"total_count":1}'
     headers:
       Content-Length:
-      - "1109"
+      - "1233"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:06 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2740,7 +2789,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a177ccd2-fa8a-46a7-9170-0dffaa4a06cb
+      - b52f3b96-3b0c-4067-8008-2b3a51db2996
     status: 200 OK
     code: 200
     duration: ""
@@ -2751,12 +2800,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/action","href_result":"/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8","id":"fe63f2a8-1f35-4cf2-abb6-3ec385cafb8c","started_at":"2023-10-27T07:51:06.207718+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/action","href_result":"/servers/814291e7-5ff7-4ae1-9615-20243b1c876e","id":"285b18ab-e43f-490b-953f-973cd930c29f","started_at":"2024-02-22T07:33:12.050759+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -2765,11 +2814,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:06 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/fe63f2a8-1f35-4cf2-abb6-3ec385cafb8c
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/285b18ab-e43f-490b-953f-973cd930c29f
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2777,60 +2826,21 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b4627ec-4ff3-4bbe-9a85-7728d99f389f
+      - 4bd54e9c-8cd5-45f0-bacd-0785a69267c0
     status: 202 Accepted
     code: 202
     duration: ""
 - request:
-    body: ""
+    body: '{}'
     form: {}
     headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:51:05.928338+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.65.46.9","private_nics":[{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
-      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3117"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:06 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0e7d29e5-49d3-40c7-9421-edca28651a6a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d?release_ip=false
-    method: DELETE
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4/private-networks/4aa37999-88a7-4f2a-bc80-a33793c83c57/detach
+    method: POST
   response:
     body: ""
     headers:
@@ -2839,9 +2849,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:06 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2849,7 +2859,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63b9b465-dd94-483c-a120-e0568c8b2f83
+      - 1c244ceb-a43b-48ff-929a-166870df46fa
     status: 204 No Content
     code: 204
     duration: ""
@@ -2858,12 +2868,117 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
-    body: '{"backend_count":0,"created_at":"2023-10-27T07:50:03.272667Z","description":"","frontend_count":0,"id":"81b984cc-a939-4be6-a09d-1f2913f5844d","instances":[{"created_at":"2023-10-27T06:12:43.533028Z","id":"f89670ea-9a9b-4e33-a255-72d8ae66ca0a","ip_address":"","region":"fr-par","status":"ready","updated_at":"2023-10-27T07:50:42.510387Z","zone":"fr-par-1"}],"ip":[{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":"81b984cc-a939-4be6-a09d-1f2913f5844d","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","private_network_count":1,"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_delete","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2023-10-27T07:51:06.294864Z","zone":"fr-par-1"}'
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:33:11.885415+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
+      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3142"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:12 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 52e85470-d874-4baa-8107-2f54b28f5d78
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4
+    method: GET
+  response:
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[{"created_at":"2024-02-22T07:16:06.849551Z","id":"e3622af2-3b01-43c6-95e7-78f7852ebc8e","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:46.868617Z","zone":"fr-par-1"}],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"ready","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:32:15.232010Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1109"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:12 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 14858cce-69f7-4e9d-9c0d-e241c75b39cf
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4?release_ip=false
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:12 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - aaa1d287-015f-4ceb-943a-ef969b4b248f
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4
+    method: GET
+  response:
+    body: '{"backend_count":0,"created_at":"2024-02-22T07:32:08.503164Z","description":"","frontend_count":0,"id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","instances":[{"created_at":"2024-02-22T07:16:06.849551Z","id":"e3622af2-3b01-43c6-95e7-78f7852ebc8e","ip_address":"","region":"fr-par","status":"ready","updated_at":"2024-02-22T07:32:46.868617Z","zone":"fr-par-1"}],"ip":[{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":"2b33be20-4e7c-4172-b20a-4fa227988fb4","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}],"name":"test-lb-with-private-network-configs","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","private_network_count":1,"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","route_count":0,"ssl_compatibility_level":"ssl_compatibility_level_intermediate","status":"to_delete","subscriber":null,"tags":[],"type":"lb-s","updated_at":"2024-02-22T07:33:12.550301Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "1113"
@@ -2872,9 +2987,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:06 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2882,7 +2997,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a6e3166-a0e0-4ec2-bc8d-1d2b4a5dd06a
+      - a31c4393-1b36-474c-98fb-b4d04986dfc4
     status: 200 OK
     code: 200
     duration: ""
@@ -2891,12 +3006,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9d22e710-2b17-439c-bc74-0aaece0025c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b06dffa0-7631-4fcc-8988-e8f2902e7c59
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"9d22e710-2b17-439c-bc74-0aaece0025c1","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2905,9 +3020,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:11 GMT
+      - Thu, 22 Feb 2024 07:33:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2915,7 +3030,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13ee000d-6957-4159-a6db-c8ea39004905
+      - 672f4755-ee69-4108-ad3c-f08d07a6792f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2924,23 +3039,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/11059644-d3c3-4d95-bdc3-4b41c4e2b52d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T07:49:58.005592Z","gateway_networks":[],"id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","ip":{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"},"is_legacy":true,"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T07:50:08.312724Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.247774Z","gateway_networks":[],"id":"a27469f4-739a-4368-b269-e7f37cd80742","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:19.958865Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "979"
+      - "1008"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:11 GMT
+      - Thu, 22 Feb 2024 07:33:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2948,7 +3063,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 706c9afa-afd2-44f0-80aa-f7156396f517
+      - c6790048-16db-4dca-9b4b-465ca50d4dc8
     status: 200 OK
     code: 200
     duration: ""
@@ -2957,12 +3072,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/08a8311b-adb1-49b3-96ff-c011ee058db5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/c523270c-3905-4dd2-9c1c-66d600e21f56
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"08a8311b-adb1-49b3-96ff-c011ee058db5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"c523270c-3905-4dd2-9c1c-66d600e21f56","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -2971,9 +3086,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:11 GMT
+      - Thu, 22 Feb 2024 07:33:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2981,7 +3096,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 902e7f18-fb6b-499e-9460-34a2e9fb09ff
+      - 10449917-e741-4035-9112-028697f9221d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2990,31 +3105,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:51:05.928338+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.65.46.9","private_nics":[{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:33:11.885415+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3117"
+      - "3142"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:11 GMT
+      - Thu, 22 Feb 2024 07:33:17 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3022,7 +3137,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bca4245b-935d-48b9-8d0d-cbec7003b5b6
+      - 8e4543df-ae5c-460e-8a7f-9e6bd5380f1c
     status: 200 OK
     code: 200
     duration: ""
@@ -3031,31 +3146,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:51:05.928338+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.65.46.9","private_nics":[{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:33:11.885415+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3117"
+      - "3142"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:16 GMT
+      - Thu, 22 Feb 2024 07:33:22 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3063,7 +3178,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9e5da36-36de-4274-b786-c36c7157ddd0
+      - 257a0f31-492a-4460-a82c-4b87d08d0fd8
     status: 200 OK
     code: 200
     duration: ""
@@ -3072,31 +3187,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:51:05.928338+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.65.46.9","private_nics":[{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:33:11.885415+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3117"
+      - "3142"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:21 GMT
+      - Thu, 22 Feb 2024 07:33:27 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3104,7 +3219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b93a2ddf-3995-47b2-9a64-82da794b0b0f
+      - 4615cf9c-58e6-456c-a60c-8976fe46b022
     status: 200 OK
     code: 200
     duration: ""
@@ -3113,31 +3228,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"18","hypervisor_id":"1602","node_id":"5","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:51:05.928338+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.65.46.9","private_nics":[{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:33:11.885415+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3117"
+      - "3142"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:26 GMT
+      - Thu, 22 Feb 2024 07:33:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3145,7 +3260,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1dc1d566-0604-49cb-ae5f-bcd9122760d6
+      - db492efa-716c-4468-a941-821018fae14c
     status: 200 OK
     code: 200
     duration: ""
@@ -3154,31 +3269,371 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:33:11.885415+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
+      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3142"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:38 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 22010257-5eb3-4a54-bc6f-0be8148b5698
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4
+    method: GET
+  response:
+    body: '{"message":"lbs not Found"}'
+    headers:
+      Content-Length:
+      - "27"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f85613f5-b5f0-4cab-824d-934c0efbc489
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4
+    method: GET
+  response:
+    body: '{"message":"lbs not Found"}'
+    headers:
+      Content-Length:
+      - "27"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0e410a78-fe43-4b6d-87aa-8efe98bba70b
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.247774Z","gateway_networks":[],"id":"a27469f4-739a-4368-b269-e7f37cd80742","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:32:03.118057Z","gateway_id":"a27469f4-739a-4368-b269-e7f37cd80742","id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.118057Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"tf-test-public-gw","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:19.958865Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1008"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6e141b54-624e-4645-a9b6-fe9dc857b795
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/7f585740-724f-4d8b-b45c-7c19677824c7
+    method: GET
+  response:
+    body: '{"id":"7f585740-724f-4d8b-b45c-7c19677824c7","ip_address":"51.159.11.206","lb_id":null,"organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","reverse":"51-159-11-206.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "285"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - afa5835f-df91-491b-936f-d0fe7029d321
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742?cleanup_dhcp=false
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 37096549-0780-41be-860f-bd22cc099565
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"a27469f4-739a-4368-b269-e7f37cd80742","type":"not_found"}'
+    headers:
+      Content-Length:
+      - "128"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:42 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9e67a8f7-22bf-4e86-aa1f-c68deacbc186
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/11718cdd-9ffa-4cd1-80d9-9daa99774418
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b651742e-4f2e-4c01-93f3-a336ae5e5bc0
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/7f585740-724f-4d8b-b45c-7c19677824c7
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - edced50b-2154-42ba-b16a-57f6b1efcd47
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"36","hypervisor_id":"2002","node_id":"28","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:33:11.885415+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.68.158.55","private_nics":[{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
+      Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3142"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:43 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a51f94ed-27f2-4f3e-b578-d9609c4af7fc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:51:26.956893+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:33:44.775826+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2997"
+      - "3019"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:32 GMT
+      - Thu, 22 Feb 2024 07:33:48 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3186,7 +3641,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5463e83-b489-4728-b5ed-e56c574a626f
+      - b504f76d-01fc-4f57-a220-5548676faa5d
     status: 200 OK
     code: 200
     duration: ""
@@ -3195,12 +3650,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3209,12 +3664,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:32 GMT
+      - Thu, 22 Feb 2024 07:33:48 GMT
       Link:
-      - </servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics?page=1&per_page=50&>;
+      - </servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3222,7 +3677,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fa5bfac2-628d-4557-a517-0c4f42d32e3b
+      - b8fca007-a283-4b08-b237-3f8c36940cfb
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3233,12 +3688,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics/1676de75-0790-49c2-89ce-471583a6dfb1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics/c13014c7-3d58-4657-87ef-8817eb917c5b
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T07:50:15.733547+00:00","id":"1676de75-0790-49c2-89ce-471583a6dfb1","mac_address":"02:00:00:14:73:c7","modification_date":"2023-10-27T07:50:46.862423+00:00","private_network_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","server_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.193385+00:00","id":"c13014c7-3d58-4657-87ef-8817eb917c5b","mac_address":"02:00:00:18:8b:b4","modification_date":"2024-02-22T07:33:02.524167+00:00","private_network_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","server_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -3247,9 +3702,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:32 GMT
+      - Thu, 22 Feb 2024 07:33:48 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3257,7 +3712,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d6e391d-7f40-4381-808f-e3bd344be38f
+      - 572040b0-04ca-448d-9d74-c1d956782c5d
     status: 200 OK
     code: 200
     duration: ""
@@ -3266,9 +3721,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics/1676de75-0790-49c2-89ce-471583a6dfb1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics/c13014c7-3d58-4657-87ef-8817eb917c5b
     method: DELETE
   response:
     body: ""
@@ -3276,9 +3731,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 27 Oct 2023 07:51:32 GMT
+      - Thu, 22 Feb 2024 07:33:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3286,7 +3741,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ec92f668-47de-49fb-9bcf-2e2bac64654a
+      - dd4cea3e-e203-4e64-82dd-a164c6acf41c
     status: 204 No Content
     code: 204
     duration: ""
@@ -3295,12 +3750,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8/private_nics/1676de75-0790-49c2-89ce-471583a6dfb1
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e/private_nics/c13014c7-3d58-4657-87ef-8817eb917c5b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"1676de75-0790-49c2-89ce-471583a6dfb1","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"c13014c7-3d58-4657-87ef-8817eb917c5b","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -3309,9 +3764,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:32 GMT
+      - Thu, 22 Feb 2024 07:33:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3319,7 +3774,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a9ccd277-ad5e-4c20-b218-b089591b3160
+      - 757596b4-4201-4dde-af09-937aec217bef
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3328,31 +3783,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T07:49:58.404684+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:b9:0f","maintenances":[],"modification_date":"2023-10-27T07:51:26.956893+00:00","name":"Scaleway
-      Terraform Provider","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T07:49:58.404684+00:00","export_uri":null,"id":"1d12bd43-e3da-44cc-b352-4445e6ca2172","modification_date":"2023-10-27T07:49:58.404684+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.392195+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-terraform-provider","id":"814291e7-5ff7-4ae1-9615-20243b1c876e","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:ad","maintenances":[],"modification_date":"2024-02-22T07:33:44.775826+00:00","name":"Scaleway
+      Terraform Provider","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.392195+00:00","export_uri":null,"id":"443c1cf4-83d7-4b33-bc5a-cd778de6d66a","modification_date":"2024-02-22T07:32:03.392195+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"814291e7-5ff7-4ae1-9615-20243b1c876e","name":"Scaleway
       Terraform Provider"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2636"
+      - "2658"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:33 GMT
+      - Thu, 22 Feb 2024 07:33:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3360,7 +3815,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 040e459a-ab65-46dd-914c-8016ceff5f41
+      - 33e47d6e-d870-431b-9452-3b7086c6dce1
     status: 200 OK
     code: 200
     duration: ""
@@ -3369,9 +3824,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: DELETE
   response:
     body: ""
@@ -3379,9 +3834,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 27 Oct 2023 07:51:33 GMT
+      - Thu, 22 Feb 2024 07:33:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3389,7 +3844,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b1ff047-a6d7-4a64-9348-42884d55f34e
+      - ec08127e-01f7-49a8-b3aa-eef110465704
     status: 204 No Content
     code: 204
     duration: ""
@@ -3398,12 +3853,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -3412,9 +3867,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:33 GMT
+      - Thu, 22 Feb 2024 07:33:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3422,7 +3877,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1898a3d-fa67-4f2b-96c6-c121d573c170
+      - f2e57494-92ac-46f6-a048-cabef611c43c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3431,9 +3886,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/1d12bd43-e3da-44cc-b352-4445e6ca2172
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/443c1cf4-83d7-4b33-bc5a-cd778de6d66a
     method: DELETE
   response:
     body: ""
@@ -3441,9 +3896,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 27 Oct 2023 07:51:33 GMT
+      - Thu, 22 Feb 2024 07:33:49 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3451,7 +3906,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d3fbf49d-911d-4deb-97cc-b8b65d4bddad
+      - eede1835-a471-441e-af4f-ee6761baed6e
     status: 204 No Content
     code: 204
     duration: ""
@@ -3460,141 +3915,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d
-    method: GET
-  response:
-    body: '{"message":"lbs not Found"}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6eda2e5e-0dc8-4ad9-ba19-5fbc9dc2d641
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d
-    method: GET
-  response:
-    body: '{"message":"lbs not Found"}'
-    headers:
-      Content-Length:
-      - "27"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 53bb4853-686e-479e-97bc-60843bc83fc8
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/11059644-d3c3-4d95-bdc3-4b41c4e2b52d
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T07:49:58.005592Z","gateway_networks":[],"id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","ip":{"address":"51.15.203.117","created_at":"2023-10-27T07:49:57.850232Z","gateway_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"117-203-15-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T07:49:57.850232Z","zone":"fr-par-1"},"is_legacy":true,"name":"tf-test-public-gw","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T07:50:08.312724Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "979"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - baa58695-2808-47c7-ab33-d90f2f057886
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/534c546e-f2a8-44f2-8b89-86559c0307ea
-    method: GET
-  response:
-    body: '{"id":"534c546e-f2a8-44f2-8b89-86559c0307ea","ip_address":"51.158.58.116","lb_id":null,"organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","reverse":"51-158-58-116.lb.fr-par.scw.cloud","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "285"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4464205c-3929-4306-b5a4-05c736b7e3d3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/11059644-d3c3-4d95-bdc3-4b41c4e2b52d?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4aa37999-88a7-4f2a-bc80-a33793c83c57
     method: DELETE
   response:
     body: ""
@@ -3604,9 +3927,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:36 GMT
+      - Thu, 22 Feb 2024 07:33:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3614,7 +3937,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e12ed628-d5ca-46c2-ba0d-cc09a734fe35
+      - a2793175-12d1-48a6-af37-e4e418d8dba1
     status: 204 No Content
     code: 204
     duration: ""
@@ -3623,138 +3946,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/11059644-d3c3-4d95-bdc3-4b41c4e2b52d
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/814291e7-5ff7-4ae1-9615-20243b1c876e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","type":"not_found"}'
-    headers:
-      Content-Length:
-      - "128"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ed4969d5-4125-4bd8-a09b-be5a12d4fafe
-    status: 404 Not Found
-    code: 404
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/534c546e-f2a8-44f2-8b89-86559c0307ea
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - af9e64ec-8447-49c6-940e-55fc404edeb2
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6258f488-3864-4a3b-b3c2-9d9840ed4a45
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 80e9cc86-c389-4f1b-9429-23a88ef8610a
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/08e1a5d6-e11f-445d-896f-f9f5884517f7
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 07:51:36 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6cdaf7d7-72fb-40c0-8367-b56fa5b000d2
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/4eaf5234-02df-4ace-a409-e1f470ea1cb8
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"4eaf5234-02df-4ace-a409-e1f470ea1cb8","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"814291e7-5ff7-4ae1-9615-20243b1c876e","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -3763,9 +3960,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:37 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3773,7 +3970,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65ffb653-1941-41f3-93eb-613f01ccee8a
+      - 7a1c8df1-a54a-4996-9af3-5e7bb91bc276
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3782,9 +3979,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4
     method: GET
   response:
     body: '{"message":"lbs not Found"}'
@@ -3796,9 +3993,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:37 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3806,7 +4003,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 73b0f12d-8e83-40af-8a48-fe81a69a5e37
+      - b1acb8b8-3526-4309-8171-7e5a873a7e5f
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3815,9 +4012,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/81b984cc-a939-4be6-a09d-1f2913f5844d
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/lbs/2b33be20-4e7c-4172-b20a-4fa227988fb4
     method: GET
   response:
     body: '{"message":"lbs not Found"}'
@@ -3829,9 +4026,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:37 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3839,7 +4036,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b95647d5-9d7d-42b3-956c-fb73fb9625ce
+      - b3e46db1-2b00-4b24-ad8b-fb97a72c13d1
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3848,9 +4045,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/534c546e-f2a8-44f2-8b89-86559c0307ea
+    url: https://api.scaleway.com/lb/v1/zones/fr-par-1/ips/7f585740-724f-4d8b-b45c-7c19677824c7
     method: GET
   response:
     body: '{"message":"ips not Found"}'
@@ -3862,9 +4059,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:37 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3872,7 +4069,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48b4d838-d93f-476a-bd74-f0d854c1d992
+      - 1f148264-d54e-45b6-9b40-904202e8c38c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3881,12 +4078,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/9d22e710-2b17-439c-bc74-0aaece0025c1
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/b06dffa0-7631-4fcc-8988-e8f2902e7c59
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"9d22e710-2b17-439c-bc74-0aaece0025c1","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"b06dffa0-7631-4fcc-8988-e8f2902e7c59","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3895,9 +4092,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:37 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3905,7 +4102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e430c13-5c6d-4773-8f28-d9bdfb7894b6
+      - b8c436fa-367e-491d-8cdc-126a568ec462
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3914,12 +4111,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/6258f488-3864-4a3b-b3c2-9d9840ed4a45
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/4aa37999-88a7-4f2a-bc80-a33793c83c57
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"private_network","resource_id":"6258f488-3864-4a3b-b3c2-9d9840ed4a45","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"private_network","resource_id":"4aa37999-88a7-4f2a-bc80-a33793c83c57","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3928,9 +4125,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:37 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3938,7 +4135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6846453b-4b76-4489-a964-d31b4f20e298
+      - ea2efa70-30f3-4021-8d7d-2bd059fdae10
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3947,12 +4144,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/08a8311b-adb1-49b3-96ff-c011ee058db5
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/c523270c-3905-4dd2-9c1c-66d600e21f56
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"08a8311b-adb1-49b3-96ff-c011ee058db5","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"c523270c-3905-4dd2-9c1c-66d600e21f56","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3961,9 +4158,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:37 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3971,7 +4168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7e2617a9-cc74-41a9-ba92-cc301c439b0e
+      - c629785e-930b-4443-8175-bb3aa8de141d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3980,12 +4177,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/11059644-d3c3-4d95-bdc3-4b41c4e2b52d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/a27469f4-739a-4368-b269-e7f37cd80742
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"11059644-d3c3-4d95-bdc3-4b41c4e2b52d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"a27469f4-739a-4368-b269-e7f37cd80742","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3994,9 +4191,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:37 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4004,7 +4201,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 363f6e98-d386-4447-b447-3065fe81ac93
+      - ac499b1b-25ec-46ab-85e4-5b4d8b06c38e
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4013,12 +4210,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/08e1a5d6-e11f-445d-896f-f9f5884517f7
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/11718cdd-9ffa-4cd1-80d9-9daa99774418
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"ip","resource_id":"08e1a5d6-e11f-445d-896f-f9f5884517f7","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"ip","resource_id":"11718cdd-9ffa-4cd1-80d9-9daa99774418","type":"not_found"}'
     headers:
       Content-Length:
       - "123"
@@ -4027,9 +4224,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 07:51:37 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4037,7 +4234,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45c1bd3c-ad42-4042-9fed-dda74c7846a2
+      - d206aa0a-dd8a-441d-aaf3-878f731e8237
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/vpc-public-gateway-dhcp-entry-basic.cassette.yaml
+++ b/scaleway/testdata/vpc-public-gateway-dhcp-entry-basic.cassette.yaml
@@ -2,29 +2,29 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","subnet":"192.168.1.0/24"}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"192.168.1.0/24"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:52 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 612d9617-6e72-45b4-8e86-93c92aa29060
+      - 7acff037-4d2f-47cf-88f8-a7a8e5bd869e
     status: 200 OK
     code: 200
     duration: ""
@@ -41,23 +41,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/ba7b9e36-bc4d-4635-b157-f546b9529478
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1f850024-cf04-440d-bdea-6d08d359fedf
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:52 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -65,34 +65,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0de4eaae-1122-47c6-b609-f4ccf10e3f1d
+      - a8e1faf6-0c58-4f8c-bc60-81c79740c1a8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":null,"id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":null,"id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "360"
+      - "371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:52 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -100,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 22b157d8-5952-445b-810f-95e5a8d8b405
+      - 8652c502-56ea-4976-9f30-36cacbac20fb
     status: 200 OK
     code: 200
     duration: ""
@@ -109,23 +109,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/11a60387-eb33-4cde-aa85-ffb296e00764
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/dac6834e-d99c-4af7-ba68-592059f80ac0
     method: GET
   response:
-    body: '{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":null,"id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":null,"id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "360"
+      - "371"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:52 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -133,34 +133,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2cf757a-e283-402f-b5ef-06aed2e69daf
+      - 72d345e6-f8e2-4de7-8c22-18861b9acf7c
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"pn_test_network","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null}'
+    body: '{"name":"pn_test_network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2023-11-06T14:47:51.999429Z","dhcp_enabled":true,"id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","name":"pn_test_network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-11-06T14:47:51.999429Z","id":"47e5e57a-73a5-4728-96c4-a1cececf93c0","subnet":"172.16.60.0/22","updated_at":"2023-11-06T14:47:51.999429Z"},{"created_at":"2023-11-06T14:47:51.999429Z","id":"326f59fb-6607-474f-8630-9c934551a4d8","subnet":"fd46:78ab:30b8:718a::/64","updated_at":"2023-11-06T14:47:51.999429Z"}],"tags":[],"updated_at":"2023-11-06T14:47:51.999429Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
+    body: '{"created_at":"2024-02-22T07:32:02.824425Z","dhcp_enabled":true,"id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.824425Z","id":"128fb77a-acbb-4326-bc6e-c3604507e0b2","subnet":"172.16.104.0/22","updated_at":"2024-02-22T07:32:02.824425Z"},{"created_at":"2024-02-22T07:32:02.824425Z","id":"3209f36a-6834-45d1-a999-204d092778a6","subnet":"fd5f:519c:6d46:5aa6::/64","updated_at":"2024-02-22T07:32:02.824425Z"}],"tags":[],"updated_at":"2024-02-22T07:32:02.824425Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "699"
+      - "717"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:52 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -168,67 +168,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e71e8324-1a89-4183-b316-a3aa045e9da4
+      - 720b1558-881c-43d6-a858-8e7cbbca11b1
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bbc0e116-ceaf-40a4-b934-d31252d5e23c
-    method: GET
-  response:
-    body: '{"created_at":"2023-11-06T14:47:51.999429Z","dhcp_enabled":true,"id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","name":"pn_test_network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-11-06T14:47:51.999429Z","id":"47e5e57a-73a5-4728-96c4-a1cececf93c0","subnet":"172.16.60.0/22","updated_at":"2023-11-06T14:47:51.999429Z"},{"created_at":"2023-11-06T14:47:51.999429Z","id":"326f59fb-6607-474f-8630-9c934551a4d8","subnet":"fd46:78ab:30b8:718a::/64","updated_at":"2023-11-06T14:47:51.999429Z"}],"tags":[],"updated_at":"2023-11-06T14:47:51.999429Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
-    headers:
-      Content-Length:
-      - "699"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 06 Nov 2023 14:47:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3a1f6642-e4a4-49c7-9cd7-0e7a0be0e781
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"foobar","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"11a60387-eb33-4cde-aa85-ffb296e00764","enable_smtp":false,"enable_bastion":false}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"foobar","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"dac6834e-d99c-4af7-ba68-592059f80ac0","enable_smtp":false,"enable_bastion":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:47:52.873073Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:03.329202Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "942"
+      - "1002"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:52 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -236,7 +203,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b73a1ab0-f665-47cf-9fd9-22350bbd05da
+      - f9e14a2c-566b-4448-8d74-83551e95439a
     status: 200 OK
     code: 200
     duration: ""
@@ -245,23 +212,89 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:03.387031Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1005"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ecd9cfc8-7d1a-442f-a4e5-a8741043ba57
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-22T07:32:02.824425Z","dhcp_enabled":true,"id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.824425Z","id":"128fb77a-acbb-4326-bc6e-c3604507e0b2","subnet":"172.16.104.0/22","updated_at":"2024-02-22T07:32:02.824425Z"},{"created_at":"2024-02-22T07:32:02.824425Z","id":"3209f36a-6834-45d1-a999-204d092778a6","subnet":"fd5f:519c:6d46:5aa6::/64","updated_at":"2024-02-22T07:32:02.824425Z"}],"tags":[],"updated_at":"2024-02-22T07:32:02.824425Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "717"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 628389f3-dfb9-4330-86eb-b7538434ef65
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_focal&order_by=created_at_asc&type=instance_local&zone=fr-par-1
     method: GET
   response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"10b2d3c3-bfa7-42d4-910b-389e95f95ccb","label":"ubuntu_focal","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
+    body: '{"local_images":[{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"2f1f7a57-c508-4f72-9f7f-536b316f36e1","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"},{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"5d083890-4354-47ab-b769-8b0de601eb3a","label":"ubuntu_focal","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
     headers:
       Content-Length:
-      - "1179"
+      - "1260"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:52 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -269,7 +302,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea9b71f4-de6a-4ade-891d-d39d84e292f4
+      - ff7386c2-7f8d-4f2a-b0cb-f770f6a08f93
     status: 200 OK
     code: 200
     duration: ""
@@ -278,59 +311,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:47:52.910689Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "945"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 06 Nov 2023 14:47:52 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fc698e9c-a392-4be0-a716-53110c7c41a7
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38421"
+      - "38183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:52 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -338,9 +338,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 97a47731-a3b0-4292-a0e9-a2e5c4d7c3a7
+      - 531dcce0-3022-4af9-a7f4-648d6aa29b4c
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
@@ -349,26 +349,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4865"
+      - "8882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:53 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -376,44 +376,44 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6e19f658-8f87-48ab-b56a-3032f13ffb23
+      - f91c79bd-60a3-498e-b31c-10d1ddfb72bb
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-srv-hungry-nobel","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5"}'
+    body: '{"name":"tf-srv-nervous-hawking","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"5d083890-4354-47ab-b769-8b0de601eb3a","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:47:53.538515+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:03.851330+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2639"
+      - "2670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:53 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -421,7 +421,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 26c52220-44dc-460a-8ac1-39ee693aae0d
+      - 8f4e607e-3a1e-4996-a07b-8e1c7a19104d
     status: 201 Created
     code: 201
     duration: ""
@@ -430,29 +430,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:47:53.538515+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:03.851330+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2639"
+      - "2670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:54 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -460,7 +460,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9443009-bb13-4e66-9567-4bfcacc362d2
+      - df5d90df-4c3b-42f8-bdf3-180ed088a089
     status: 200 OK
     code: 200
     duration: ""
@@ -469,29 +469,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:47:53.538515+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:03.851330+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2639"
+      - "2670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:54 GMT
+      - Thu, 22 Feb 2024 07:32:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -499,7 +499,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e968146e-aa71-48cc-8663-940e2c12eb79
+      - df19fa12-5525-4ac5-8301-be921bb22dea
     status: 200 OK
     code: 200
     duration: ""
@@ -510,12 +510,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/1189adb5-1573-4005-aef2-0cd295676971/action","href_result":"/servers/1189adb5-1573-4005-aef2-0cd295676971","id":"2f52b21b-8786-462d-ad9c-ee2609664428","started_at":"2023-11-06T14:47:55.008814+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/action","href_result":"/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","id":"d327dafe-fb0e-440d-afa6-55f424e14e07","started_at":"2024-02-22T07:32:04.990991+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -524,11 +524,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:55 GMT
+      - Thu, 22 Feb 2024 07:32:05 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/2f52b21b-8786-462d-ad9c-ee2609664428
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/d327dafe-fb0e-440d-afa6-55f424e14e07
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -536,7 +536,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f49c1ab9-7ff2-4401-9de8-9f2066c9a951
+      - 804fe4ea-6889-44f2-b0fe-e8eabc1417e5
     status: 202 Accepted
     code: 202
     duration: ""
@@ -545,29 +545,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:47:54.222488+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:04.823243+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2661"
+      - "2692"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:55 GMT
+      - Thu, 22 Feb 2024 07:32:05 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -575,7 +575,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4bc2eaac-0c1b-40e2-ae24-27d6652824b7
+      - e45feb67-b48a-4aff-8b25-974fdcd6daf3
     status: 200 OK
     code: 200
     duration: ""
@@ -584,23 +584,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:47:53.569665Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.565201Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "942"
+      - "1002"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:58 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -608,7 +608,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 310c6ffd-d9b7-4110-81ca-bc969a6d30b3
+      - ed332df5-eea7-4710-8a60-2c586ba09fb0
     status: 200 OK
     code: 200
     duration: ""
@@ -617,23 +617,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:47:53.569665Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.565201Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "942"
+      - "1002"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:58 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -641,7 +641,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6b53f7be-cbe8-499f-bd41-1be88377a541
+      - 3d7cae9b-aa7f-4e2a-8dd1-7854ed64adad
     status: 200 OK
     code: 200
     duration: ""
@@ -650,23 +650,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":false,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:47:53.569665Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.565201Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "942"
+      - "1002"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:58 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -674,34 +674,73 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61d5480e-4a98-42bd-a7ab-f67898947c66
+      - 5d633e09-9dac-4969-b7e7-441a67088a68
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"ba7b9e36-bc4d-4635-b157-f546b9529478"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:04.823243+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2692"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:10 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4c8144a2-fb57-42a3-80ee-581ca8ee4172
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"1f850024-cf04-440d-bdea-6d08d359fedf"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":null,"private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"created","updated_at":"2023-11-06T14:47:59.014061Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":null,"private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"created","updated_at":"2024-02-22T07:32:11.108483Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "953"
+      - "983"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:59 GMT
+      - Thu, 22 Feb 2024 07:32:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -709,7 +748,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - edb9c146-55a2-4017-baea-a5d0dc83cbca
+      - 441922c3-28b8-4172-8cd3-d4970bd31e76
     status: 200 OK
     code: 200
     duration: ""
@@ -718,23 +757,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":null,"private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"created","updated_at":"2023-11-06T14:47:59.014061Z","zone":"fr-par-1"}],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:47:59.190410Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":null,"private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"created","updated_at":"2024-02-22T07:32:11.108483Z","zone":"fr-par-1"}],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.288671Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1898"
+      - "1988"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:47:59 GMT
+      - Thu, 22 Feb 2024 07:32:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -742,7 +781,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e554b958-768f-4c7f-8eab-023173b9c72c
+      - 59ffc744-a5c3-4608-9db7-de94dae44401
     status: 200 OK
     code: 200
     duration: ""
@@ -751,101 +790,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:47:54.222488+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2768"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 06 Nov 2023 14:48:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b2c58bd1-36a8-4526-bf2e-c7e82641fe60
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"configuring","updated_at":"2023-11-06T14:48:00.365854Z","zone":"fr-par-1"}],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:47:59.190410Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1917"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 06 Nov 2023 14:48:04 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 50988d19-50af-4ef7-b83d-7d17fb1c8f80
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:47:54.222488+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:04.823243+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2768"
+      - "2801"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:07 GMT
+      - Thu, 22 Feb 2024 07:32:15 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -853,7 +820,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17ab1312-9294-4f53-9f31-ae2b4f0078f2
+      - 158c55f3-ae59-4618-9072-d6ea16a72785
     status: 200 OK
     code: 200
     duration: ""
@@ -862,23 +829,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:48:05.873748Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":null,"private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"created","updated_at":"2024-02-22T07:32:11.108483Z","zone":"fr-par-1"}],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.288671Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1907"
+      - "1988"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:09 GMT
+      - Thu, 22 Feb 2024 07:32:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -886,7 +853,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 89b62fb9-74b4-4842-90c1-cd94faafeeca
+      - 391a123f-e656-403e-a8eb-f5239d3f779e
     status: 200 OK
     code: 200
     duration: ""
@@ -895,161 +862,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 06 Nov 2023 14:48:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b42fffd2-5c6a-420a-85da-11838b733451
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 06 Nov 2023 14:48:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2d23f763-6edd-4c82-9780-c4bb834f4c92
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:48:05.873748Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1907"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 06 Nov 2023 14:48:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 8487f642-1221-4afe-a4ee-12ea0901eb98
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 06 Nov 2023 14:48:09 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4d55dfa6-aeb0-4e22-8f4a-a398d8b14011
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:47:54.222488+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:04.823243+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2768"
+      - "2801"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:12 GMT
+      - Thu, 22 Feb 2024 07:32:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1057,7 +892,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e69b53a0-8a31-4d1a-b589-c2f9f89b5b91
+      - b0b53db4-d224-4446-a5dc-7feff1c5eca9
     status: 200 OK
     code: 200
     duration: ""
@@ -1066,29 +901,233 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:20.230187Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1997"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 3d839f86-a804-42f8-9e15-8874fc0ff5e0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0ccb3dba-ee79-4865-8c7d-f1238baa5d80
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ba3eeb4c-5175-46e5-95b0-5a2a9ba4f3b9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:20.230187Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1997"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 85515e89-08e5-4f33-880a-2509bb685601
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:21 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eb48f858-3a84-4265-9fef-779a3e3b3703
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:04.823243+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2801"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8734c85d-e31b-4b23-be64-2616f915253c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:48:12.650611+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:26.541811+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2799"
+      - "2832"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:17 GMT
+      - Thu, 22 Feb 2024 07:32:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1096,7 +1135,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aeabadab-ac6c-45a4-ac88-2a7d746fb771
+      - 188c13b1-3220-478a-b70d-6ecc27666454
     status: 200 OK
     code: 200
     duration: ""
@@ -1105,23 +1144,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bbc0e116-ceaf-40a4-b934-d31252d5e23c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0
     method: GET
   response:
-    body: '{"created_at":"2023-11-06T14:47:51.999429Z","dhcp_enabled":true,"id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","name":"pn_test_network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-11-06T14:47:51.999429Z","id":"47e5e57a-73a5-4728-96c4-a1cececf93c0","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:58.503271Z"},{"created_at":"2023-11-06T14:47:51.999429Z","id":"326f59fb-6607-474f-8630-9c934551a4d8","subnet":"fd46:78ab:30b8:718a::/64","updated_at":"2023-11-06T14:47:58.511411Z"}],"tags":[],"updated_at":"2023-11-06T14:48:00.686975Z","vpc_id":"c5f43d26-6157-4a9a-85a5-089b18e169a4"}'
+    body: '{"created_at":"2024-02-22T07:32:02.824425Z","dhcp_enabled":true,"id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.824425Z","id":"128fb77a-acbb-4326-bc6e-c3604507e0b2","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:09.311004Z"},{"created_at":"2024-02-22T07:32:02.824425Z","id":"3209f36a-6834-45d1-a999-204d092778a6","subnet":"fd5f:519c:6d46:5aa6::/64","updated_at":"2024-02-22T07:32:09.315405Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.342003Z","vpc_id":"3a72f67a-5c75-4c40-8c9f-8f01d0342a51"}'
     headers:
       Content-Length:
-      - "699"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:17 GMT
+      - Thu, 22 Feb 2024 07:32:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1129,7 +1168,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b45f102-7a42-4714-ab27-31ce71da25cd
+      - 844d3754-8639-4cbf-a30c-076754d73a9a
     status: 200 OK
     code: 200
     duration: ""
@@ -1138,29 +1177,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:48:12.650611+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:26.541811+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2799"
+      - "2832"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:18 GMT
+      - Thu, 22 Feb 2024 07:32:31 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1168,23 +1207,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c1f2f36-f3ae-483e-9565-4ce737fc30b5
+      - 7bb8aad9-21a4-4527-8c68-2912693de744
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c"}'
+    body: '{"private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:18.209880+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:32:31.664077+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1193,9 +1232,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:19 GMT
+      - Thu, 22 Feb 2024 07:32:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1203,7 +1242,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 165bb91a-d4d6-4d13-9950-ffb1e2428130
+      - e6d429c1-0da5-4fef-b7d2-ee20792c7d44
     status: 201 Created
     code: 201
     duration: ""
@@ -1212,12 +1251,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics/028c08e0-2863-4b32-a9e2-013d74148340
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics/0629dc64-95c5-4943-92cb-7a20742413f5
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:18.209880+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:32:31.664077+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1226,9 +1265,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:19 GMT
+      - Thu, 22 Feb 2024 07:32:32 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1236,7 +1275,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 037fe475-158e-4e4c-9c6f-8d2f8bf6ae67
+      - ef90b4c7-e48e-4335-9b21-a27bb887d2fd
     status: 200 OK
     code: 200
     duration: ""
@@ -1245,12 +1284,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics/028c08e0-2863-4b32-a9e2-013d74148340
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics/0629dc64-95c5-4943-92cb-7a20742413f5
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:21.050241+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:32:32.420037+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1259,9 +1298,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:24 GMT
+      - Thu, 22 Feb 2024 07:32:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1269,7 +1308,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84c94909-ffc0-46da-b62d-ef7ce7632d80
+      - bc2bf5d4-6a20-4e46-90bb-f7ae17e340cc
     status: 200 OK
     code: 200
     duration: ""
@@ -1278,12 +1317,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics/028c08e0-2863-4b32-a9e2-013d74148340
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics/0629dc64-95c5-4943-92cb-7a20742413f5
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:21.050241+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:32:32.420037+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1292,9 +1331,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:29 GMT
+      - Thu, 22 Feb 2024 07:32:42 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1302,7 +1341,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16853b04-2833-481c-92b5-37fa191e06cf
+      - 181567fa-1014-43f1-841f-774168ff4dc4
     status: 200 OK
     code: 200
     duration: ""
@@ -1311,12 +1350,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics/028c08e0-2863-4b32-a9e2-013d74148340
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics/0629dc64-95c5-4943-92cb-7a20742413f5
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:21.050241+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:32:32.420037+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1325,9 +1364,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:35 GMT
+      - Thu, 22 Feb 2024 07:32:47 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1335,7 +1374,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d156b442-83f7-413e-9c44-ffac2bab9d95
+      - 456c870c-f343-4716-b682-7dfddbe0528d
     status: 200 OK
     code: 200
     duration: ""
@@ -1344,12 +1383,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics/028c08e0-2863-4b32-a9e2-013d74148340
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics/0629dc64-95c5-4943-92cb-7a20742413f5
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:21.050241+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:32:32.420037+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1358,9 +1397,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:40 GMT
+      - Thu, 22 Feb 2024 07:32:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1368,7 +1407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3cd019c4-ea58-4c47-8764-5c004625ed26
+      - 2d3f5c94-89dc-4f31-8aa2-2f0f016fb483
     status: 200 OK
     code: 200
     duration: ""
@@ -1377,12 +1416,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics/028c08e0-2863-4b32-a9e2-013d74148340
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics/0629dc64-95c5-4943-92cb-7a20742413f5
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:21.050241+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:32:32.420037+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1391,9 +1430,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:45 GMT
+      - Thu, 22 Feb 2024 07:32:57 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1401,7 +1440,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 017ea368-f6d5-468f-9e28-8790b3ba41d3
+      - 1e663fb1-66b1-49a1-a60c-fee86af49f40
     status: 200 OK
     code: 200
     duration: ""
@@ -1410,12 +1449,45 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics/028c08e0-2863-4b32-a9e2-013d74148340
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics/0629dc64-95c5-4943-92cb-7a20742413f5
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:32:32.420037+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "376"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:02 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 46cf4135-9ca1-4299-932a-c0ca28bb93f7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics/0629dc64-95c5-4943-92cb-7a20742413f5
+    method: GET
+  response:
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1424,9 +1496,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:50 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1434,7 +1506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 25316d9d-5f74-4f94-9e59-ee25aa7c6ec0
+      - 544299ee-052f-477a-8df6-6fd6f8f983ac
     status: 200 OK
     code: 200
     duration: ""
@@ -1443,12 +1515,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics/028c08e0-2863-4b32-a9e2-013d74148340
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics/0629dc64-95c5-4943-92cb-7a20742413f5
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1457,9 +1529,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:50 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1467,7 +1539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5605a69c-199a-48c8-81d0-3db34addf3b9
+      - 6cc5d54d-8f52-47a7-ace9-ac1344b4745e
     status: 200 OK
     code: 200
     duration: ""
@@ -1476,29 +1548,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:48:12.650611+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:26.541811+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3152"
+      - "3185"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:50 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1506,7 +1578,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 022b13a9-f321-4b42-a4a6-16fb66d26a36
+      - e5dc1f49-d851-4900-893a-cb86cd92fa21
     status: 200 OK
     code: 200
     duration: ""
@@ -1515,9 +1587,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1529,9 +1601,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:50 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1539,7 +1611,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c763fed-385a-471b-8c33-f1f8ac260765
+      - 74a54712-e09f-49a0-89b7-ed26cfbd63c1
     status: 200 OK
     code: 200
     duration: ""
@@ -1548,12 +1620,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1562,12 +1634,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:51 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Link:
-      - </servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics?page=1&per_page=50&>;
+      - </servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1575,7 +1647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe46949c-75c0-41e6-9ec7-15743ee3778f
+      - f580b127-c26d-4299-ae66-0348e2d7b5df
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1586,23 +1658,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:51 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1610,34 +1682,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57fe14ef-f8bd-47a9-aed0-f2162952aa1d
+      - 67000b3a-4e43-4e27-8b0e-b3c500b372b8
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_network_id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","mac_address":"02:00:00:14:9e:21","ip_address":"192.168.1.1"}'
+    body: '{"gateway_network_id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","mac_address":"02:00:00:18:8b:b5","ip_address":"192.168.1.1"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries
     method: POST
   response:
-    body: '{"created_at":"2023-11-06T14:48:20.946175Z","gateway_network_id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","hostname":"tf-srv-hungry-nobel","id":"db59a730-59b0-41d4-a09e-ee3eae6a8352","ip_address":"192.168.1.1","mac_address":"02:00:00:14:9e:21","type":"reservation","updated_at":"2023-11-06T14:48:51.705215Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:32.358213Z","gateway_network_id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","hostname":"tf-srv-nervous-hawking","id":"8c619764-2b50-481d-9c20-c0860cd645b2","ip_address":"192.168.1.1","mac_address":"02:00:00:18:8b:b5","type":"reservation","updated_at":"2024-02-22T07:33:08.427423Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "324"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:51 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1645,7 +1717,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7821a58-bc21-49f3-800d-2c5af49f6d5c
+      - 0fa1804f-a6cc-4cbf-93e4-f180328aa291
     status: 200 OK
     code: 200
     duration: ""
@@ -1654,23 +1726,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:51 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1678,7 +1750,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 661d28fe-9408-404a-908f-b6c302e8b2e2
+      - cdbdd64e-d7cc-4f3a-b270-877fb92e9a06
     status: 200 OK
     code: 200
     duration: ""
@@ -1687,23 +1759,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/db59a730-59b0-41d4-a09e-ee3eae6a8352
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/8c619764-2b50-481d-9c20-c0860cd645b2
     method: GET
   response:
-    body: '{"created_at":"2023-11-06T14:48:20.946175Z","gateway_network_id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","hostname":"tf-srv-hungry-nobel","id":"db59a730-59b0-41d4-a09e-ee3eae6a8352","ip_address":"192.168.1.1","mac_address":"02:00:00:14:9e:21","type":"reservation","updated_at":"2023-11-06T14:48:51.705215Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:32.358213Z","gateway_network_id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","hostname":"tf-srv-nervous-hawking","id":"8c619764-2b50-481d-9c20-c0860cd645b2","ip_address":"192.168.1.1","mac_address":"02:00:00:18:8b:b5","type":"reservation","updated_at":"2024-02-22T07:33:08.427423Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "324"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:51 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1711,7 +1783,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 946b4d9e-9fb4-45d9-a6ac-c5013f7017d8
+      - dd532e42-fb7a-41d9-b239-4a06a8d59e21
     status: 200 OK
     code: 200
     duration: ""
@@ -1720,23 +1792,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/db59a730-59b0-41d4-a09e-ee3eae6a8352
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/8c619764-2b50-481d-9c20-c0860cd645b2
     method: GET
   response:
-    body: '{"created_at":"2023-11-06T14:48:20.946175Z","gateway_network_id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","hostname":"tf-srv-hungry-nobel","id":"db59a730-59b0-41d4-a09e-ee3eae6a8352","ip_address":"192.168.1.1","mac_address":"02:00:00:14:9e:21","type":"reservation","updated_at":"2023-11-06T14:48:51.705215Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:32.358213Z","gateway_network_id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","hostname":"tf-srv-nervous-hawking","id":"8c619764-2b50-481d-9c20-c0860cd645b2","ip_address":"192.168.1.1","mac_address":"02:00:00:18:8b:b5","type":"reservation","updated_at":"2024-02-22T07:33:08.427423Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "324"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:52 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1744,7 +1816,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 931d9acb-8dc3-438a-ab17-fd2bc15729f2
+      - f1552da5-d018-4d8e-a853-6e4fd634eba7
     status: 200 OK
     code: 200
     duration: ""
@@ -1753,23 +1825,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/ba7b9e36-bc4d-4635-b157-f546b9529478
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/dac6834e-d99c-4af7-ba68-592059f80ac0
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "405"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:52 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1777,7 +1849,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99f0f568-f2c0-4a75-9878-269f9cd1ff31
+      - 7fc64d14-dd02-4c61-bc4b-b16e4510d62b
     status: 200 OK
     code: 200
     duration: ""
@@ -1786,23 +1858,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/11a60387-eb33-4cde-aa85-ffb296e00764
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1f850024-cf04-440d-bdea-6d08d359fedf
     method: GET
   response:
-    body: '{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "394"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:52 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1810,7 +1882,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76a54d05-664c-48cd-83a5-13c5133057ab
+      - 7013afc3-84c1-4301-8425-db24d5317dba
     status: 200 OK
     code: 200
     duration: ""
@@ -1819,23 +1891,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bbc0e116-ceaf-40a4-b934-d31252d5e23c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0
     method: GET
   response:
-    body: '{"created_at":"2023-11-06T14:47:51.999429Z","dhcp_enabled":true,"id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","name":"pn_test_network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-11-06T14:47:51.999429Z","id":"47e5e57a-73a5-4728-96c4-a1cececf93c0","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:58.503271Z"},{"created_at":"2023-11-06T14:47:51.999429Z","id":"326f59fb-6607-474f-8630-9c934551a4d8","subnet":"fd46:78ab:30b8:718a::/64","updated_at":"2023-11-06T14:47:58.511411Z"}],"tags":[],"updated_at":"2023-11-06T14:48:00.686975Z","vpc_id":"c5f43d26-6157-4a9a-85a5-089b18e169a4"}'
+    body: '{"created_at":"2024-02-22T07:32:02.824425Z","dhcp_enabled":true,"id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.824425Z","id":"128fb77a-acbb-4326-bc6e-c3604507e0b2","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:09.311004Z"},{"created_at":"2024-02-22T07:32:02.824425Z","id":"3209f36a-6834-45d1-a999-204d092778a6","subnet":"fd5f:519c:6d46:5aa6::/64","updated_at":"2024-02-22T07:32:09.315405Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.342003Z","vpc_id":"3a72f67a-5c75-4c40-8c9f-8f01d0342a51"}'
     headers:
       Content-Length:
-      - "699"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:52 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1843,7 +1915,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09ff8bf4-c7dc-4633-94a8-4ea873ad4204
+      - a8d263cc-a975-42ad-a54a-a773cb24a579
     status: 200 OK
     code: 200
     duration: ""
@@ -1852,23 +1924,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:48:05.873748Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:20.230187Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1907"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:52 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1876,7 +1948,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b34082d7-101d-4dae-b546-fc1d360d8454
+      - 3b3d3200-d7c2-4981-b21c-2ea92f56182c
     status: 200 OK
     code: 200
     duration: ""
@@ -1885,23 +1957,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:52 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1909,7 +1981,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 712eb93e-697c-483e-a50d-0589c0b0bbd6
+      - 9d94c822-e2cb-4960-8756-8af60dc74a78
     status: 200 OK
     code: 200
     duration: ""
@@ -1918,23 +1990,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:48:05.873748Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:20.230187Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1907"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:52 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1942,7 +2014,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3c393558-f41f-44c6-96cf-04456dbdd4a3
+      - cffe2c54-6172-43f0-8494-53b40fb7b6a4
     status: 200 OK
     code: 200
     duration: ""
@@ -1951,29 +2023,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:48:12.650611+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:26.541811+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3152"
+      - "3185"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:52 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1981,7 +2053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 778ccbf3-eaaa-4b7a-8cbb-1f70f2a784fb
+      - f72c875b-deb2-4237-bef1-8337e43cd752
     status: 200 OK
     code: 200
     duration: ""
@@ -1990,23 +2062,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:52 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2014,7 +2086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16d98378-bf97-49e7-a6a9-df53ea71298b
+      - ca1d9272-5794-481c-85da-119e1c8a605b
     status: 200 OK
     code: 200
     duration: ""
@@ -2023,9 +2095,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2037,9 +2109,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:52 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2047,7 +2119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9a92ded-723f-4970-9ae1-06ce6bedfbd0
+      - a7dd81b3-787d-41cc-9ecd-c9c4db9be75a
     status: 200 OK
     code: 200
     duration: ""
@@ -2056,12 +2128,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2070,12 +2142,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:52 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Link:
-      - </servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics?page=1&per_page=50&>;
+      - </servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2083,7 +2155,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 37cd5546-0611-4dfe-9217-b72c80ea3d0a
+      - 404a67b0-e755-4ec7-a219-98781ba84770
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2094,23 +2166,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/db59a730-59b0-41d4-a09e-ee3eae6a8352
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/8c619764-2b50-481d-9c20-c0860cd645b2
     method: GET
   response:
-    body: '{"created_at":"2023-11-06T14:48:20.946175Z","gateway_network_id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","hostname":"tf-srv-hungry-nobel","id":"db59a730-59b0-41d4-a09e-ee3eae6a8352","ip_address":"192.168.1.1","mac_address":"02:00:00:14:9e:21","type":"reservation","updated_at":"2023-11-06T14:48:51.705215Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:32.358213Z","gateway_network_id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","hostname":"tf-srv-nervous-hawking","id":"8c619764-2b50-481d-9c20-c0860cd645b2","ip_address":"192.168.1.1","mac_address":"02:00:00:18:8b:b5","type":"reservation","updated_at":"2024-02-22T07:33:08.427423Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "324"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:54 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2118,7 +2190,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 74c06464-34f0-4433-b21e-db0bb6fe8d73
+      - b0f0da3d-df6a-4ab4-bcd1-614844ace4f7
     status: 200 OK
     code: 200
     duration: ""
@@ -2127,23 +2199,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bbc0e116-ceaf-40a4-b934-d31252d5e23c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0
     method: GET
   response:
-    body: '{"created_at":"2023-11-06T14:47:51.999429Z","dhcp_enabled":true,"id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","name":"pn_test_network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-11-06T14:47:51.999429Z","id":"47e5e57a-73a5-4728-96c4-a1cececf93c0","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:58.503271Z"},{"created_at":"2023-11-06T14:47:51.999429Z","id":"326f59fb-6607-474f-8630-9c934551a4d8","subnet":"fd46:78ab:30b8:718a::/64","updated_at":"2023-11-06T14:47:58.511411Z"}],"tags":[],"updated_at":"2023-11-06T14:48:00.686975Z","vpc_id":"c5f43d26-6157-4a9a-85a5-089b18e169a4"}'
+    body: '{"created_at":"2024-02-22T07:32:02.824425Z","dhcp_enabled":true,"id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.824425Z","id":"128fb77a-acbb-4326-bc6e-c3604507e0b2","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:09.311004Z"},{"created_at":"2024-02-22T07:32:02.824425Z","id":"3209f36a-6834-45d1-a999-204d092778a6","subnet":"fd5f:519c:6d46:5aa6::/64","updated_at":"2024-02-22T07:32:09.315405Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.342003Z","vpc_id":"3a72f67a-5c75-4c40-8c9f-8f01d0342a51"}'
     headers:
       Content-Length:
-      - "699"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:55 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2151,7 +2223,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06035be4-b381-4333-a2f0-15ba818f3cf8
+      - e72220df-521f-48aa-88a9-a4f0d918a4cd
     status: 200 OK
     code: 200
     duration: ""
@@ -2160,23 +2232,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/ba7b9e36-bc4d-4635-b157-f546b9529478
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/dac6834e-d99c-4af7-ba68-592059f80ac0
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "405"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:55 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2184,7 +2256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7c6f99b1-e67b-4303-8c41-eef0959d1212
+      - b9f2a439-a992-4b51-908a-02a896ce0a7f
     status: 200 OK
     code: 200
     duration: ""
@@ -2193,23 +2265,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/11a60387-eb33-4cde-aa85-ffb296e00764
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1f850024-cf04-440d-bdea-6d08d359fedf
     method: GET
   response:
-    body: '{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "394"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:55 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2217,7 +2289,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0809ddaf-9897-46ff-8c9c-8f08dd7df0b1
+      - fb4d2551-affa-40bb-ad48-e2adbe34c97c
     status: 200 OK
     code: 200
     duration: ""
@@ -2226,23 +2298,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:48:05.873748Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:20.230187Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1907"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:55 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2250,7 +2322,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0ffd33b-18b7-4fb5-ba90-38f2bc20e6bf
+      - d824a546-199d-478c-9325-07fad0c31ae2
     status: 200 OK
     code: 200
     duration: ""
@@ -2259,23 +2331,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:55 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2283,7 +2355,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e720b6f6-4c9e-47e8-8ce3-57a56f5644ba
+      - d1174f1d-7953-4a66-9064-09668bbe8a9a
     status: 200 OK
     code: 200
     duration: ""
@@ -2292,29 +2364,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:48:12.650611+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:26.541811+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3152"
+      - "3185"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:55 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2322,7 +2394,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb27ec4b-ee84-455d-90b8-9002ba3dd22f
+      - cc550a45-eef5-409e-b33f-5ca768705a5b
     status: 200 OK
     code: 200
     duration: ""
@@ -2331,23 +2403,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:48:05.873748Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:20.230187Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1907"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:55 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2355,7 +2427,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1a04966-24dd-4e6f-acee-e32d961edbe3
+      - cf01d6dc-5295-423c-a278-870e683346fa
     status: 200 OK
     code: 200
     duration: ""
@@ -2364,9 +2436,42 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/user_data
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "996"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:10 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 98912a27-ca9f-4863-a73c-f024e02bd56f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2378,9 +2483,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:55 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2388,7 +2493,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 686dc981-251a-4f8f-a8ed-4d74cea6cf35
+      - 0d6585d4-d918-4f6b-b203-2e1fb7957c3a
     status: 200 OK
     code: 200
     duration: ""
@@ -2397,12 +2502,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2411,12 +2516,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:55 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Link:
-      - </servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics?page=1&per_page=50&>;
+      - </servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2424,7 +2529,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b06674cb-5647-408b-b670-21447d1ad8a7
+      - 06a96348-db4a-403d-acb9-28401dcd3d2d
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2435,23 +2540,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/8c619764-2b50-481d-9c20-c0860cd645b2
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:32.358213Z","gateway_network_id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","hostname":"tf-srv-nervous-hawking","id":"8c619764-2b50-481d-9c20-c0860cd645b2","ip_address":"192.168.1.1","mac_address":"02:00:00:18:8b:b5","type":"reservation","updated_at":"2024-02-22T07:33:08.427423Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:55 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2459,7 +2564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 881f2cda-c0df-4a37-93f8-bd7bb77b2e92
+      - d9f01ecb-4fbc-4579-a64d-b8fd5338f3f7
     status: 200 OK
     code: 200
     duration: ""
@@ -2468,23 +2573,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/db59a730-59b0-41d4-a09e-ee3eae6a8352
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
     method: GET
   response:
-    body: '{"created_at":"2023-11-06T14:48:20.946175Z","gateway_network_id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","hostname":"tf-srv-hungry-nobel","id":"db59a730-59b0-41d4-a09e-ee3eae6a8352","ip_address":"192.168.1.1","mac_address":"02:00:00:14:9e:21","type":"reservation","updated_at":"2023-11-06T14:48:51.705215Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "324"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:55 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2492,40 +2597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f77490c3-b52e-45ca-a8da-35460b683b10
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 06 Nov 2023 14:48:56 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b87447b4-1141-40a2-9a31-93d5c9934963
+      - 07a8c14f-9298-4d2c-b665-7ce9a73a476b
     status: 200 OK
     code: 200
     duration: ""
@@ -2536,23 +2608,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/db59a730-59b0-41d4-a09e-ee3eae6a8352
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/8c619764-2b50-481d-9c20-c0860cd645b2
     method: PATCH
   response:
-    body: '{"created_at":"2023-11-06T14:48:20.946175Z","gateway_network_id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","hostname":"tf-srv-hungry-nobel","id":"db59a730-59b0-41d4-a09e-ee3eae6a8352","ip_address":"192.168.1.2","mac_address":"02:00:00:14:9e:21","type":"reservation","updated_at":"2023-11-06T14:48:56.706017Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:32.358213Z","gateway_network_id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","hostname":"tf-srv-nervous-hawking","id":"8c619764-2b50-481d-9c20-c0860cd645b2","ip_address":"192.168.1.2","mac_address":"02:00:00:18:8b:b5","type":"reservation","updated_at":"2024-02-22T07:33:11.282547Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "324"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:56 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2560,7 +2632,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1357d0f6-11b7-4f41-bd29-10b28d98f855
+      - 4e305dd5-9142-4393-9944-66932ea1b4e7
     status: 200 OK
     code: 200
     duration: ""
@@ -2569,23 +2641,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:57 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2593,7 +2665,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5b6b19c-d121-42de-ba92-7abe1b540c65
+      - 9bc29e4f-59aa-4b96-9db6-41d1b11ac886
     status: 200 OK
     code: 200
     duration: ""
@@ -2602,23 +2674,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/db59a730-59b0-41d4-a09e-ee3eae6a8352
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/8c619764-2b50-481d-9c20-c0860cd645b2
     method: GET
   response:
-    body: '{"created_at":"2023-11-06T14:48:20.946175Z","gateway_network_id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","hostname":"tf-srv-hungry-nobel","id":"db59a730-59b0-41d4-a09e-ee3eae6a8352","ip_address":"192.168.1.2","mac_address":"02:00:00:14:9e:21","type":"reservation","updated_at":"2023-11-06T14:48:56.706017Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:32.358213Z","gateway_network_id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","hostname":"tf-srv-nervous-hawking","id":"8c619764-2b50-481d-9c20-c0860cd645b2","ip_address":"192.168.1.2","mac_address":"02:00:00:18:8b:b5","type":"reservation","updated_at":"2024-02-22T07:33:11.282547Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "324"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:57 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2626,7 +2698,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fde4253-4c12-4f81-856a-06cffd22035d
+      - 36614789-ed2e-4216-982f-868a9d21eec0
     status: 200 OK
     code: 200
     duration: ""
@@ -2635,23 +2707,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/db59a730-59b0-41d4-a09e-ee3eae6a8352
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/8c619764-2b50-481d-9c20-c0860cd645b2
     method: GET
   response:
-    body: '{"created_at":"2023-11-06T14:48:20.946175Z","gateway_network_id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","hostname":"tf-srv-hungry-nobel","id":"db59a730-59b0-41d4-a09e-ee3eae6a8352","ip_address":"192.168.1.2","mac_address":"02:00:00:14:9e:21","type":"reservation","updated_at":"2023-11-06T14:48:56.706017Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:32.358213Z","gateway_network_id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","hostname":"tf-srv-nervous-hawking","id":"8c619764-2b50-481d-9c20-c0860cd645b2","ip_address":"192.168.1.2","mac_address":"02:00:00:18:8b:b5","type":"reservation","updated_at":"2024-02-22T07:33:11.282547Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "324"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:57 GMT
+      - Thu, 22 Feb 2024 07:33:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2659,7 +2731,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dace3078-bd9e-4122-9d0c-fdb92c96ee46
+      - eadd9058-b5b6-41b7-926e-8751ff323ba7
     status: 200 OK
     code: 200
     duration: ""
@@ -2668,23 +2740,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/11a60387-eb33-4cde-aa85-ffb296e00764
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0
     method: GET
   response:
-    body: '{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:02.824425Z","dhcp_enabled":true,"id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","name":"pn_test_network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:02.824425Z","id":"128fb77a-acbb-4326-bc6e-c3604507e0b2","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:09.311004Z"},{"created_at":"2024-02-22T07:32:02.824425Z","id":"3209f36a-6834-45d1-a999-204d092778a6","subnet":"fd5f:519c:6d46:5aa6::/64","updated_at":"2024-02-22T07:32:09.315405Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.342003Z","vpc_id":"3a72f67a-5c75-4c40-8c9f-8f01d0342a51"}'
     headers:
       Content-Length:
-      - "394"
+      - "716"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:57 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2692,7 +2764,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 91898dbe-b8d7-42a3-ae1e-7cc46867f4e9
+      - c229509d-a66e-4a94-98d8-aa7bea935a90
     status: 200 OK
     code: 200
     duration: ""
@@ -2701,23 +2773,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/ba7b9e36-bc4d-4635-b157-f546b9529478
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1f850024-cf04-440d-bdea-6d08d359fedf
     method: GET
   response:
-    body: '{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "568"
+      - "586"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:57 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2725,7 +2797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a83ae527-464b-4675-acc9-c56fae8d85a2
+      - a1ef9f2b-b7e9-4dbc-a746-c0898ddeaa79
     status: 200 OK
     code: 200
     duration: ""
@@ -2734,23 +2806,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/dac6834e-d99c-4af7-ba68-592059f80ac0
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:48:05.873748Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1907"
+      - "405"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:57 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2758,7 +2830,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 817a89c1-b7ec-4dd6-b0b3-2d5417b34deb
+      - 361a46f1-70b0-4ff5-a6c5-a72cc8799be0
     status: 200 OK
     code: 200
     duration: ""
@@ -2767,23 +2839,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bbc0e116-ceaf-40a4-b934-d31252d5e23c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
     method: GET
   response:
-    body: '{"created_at":"2023-11-06T14:47:51.999429Z","dhcp_enabled":true,"id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","name":"pn_test_network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-11-06T14:47:51.999429Z","id":"47e5e57a-73a5-4728-96c4-a1cececf93c0","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:58.503271Z"},{"created_at":"2023-11-06T14:47:51.999429Z","id":"326f59fb-6607-474f-8630-9c934551a4d8","subnet":"fd46:78ab:30b8:718a::/64","updated_at":"2023-11-06T14:47:58.511411Z"}],"tags":[],"updated_at":"2023-11-06T14:48:00.686975Z","vpc_id":"c5f43d26-6157-4a9a-85a5-089b18e169a4"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:20.230187Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "699"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:57 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2791,7 +2863,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a827314-2c79-41ea-bbdd-e1ec577270d7
+      - a7b77276-0f37-404d-ac96-72a3811540b0
     status: 200 OK
     code: 200
     duration: ""
@@ -2800,23 +2872,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:57 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2824,7 +2896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e621e049-c96e-4940-8a1b-da67f93f61c6
+      - 9cc6b170-f933-41ae-9105-0d5ea75ee714
     status: 200 OK
     code: 200
     duration: ""
@@ -2833,23 +2905,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:48:05.873748Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:20.230187Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1907"
+      - "1997"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:57 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2857,7 +2929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e6d6a68-8f67-4665-9db3-c57188e869c3
+      - ef9d5d5f-26a4-4e43-960b-edc4d2df634d
     status: 200 OK
     code: 200
     duration: ""
@@ -2866,23 +2938,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:58 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2890,7 +2962,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7105d7d-f0a9-4270-9c83-8236458cefe6
+      - e5fa6704-6cdc-422e-b21a-08a7b627346f
     status: 200 OK
     code: 200
     duration: ""
@@ -2899,29 +2971,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:48:12.650611+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:26.541811+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3152"
+      - "3185"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:57 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2929,7 +3001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7a80ad5-660c-4477-b011-fed0da2d4910
+      - 1b4dba67-7dc0-4289-855d-53cd3e165dab
     status: 200 OK
     code: 200
     duration: ""
@@ -2938,9 +3010,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2952,9 +3024,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:58 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2962,7 +3034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f528c5a-3f9a-4569-9594-3ed8f49564bf
+      - d5ae4234-40f4-493c-a7a6-37629dcee304
     status: 200 OK
     code: 200
     duration: ""
@@ -2971,12 +3043,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2985,12 +3057,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:58 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Link:
-      - </servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics?page=1&per_page=50&>;
+      - </servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2998,7 +3070,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2eb44e5b-1262-4c5f-88e1-3f8357e205a6
+      - 9ba1d914-c518-4ae3-b8d0-d8cb46abb50c
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3009,23 +3081,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/db59a730-59b0-41d4-a09e-ee3eae6a8352
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/8c619764-2b50-481d-9c20-c0860cd645b2
     method: GET
   response:
-    body: '{"created_at":"2023-11-06T14:48:20.946175Z","gateway_network_id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","hostname":"tf-srv-hungry-nobel","id":"db59a730-59b0-41d4-a09e-ee3eae6a8352","ip_address":"192.168.1.2","mac_address":"02:00:00:14:9e:21","type":"reservation","updated_at":"2023-11-06T14:48:56.706017Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:32.358213Z","gateway_network_id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","hostname":"tf-srv-nervous-hawking","id":"8c619764-2b50-481d-9c20-c0860cd645b2","ip_address":"192.168.1.2","mac_address":"02:00:00:18:8b:b5","type":"reservation","updated_at":"2024-02-22T07:33:11.282547Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "324"
+      - "335"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:58 GMT
+      - Thu, 22 Feb 2024 07:33:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3033,7 +3105,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71130154-1c8a-43cf-9c63-c6255041bee6
+      - 701fc088-0b66-4d8f-9681-b478c3ae1eeb
     status: 200 OK
     code: 200
     duration: ""
@@ -3042,23 +3114,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:59 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3066,7 +3138,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9db39c9a-2365-495c-a93b-782505c1fa7f
+      - fa82d5fe-5387-454d-8866-96b5da00cd90
     status: 200 OK
     code: 200
     duration: ""
@@ -3075,9 +3147,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/db59a730-59b0-41d4-a09e-ee3eae6a8352
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/8c619764-2b50-481d-9c20-c0860cd645b2
     method: DELETE
   response:
     body: ""
@@ -3087,9 +3159,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:59 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3097,7 +3169,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 468cefcc-3999-4e0f-96e2-23a460dace44
+      - 9a35d517-91a5-4f7d-8efb-d84e2cbc1d60
     status: 204 No Content
     code: 204
     duration: ""
@@ -3106,23 +3178,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:59 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3130,7 +3202,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc13912e-a259-4f1d-9a67-2d3c05784698
+      - a4122d17-4faf-4108-bdf9-bd6aee929f60
     status: 200 OK
     code: 200
     duration: ""
@@ -3139,23 +3211,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"ready","updated_at":"2023-11-06T14:48:05.784281Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"ready","updated_at":"2024-02-22T07:32:20.080456Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "966"
+      - "996"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:59 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3163,7 +3235,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 332e2c5e-54ff-4589-9d51-ff6cacfafa62
+      - 3a9ac269-a25b-4ed0-9e19-8d74c3aae8c6
     status: 200 OK
     code: 200
     duration: ""
@@ -3172,9 +3244,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -3184,9 +3256,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:59 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3194,7 +3266,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2bae9e03-fef8-46cf-961b-efa5eca49854
+      - 0347c7e5-0244-46c2-a688-d9974510207b
     status: 204 No Content
     code: 204
     duration: ""
@@ -3203,29 +3275,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:48:12.650611+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:32:26.541811+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3152"
+      - "3185"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:59 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3233,7 +3305,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f01a654-72fd-4586-9559-00ebe87d576a
+      - c8bdf193-3dcf-4954-ac2d-90c64b234d16
     status: 200 OK
     code: 200
     duration: ""
@@ -3242,23 +3314,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-11-06T14:47:59.014061Z","dhcp":{"address":"192.168.1.1","created_at":"2023-11-06T14:47:51.990725Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"ba7b9e36-bc4d-4635-b157-f546b9529478","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2023-11-06T14:47:51.990725Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","ipam_config":null,"mac_address":"02:00:00:14:9E:20","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","status":"detaching","updated_at":"2023-11-06T14:48:59.555776Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108483Z","dhcp":{"address":"192.168.1.1","created_at":"2024-02-22T07:32:02.367106Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"1f850024-cf04-440d-bdea-6d08d359fedf","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"192.168.1.254","pool_low":"192.168.1.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"192.168.1.0/24","updated_at":"2024-02-22T07:32:02.367106Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","ipam_config":null,"mac_address":"02:00:00:18:8B:AF","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","status":"detaching","updated_at":"2024-02-22T07:33:13.415707Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "970"
+      - "1000"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:59 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3266,7 +3338,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 54d159a0-cb74-4a84-840f-5ca6fa665484
+      - e93b69a1-bea6-48b6-96cd-731e4cbf0367
     status: 200 OK
     code: 200
     duration: ""
@@ -3277,12 +3349,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/1189adb5-1573-4005-aef2-0cd295676971/action","href_result":"/servers/1189adb5-1573-4005-aef2-0cd295676971","id":"41511932-ce8a-4495-a422-622d136e40fd","started_at":"2023-11-06T14:48:59.941531+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/action","href_result":"/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","id":"386f558d-24f9-48fc-b4b5-ea37bbfbb1c6","started_at":"2024-02-22T07:33:13.646885+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -3291,11 +3363,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:48:59 GMT
+      - Thu, 22 Feb 2024 07:33:13 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/41511932-ce8a-4495-a422-622d136e40fd
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/386f558d-24f9-48fc-b4b5-ea37bbfbb1c6
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3303,7 +3375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d9be0a8-6700-4605-8d89-47eefd9be23f
+      - aa7c39ec-2421-4b57-bda6-92094a08965c
     status: 202 Accepted
     code: 202
     duration: ""
@@ -3312,29 +3384,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:48:59.687550+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:33:13.484630+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3120"
+      - "3153"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:00 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3342,7 +3414,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cdd84f78-e15e-41e0-85df-95f167a794a7
+      - 9cf9bd8d-0833-4073-9a94-f9838940cf82
     status: 200 OK
     code: 200
     duration: ""
@@ -3351,12 +3423,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/1d6b47a8-11d0-467c-981d-1d1fbfe3562a
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/aaf270bd-158e-4fa2-af8b-da1ccdc09d0e
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"1d6b47a8-11d0-467c-981d-1d1fbfe3562a","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"aaf270bd-158e-4fa2-af8b-da1ccdc09d0e","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -3365,9 +3437,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:05 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3375,7 +3447,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12247dec-6f4e-40f9-b2a2-95409874bea8
+      - 0e14ee40-f4e8-4e95-bfc8-0299f07f7922
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3384,23 +3456,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:48:05.873748Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:20.230187Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "941"
+      - "1001"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:05 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3408,7 +3480,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aaac9cc0-755e-404c-8e14-b37848af8e92
+      - e0108496-cd0f-4acb-adeb-ea977c9838bf
     status: 200 OK
     code: 200
     duration: ""
@@ -3417,12 +3489,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/ba7b9e36-bc4d-4635-b157-f546b9529478
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/1f850024-cf04-440d-bdea-6d08d359fedf
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"ba7b9e36-bc4d-4635-b157-f546b9529478","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"1f850024-cf04-440d-bdea-6d08d359fedf","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3431,9 +3503,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:05 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3441,7 +3513,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4f92419-cffb-4fa4-9759-8841efcb5a08
+      - 86c6d535-f167-4db4-911d-32747f963e9d
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3450,23 +3522,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-11-06T14:47:52.873073Z","gateway_networks":[],"id":"9daae55d-4335-4b8d-87e0-51427a152976","ip":{"address":"51.158.121.229","created_at":"2023-11-06T14:47:52.595668Z","gateway_id":"9daae55d-4335-4b8d-87e0-51427a152976","id":"11a60387-eb33-4cde-aa85-ffb296e00764","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"229-121-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-11-06T14:47:52.595668Z","zone":"fr-par-1"},"is_legacy":true,"name":"foobar","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-11-06T14:48:05.873748Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.329202Z","gateway_networks":[],"id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","ip":{"address":"163.172.175.163","created_at":"2024-02-22T07:32:03.177465Z","gateway_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","id":"dac6834e-d99c-4af7-ba68-592059f80ac0","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"163-175-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.177465Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"foobar","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:20.230187Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "941"
+      - "1001"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:05 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3474,7 +3546,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09890ded-0141-4c13-9e93-a85af56ed961
+      - ab7b40b7-947b-43ca-bb6a-460f3781589f
     status: 200 OK
     code: 200
     duration: ""
@@ -3483,9 +3555,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -3495,9 +3567,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:05 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3505,7 +3577,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 580930bc-9394-47f0-b996-eea7eeda5431
+      - c95dbee2-8eff-48c9-9e46-6cb8c74ffb45
     status: 204 No Content
     code: 204
     duration: ""
@@ -3514,12 +3586,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/9daae55d-4335-4b8d-87e0-51427a152976
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/0a90ea3d-351e-4359-8cb8-06d8b92ce50c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"9daae55d-4335-4b8d-87e0-51427a152976","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"0a90ea3d-351e-4359-8cb8-06d8b92ce50c","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3528,9 +3600,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:05 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3538,7 +3610,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71a257da-954c-4ec4-a8ea-e5a8e14b8e9d
+      - 1b8b5ec9-935f-4654-8e13-e22926ea7644
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3547,48 +3619,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:48:59.687550+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3120"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 06 Nov 2023 14:49:05 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 91522e9e-610b-473e-8d7d-62a71f231d08
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/11a60387-eb33-4cde-aa85-ffb296e00764
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/dac6834e-d99c-4af7-ba68-592059f80ac0
     method: DELETE
   response:
     body: ""
@@ -3598,9 +3631,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:05 GMT
+      - Thu, 22 Feb 2024 07:33:18 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3608,7 +3641,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fc07db07-2179-41fa-b713-03f54e2a73ce
+      - 27bea25a-010a-4d6a-82b5-09516a1385ec
     status: 204 No Content
     code: 204
     duration: ""
@@ -3617,29 +3650,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:48:59.687550+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:33:13.484630+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3120"
+      - "3153"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:10 GMT
+      - Thu, 22 Feb 2024 07:33:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3647,7 +3680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06a34863-e5ef-4f8f-b10b-2b4a9483e8d1
+      - 491fe471-0ec0-4123-a3ab-bdb09193012a
     status: 200 OK
     code: 200
     duration: ""
@@ -3656,29 +3689,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:48:59.687550+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:33:13.484630+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3120"
+      - "3153"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:16 GMT
+      - Thu, 22 Feb 2024 07:33:24 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3686,7 +3719,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2fc8abe2-a38a-4a81-b5c8-5ca6e05638b7
+      - fa0da1e9-39fe-44d3-8194-80d32a54a031
     status: 200 OK
     code: 200
     duration: ""
@@ -3695,29 +3728,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:48:59.687550+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:33:13.484630+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3120"
+      - "3153"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:21 GMT
+      - Thu, 22 Feb 2024 07:33:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3725,7 +3758,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2009cbb8-9d18-492a-969a-f4ecf717df33
+      - f053fc61-f7cb-498d-9c28-67bb7ae8b89e
     status: 200 OK
     code: 200
     duration: ""
@@ -3734,29 +3767,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"32","hypervisor_id":"303","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:48:59.687550+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.72.84.13","private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:33:13.484630+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3120"
+      - "3153"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:26 GMT
+      - Thu, 22 Feb 2024 07:33:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3764,7 +3797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 72f9ee57-f3dc-4718-b5f5-6d56ddc4ef14
+      - f5e9a08a-918b-434e-9370-12f389f7a537
     status: 200 OK
     code: 200
     duration: ""
@@ -3773,29 +3806,107 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:33:13.484630+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3153"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:40 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 9ef60eba-15e6-4972-95ae-fc15cd1364d0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"202","node_id":"27","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:33:13.484630+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.64.166.53","private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3153"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 1aff8dde-3161-4e77-ba2d-dfc255894254
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:49:27.832552+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:33:48.049597+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3000"
+      - "3031"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:31 GMT
+      - Thu, 22 Feb 2024 07:33:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3803,7 +3914,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d6d75bd-7dbe-4f75-9d79-0be890ba4ed5
+      - c501c64f-2c38-41b4-b497-d176ba193fab
     status: 200 OK
     code: 200
     duration: ""
@@ -3812,12 +3923,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3826,12 +3937,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:31 GMT
+      - Thu, 22 Feb 2024 07:33:50 GMT
       Link:
-      - </servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics?page=1&per_page=50&>;
+      - </servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3839,7 +3950,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 663c9c5d-f27c-4ad9-af7c-bce2f07e389b
+      - c11114ad-2bf9-4d0f-9681-c63e88eec0a0
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3850,12 +3961,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics/028c08e0-2863-4b32-a9e2-013d74148340
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics/0629dc64-95c5-4943-92cb-7a20742413f5
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-11-06T14:48:18.209880+00:00","id":"028c08e0-2863-4b32-a9e2-013d74148340","mac_address":"02:00:00:14:9e:21","modification_date":"2023-11-06T14:48:49.298684+00:00","private_network_id":"bbc0e116-ceaf-40a4-b934-d31252d5e23c","server_id":"1189adb5-1573-4005-aef2-0cd295676971","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:31.664077+00:00","id":"0629dc64-95c5-4943-92cb-7a20742413f5","mac_address":"02:00:00:18:8b:b5","modification_date":"2024-02-22T07:33:02.962655+00:00","private_network_id":"53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0","server_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -3864,9 +3975,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:31 GMT
+      - Thu, 22 Feb 2024 07:33:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3874,7 +3985,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f1eafd8-c924-438b-9280-c71f7ef27567
+      - 1def2706-bd50-4aaf-ab03-c98752a2a81c
     status: 200 OK
     code: 200
     duration: ""
@@ -3883,9 +3994,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics/028c08e0-2863-4b32-a9e2-013d74148340
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics/0629dc64-95c5-4943-92cb-7a20742413f5
     method: DELETE
   response:
     body: ""
@@ -3893,9 +4004,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Mon, 06 Nov 2023 14:49:31 GMT
+      - Thu, 22 Feb 2024 07:33:50 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3903,7 +4014,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4294a692-b56c-40b3-a081-a2254dc42b38
+      - 052d7e1d-0f40-4267-bc58-1f176c1c00b4
     status: 204 No Content
     code: 204
     duration: ""
@@ -3912,12 +4023,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971/private_nics/028c08e0-2863-4b32-a9e2-013d74148340
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f/private_nics/0629dc64-95c5-4943-92cb-7a20742413f5
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"028c08e0-2863-4b32-a9e2-013d74148340","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"0629dc64-95c5-4943-92cb-7a20742413f5","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -3926,9 +4037,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:32 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3936,7 +4047,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b03c363b-e22b-44c2-bf1f-3cdb4e65e1e6
+      - e075c183-5969-4e80-8ead-565e40947c3c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3945,29 +4056,29 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-11-06T14:47:53.538515+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-hungry-nobel","id":"1189adb5-1573-4005-aef2-0cd295676971","image":{"arch":"x86_64","creation_date":"2023-08-08T13:33:54.403199+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"e61b1d27-f80a-4cfd-9121-39f695f3bc68","modification_date":"2023-08-08T13:33:54.403199+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"e2ae7926-f93d-4d02-b859-84b2a13a060b","name":"Ubuntu
-      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2c:2d:db","maintenances":[],"modification_date":"2023-11-06T14:49:27.832552+00:00","name":"tf-srv-hungry-nobel","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-11-06T14:47:53.538515+00:00","export_uri":null,"id":"da2cab25-961c-436f-917b-46f5b822df69","modification_date":"2023-11-06T14:47:53.538515+00:00","name":"Ubuntu
-      20.04 Focal Fossa","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"1189adb5-1573-4005-aef2-0cd295676971","name":"tf-srv-hungry-nobel"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:03.851330+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-nervous-hawking","id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","image":{"arch":"x86_64","creation_date":"2024-01-31T15:37:20.774159+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"5d083890-4354-47ab-b769-8b0de601eb3a","modification_date":"2024-01-31T15:37:20.774159+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"202c71ba-c8b4-45ae-9f2a-d88a83fda487","name":"Ubuntu
+      20.04 Focal Fossa","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:b1","maintenances":[],"modification_date":"2024-02-22T07:33:48.049597+00:00","name":"tf-srv-nervous-hawking","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:03.851330+00:00","export_uri":null,"id":"381600fc-c23e-4fbe-ae87-0a82528dfd3f","modification_date":"2024-02-22T07:32:03.851330+00:00","name":"Ubuntu
+      20.04 Focal Fossa","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","name":"tf-srv-nervous-hawking"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2639"
+      - "2670"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:32 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3975,7 +4086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83e9c86d-b3ef-4d2d-852d-dd06802b024a
+      - 84b1be8b-c4b7-4957-884f-15a7c0c0afa0
     status: 200 OK
     code: 200
     duration: ""
@@ -3984,9 +4095,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: DELETE
   response:
     body: ""
@@ -3994,9 +4105,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Mon, 06 Nov 2023 14:49:32 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4004,7 +4115,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a62eec7c-3588-48f2-90fb-f751c761cd54
+      - 0c8ec926-43c5-411f-9eb4-2a7f0da840a6
     status: 204 No Content
     code: 204
     duration: ""
@@ -4013,12 +4124,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/1189adb5-1573-4005-aef2-0cd295676971
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/51f0e7b0-03c3-4c64-8977-4b1860dd1c9f
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"1189adb5-1573-4005-aef2-0cd295676971","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"51f0e7b0-03c3-4c64-8977-4b1860dd1c9f","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -4027,9 +4138,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:32 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4037,7 +4148,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3f8212e-d7e6-4826-8694-07568d9e7c05
+      - d4ccaffa-674c-4484-852d-94980e9549d8
     status: 404 Not Found
     code: 404
     duration: ""
@@ -4046,9 +4157,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/da2cab25-961c-436f-917b-46f5b822df69
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/381600fc-c23e-4fbe-ae87-0a82528dfd3f
     method: DELETE
   response:
     body: ""
@@ -4056,9 +4167,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Mon, 06 Nov 2023 14:49:32 GMT
+      - Thu, 22 Feb 2024 07:33:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4066,7 +4177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da93a0ff-398a-4f8e-9a75-8ecccff2e7e2
+      - 1934ca1f-f6a8-4fba-8369-371bf4607b95
     status: 204 No Content
     code: 204
     duration: ""
@@ -4075,9 +4186,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bbc0e116-ceaf-40a4-b934-d31252d5e23c
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/53aa9d93-11b9-40fa-b5e5-3a6eee4c71c0
     method: DELETE
   response:
     body: ""
@@ -4087,9 +4198,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:36 GMT
+      - Thu, 22 Feb 2024 07:33:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4097,7 +4208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b0578d4-1b5c-4ada-b1d2-01dd604a71f4
+      - 91ba0486-58c7-4e0c-beb2-818a9fa8d366
     status: 204 No Content
     code: 204
     duration: ""
@@ -4106,12 +4217,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/db59a730-59b0-41d4-a09e-ee3eae6a8352
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/8c619764-2b50-481d-9c20-c0860cd645b2
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"dhcp_entry","resource_id":"db59a730-59b0-41d4-a09e-ee3eae6a8352","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp_entry","resource_id":"8c619764-2b50-481d-9c20-c0860cd645b2","type":"not_found"}'
     headers:
       Content-Length:
       - "131"
@@ -4120,9 +4231,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 06 Nov 2023 14:49:37 GMT
+      - Thu, 22 Feb 2024 07:33:52 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4130,7 +4241,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6082036d-ceb1-455b-b24a-54558905a22c
+      - 5229f4e1-ad3d-43a6-996a-dedc70ce5c01
     status: 404 Not Found
     code: 404
     duration: ""

--- a/scaleway/testdata/vpc-public-gateway-pat-rule-with-instance.cassette.yaml
+++ b/scaleway/testdata/vpc-public-gateway-pat-rule-with-instance.cassette.yaml
@@ -13,7 +13,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
-    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "574"
@@ -22,7 +22,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:52:29 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f0f28eb6-2f5f-4f67-bd0f-4471b6a534dc
+      - e7132ac6-9570-4336-b5ac-97e5b3ee6dc1
     status: 200 OK
     code: 200
     duration: ""
@@ -43,10 +43,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/0d51c640-64c6-4a4a-8323-6f256cff01e2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/4d0baa73-0126-417f-9e7a-2d137c408b51
     method: GET
   response:
-    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "574"
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:02 GMT
+      - Thu, 22 Feb 2024 07:52:29 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -65,7 +65,77 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3b76da3a-0f91-45a7-9439-4951a5aff8e6
+      - 860ecf09-fb22-4ade-82dd-8fef8e334475
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"My Private Network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2024-02-22T07:52:29.659146Z","dhcp_enabled":true,"id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","name":"My
+      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:52:29.659146Z","id":"57ac5911-b190-4eea-884a-2d52125d8532","subnet":"172.16.76.0/22","updated_at":"2024-02-22T07:52:29.659146Z"},{"created_at":"2024-02-22T07:52:29.659146Z","id":"9af9ab8a-ed48-496f-a509-ad3f8023d4e1","subnet":"fd5f:519c:6d46:32c7::/64","updated_at":"2024-02-22T07:52:29.659146Z"}],"tags":[],"updated_at":"2024-02-22T07:52:29.659146Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "719"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:52:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 6ab7fa96-65fd-4636-b3b0-c087c7b415de
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cb91e992-5ba8-4734-ab36-0f5425ed4ffa
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-22T07:52:29.659146Z","dhcp_enabled":true,"id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","name":"My
+      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:52:29.659146Z","id":"57ac5911-b190-4eea-884a-2d52125d8532","subnet":"172.16.76.0/22","updated_at":"2024-02-22T07:52:29.659146Z"},{"created_at":"2024-02-22T07:52:29.659146Z","id":"9af9ab8a-ed48-496f-a509-ad3f8023d4e1","subnet":"fd5f:519c:6d46:32c7::/64","updated_at":"2024-02-22T07:52:29.659146Z"}],"tags":[],"updated_at":"2024-02-22T07:52:29.659146Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "719"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:52:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 86a2a106-e14a-4b30-96af-da676d133660
     status: 200 OK
     code: 200
     duration: ""
@@ -81,16 +151,16 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":null,"id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"}'
+    body: '{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":null,"id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "369"
+      - "367"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
+      - Thu, 22 Feb 2024 07:52:30 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -100,216 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 756feac1-f1ea-4365-a04d-45d9a2cb98e4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/1c9ba85d-8322-494b-8a83-3580caaa1c38
-    method: GET
-  response:
-    body: '{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":null,"id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "369"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e4bae936-edfe-42b7-86af-252f034c56cf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"The Public
-      Gateway","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","enable_smtp":false,"enable_bastion":false}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
-    method: POST
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:03.281397Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1012"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 360c6dc5-14f5-494a-9fe4-850c1979bdc3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:03.281397Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1012"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:03 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 738b50c1-2c73-41ec-8a33-4cb4c1496b6b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"name":"My Private Network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
-    method: POST
-  response:
-    body: '{"message":"internal error"}'
-    headers:
-      Content-Length:
-      - "28"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:04 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7b9fbd60-cf5b-42a2-90de-640d4e4831b5
-    status: 500 Internal Server Error
-    code: 500
-    duration: ""
-- request:
-    body: '{"name":"My Private Network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
-    method: POST
-  response:
-    body: '{"created_at":"2024-02-22T07:32:06.793480Z","dhcp_enabled":true,"id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","name":"My
-      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.793480Z","id":"cfab4620-880e-43af-b87a-d21bcb08aab9","subnet":"172.16.116.0/22","updated_at":"2024-02-22T07:32:06.793480Z"},{"created_at":"2024-02-22T07:32:06.793480Z","id":"fc7dce1e-4f21-462a-ba78-911b75248f3f","subnet":"fd5f:519c:6d46:e5e0::/64","updated_at":"2024-02-22T07:32:06.793480Z"}],"tags":[],"updated_at":"2024-02-22T07:32:06.793480Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "720"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:07 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 37466253-23da-4bf2-a516-73dcb4cc566a
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c32d6278-5c7d-4b15-a946-45c8a3487f84
-    method: GET
-  response:
-    body: '{"created_at":"2024-02-22T07:32:06.793480Z","dhcp_enabled":true,"id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","name":"My
-      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.793480Z","id":"cfab4620-880e-43af-b87a-d21bcb08aab9","subnet":"172.16.116.0/22","updated_at":"2024-02-22T07:32:06.793480Z"},{"created_at":"2024-02-22T07:32:06.793480Z","id":"fc7dce1e-4f21-462a-ba78-911b75248f3f","subnet":"fd5f:519c:6d46:e5e0::/64","updated_at":"2024-02-22T07:32:06.793480Z"}],"tags":[],"updated_at":"2024-02-22T07:32:06.793480Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
-    headers:
-      Content-Length:
-      - "720"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:07 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 573a5042-97f9-46c6-976e-ca1757c02a5e
+      - 9c6f5ada-3ac6-4a46-bae4-a0ba44d87baa
     status: 200 OK
     code: 200
     duration: ""
@@ -332,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:07 GMT
+      - Thu, 22 Feb 2024 07:52:30 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -342,7 +203,40 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4dd62fad-4309-4475-9e87-988137239227
+      - 4b07455b-4cb6-4506-b91e-4ab5b0e9b259
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/9fd1efc6-ef55-47e5-86fc-e68066f1c01a
+    method: GET
+  response:
+    body: '{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":null,"id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "367"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:52:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - db1fb2a6-1fc5-41c8-9ad8-6e38bc6ba082
     status: 200 OK
     code: 200
     duration: ""
@@ -365,7 +259,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:07 GMT
+      - Thu, 22 Feb 2024 07:52:30 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
@@ -378,7 +272,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c52e38b0-e1d4-42b2-9527-605f5f2620e6
+      - 556c9e48-d6e7-470e-8e60-e3178ad7dede
       X-Total-Count:
       - "61"
     status: 200 OK
@@ -403,7 +297,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:07 GMT
+      - Thu, 22 Feb 2024 07:52:30 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
@@ -416,9 +310,80 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4be534cc-2c52-4c5b-8af6-d1c5362d2985
+      - 19df49b5-8207-4944-8906-ad650b2bbdf7
       X-Total-Count:
       - "61"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"The Public
+      Gateway","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","enable_smtp":false,"enable_bastion":false}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
+    method: POST
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:30.366833Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1010"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:52:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0088dfac-1614-491a-8ba5-a23458340571
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:30.447902Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1013"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:52:30 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a666e0a-a726-478d-b825-69f4edf65552
     status: 200 OK
     code: 200
     duration: ""
@@ -436,12 +401,12 @@ interactions:
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Scaleway
       Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
@@ -451,9 +416,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:08 GMT
+      - Thu, 22 Feb 2024 07:52:31 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -463,7 +428,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b3afffa-a735-41ee-8a84-36a758b637ca
+      - 28ed6f45-c37e-4d64-9c2a-1a7cb3e4c44d
     status: 201 Created
     code: 201
     duration: ""
@@ -474,119 +439,17 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.429950Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1012"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:08 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1ecb967e-f845-45cc-b09d-76b18497639c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.429950Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1012"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:08 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ab11ac40-c50a-477d-9131-08af930315b4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.429950Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1012"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:08 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 0f942647-887c-4d5d-b5bd-0759821cd461
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Scaleway
       Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
@@ -596,7 +459,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:08 GMT
+      - Thu, 22 Feb 2024 07:52:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -606,7 +469,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5e232c8a-35ba-43d3-83df-bc02e18e974a
+      - 2b5bf56a-3e16-40ba-9e75-18dac2dec852
     status: 200 OK
     code: 200
     duration: ""
@@ -617,17 +480,17 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Scaleway
       Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
@@ -637,7 +500,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:08 GMT
+      - Thu, 22 Feb 2024 07:52:31 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -647,7 +510,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7ba92cb8-fb0b-400e-a2ba-febc75be051f
+      - 4327fbe1-a9dd-48ae-ae1f-37d44c1818ee
     status: 200 OK
     code: 200
     duration: ""
@@ -660,10 +523,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/action","href_result":"/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8","id":"a0196bd7-28a2-4668-aa6c-79c66f20b070","started_at":"2024-02-22T07:32:08.831437+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/action","href_result":"/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920","id":"a273c664-921c-45fe-acfc-27aea184f44c","started_at":"2024-02-22T07:52:32.241476+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -672,9 +535,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:09 GMT
+      - Thu, 22 Feb 2024 07:52:32 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/a0196bd7-28a2-4668-aa6c-79c66f20b070
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/a273c664-921c-45fe-acfc-27aea184f44c
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -684,7 +547,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 503a84a2-9ba5-4cd5-8f86-de46bfcae8d8
+      - 88f8a99f-272f-456a-bcd9-b48bc082dd00
     status: 202 Accepted
     code: 202
     duration: ""
@@ -695,17 +558,17 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:08.685734+00:00","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:52:31.759456+00:00","name":"Scaleway
       Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
@@ -715,7 +578,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:09 GMT
+      - Thu, 22 Feb 2024 07:52:32 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -725,12 +588,114 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c36ee950-4ff0-49d3-b96c-ab1b24c18ad6
+      - 70652c5e-1aab-4ce4-aed1-658332b26d6f
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"0d51c640-64c6-4a4a-8323-6f256cff01e2"}'
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:31.243783Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1010"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:52:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f49a1ecb-38b9-4ef4-a9c6-39b4d28cc8f5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:31.243783Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1010"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:52:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f279f1d3-40e6-480a-909e-7ec8387968cb
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:31.243783Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1010"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:52:35 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cbcb5170-905a-4d1d-aca2-b1ee80590463
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"4d0baa73-0126-417f-9e7a-2d137c408b51"}'
     form: {}
     headers:
       Content-Type:
@@ -741,7 +706,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":null,"private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"created","updated_at":"2024-02-22T07:32:11.108412Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":null,"private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"created","updated_at":"2024-02-22T07:52:37.229497Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "971"
@@ -750,7 +715,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:11 GMT
+      - Thu, 22 Feb 2024 07:52:37 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -760,7 +725,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e81b4fab-4a12-4cb8-8c13-f0b58ddd8fd0
+      - aa3f1512-c3be-4bcc-8c91-c3e659c811ca
     status: 200 OK
     code: 200
     duration: ""
@@ -771,20 +736,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":null,"private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"created","updated_at":"2024-02-22T07:32:11.108412Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.125663Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":null,"private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"created","updated_at":"2024-02-22T07:52:37.229497Z","zone":"fr-par-1"}],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:37.413589Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1986"
+      - "1984"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:11 GMT
+      - Thu, 22 Feb 2024 07:52:37 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -794,7 +759,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31c57f94-6091-4c58-9e0f-99b29f1df7ba
+      - dbe85795-84bc-4a8a-a9ac-7a40824cce64
     status: 200 OK
     code: 200
     duration: ""
@@ -805,27 +770,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:08.685734+00:00","name":"Scaleway
-      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:52:31.759456+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.194.118.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2650"
+      - "2759"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:14 GMT
+      - Thu, 22 Feb 2024 07:52:37 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -835,7 +800,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6266861-4a69-46d9-8b81-09bedc760cf9
+      - a27c8caa-7e76-4d77-86ea-f46011d244cd
     status: 200 OK
     code: 200
     duration: ""
@@ -846,20 +811,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":null,"private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"created","updated_at":"2024-02-22T07:32:11.108412Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.347441Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":null,"private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"created","updated_at":"2024-02-22T07:52:37.229497Z","zone":"fr-par-1"}],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:37.413589Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1986"
+      - "1984"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:16 GMT
+      - Thu, 22 Feb 2024 07:52:42 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -869,7 +834,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8229ba57-83ad-454a-b91b-cd89b9ea1d02
+      - b30adc18-bcbd-4ce3-b0d8-5e2cb764261d
     status: 200 OK
     code: 200
     duration: ""
@@ -880,27 +845,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:08.685734+00:00","name":"Scaleway
-      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:52:31.759456+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.194.118.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2758"
+      - "2759"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:19 GMT
+      - Thu, 22 Feb 2024 07:52:43 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -910,7 +875,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48c277f9-c4b2-480f-935f-8d84bc1c3d8f
+      - 05915c84-d7eb-44c4-add9-39a4461185e2
     status: 200 OK
     code: 200
     duration: ""
@@ -921,20 +886,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"configuring","updated_at":"2024-02-22T07:32:17.467298Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.347441Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:46.596236Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2005"
+      - "1993"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:21 GMT
+      - Thu, 22 Feb 2024 07:52:47 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -944,7 +909,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48fe28f7-3353-4a79-9c5f-0202fe53c4ea
+      - 819c44e7-5035-4938-91b9-04a0af8ab9a0
     status: 200 OK
     code: 200
     duration: ""
@@ -955,85 +920,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/788f74d0-71d6-4b92-88f5-745dad4446d3
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:08.685734+00:00","name":"Scaleway
-      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
-      Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "2758"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:24 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 2b7c2de3-f88e-431f-93b8-9355fd085378
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1995"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:32:26 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ff35bf79-dbe1-4d02-a465-f6c26f639ec3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -1042,7 +932,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:26 GMT
+      - Thu, 22 Feb 2024 07:52:47 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1052,7 +942,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 354f5dbb-21d0-499e-8357-ee007061cf60
+      - 53af42bb-6d86-484e-8892-dab05882e079
     status: 200 OK
     code: 200
     duration: ""
@@ -1063,10 +953,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/788f74d0-71d6-4b92-88f5-745dad4446d3
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -1075,7 +965,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:26 GMT
+      - Thu, 22 Feb 2024 07:52:47 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1085,7 +975,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b7be661b-6d65-441f-a45a-d9a81f441b9a
+      - 13ea93eb-5aaf-4301-a3f1-da40429fb2da
     status: 200 OK
     code: 200
     duration: ""
@@ -1096,20 +986,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:46.596236Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1995"
+      - "1993"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:26 GMT
+      - Thu, 22 Feb 2024 07:52:47 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1119,7 +1009,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6636fe6-39a4-4683-9add-a0fccc57434b
+      - 9cf07c6f-1671-48dc-8db9-120a9e823690
     status: 200 OK
     code: 200
     duration: ""
@@ -1130,10 +1020,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/788f74d0-71d6-4b92-88f5-745dad4446d3
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -1142,7 +1032,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:26 GMT
+      - Thu, 22 Feb 2024 07:52:47 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1152,7 +1042,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c52c683d-2a23-4da4-92a6-8b7749769244
+      - c7178a38-7969-412a-9060-3692c7bfd41b
     status: 200 OK
     code: 200
     duration: ""
@@ -1163,27 +1053,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:28.133090+00:00","name":"Scaleway
-      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:52:46.921187+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.194.118.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2789"
+      - "2790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:29 GMT
+      - Thu, 22 Feb 2024 07:52:48 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1193,7 +1083,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b2f5353-12de-411b-8a78-01b22ff13ed1
+      - 726822c8-76f0-464a-83d6-166e16fb2dec
     status: 200 OK
     code: 200
     duration: ""
@@ -1204,11 +1094,11 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c32d6278-5c7d-4b15-a946-45c8a3487f84
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cb91e992-5ba8-4734-ab36-0f5425ed4ffa
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:06.793480Z","dhcp_enabled":true,"id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","name":"My
-      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.793480Z","id":"cfab4620-880e-43af-b87a-d21bcb08aab9","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:09.219464Z"},{"created_at":"2024-02-22T07:32:06.793480Z","id":"fc7dce1e-4f21-462a-ba78-911b75248f3f","subnet":"fd5f:519c:6d46:e5e0::/64","updated_at":"2024-02-22T07:32:09.222655Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.744585Z","vpc_id":"7f8ca777-3b28-467d-95c6-e3505bdb07a7"}'
+    body: '{"created_at":"2024-02-22T07:52:29.659146Z","dhcp_enabled":true,"id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","name":"My
+      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:52:29.659146Z","id":"57ac5911-b190-4eea-884a-2d52125d8532","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:35.891341Z"},{"created_at":"2024-02-22T07:52:29.659146Z","id":"9af9ab8a-ed48-496f-a509-ad3f8023d4e1","subnet":"fd5f:519c:6d46:32c7::/64","updated_at":"2024-02-22T07:52:35.896271Z"}],"tags":[],"updated_at":"2024-02-22T07:52:43.826843Z","vpc_id":"3b348a0e-5f9c-4f3c-98bf-b12bfe2399ce"}'
     headers:
       Content-Length:
       - "716"
@@ -1217,7 +1107,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:29 GMT
+      - Thu, 22 Feb 2024 07:52:48 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1227,7 +1117,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 617cdf5e-9ac5-43d1-8d4f-63ad2dc2e38a
+      - cdff7942-4f5d-42ad-88ce-6b114a29b701
     status: 200 OK
     code: 200
     duration: ""
@@ -1238,27 +1128,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:28.133090+00:00","name":"Scaleway
-      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:52:46.921187+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.194.118.13","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2789"
+      - "2790"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:29 GMT
+      - Thu, 22 Feb 2024 07:52:48 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1268,12 +1158,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12cab566-eb25-4df5-a701-beb5e94152e6
+      - 68b071ab-bdc1-4f35-99a2-545ee717af23
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84"}'
+    body: '{"private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa"}'
     form: {}
     headers:
       Content-Type:
@@ -1281,10 +1171,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:29.962647+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:52:48.751065+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1293,7 +1183,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:30 GMT
+      - Thu, 22 Feb 2024 07:52:49 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1303,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1d3767a8-f794-405e-bd9d-6fde8ab10110
+      - 86f9514c-f856-4c52-a494-ebf87c9b741a
     status: 201 Created
     code: 201
     duration: ""
@@ -1314,10 +1204,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics/571414af-161b-46c5-9d73-df1ea12a8fa3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:29.962647+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:52:48.751065+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1326,7 +1216,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:30 GMT
+      - Thu, 22 Feb 2024 07:52:49 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1336,7 +1226,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 270b9569-2427-4872-8082-638d9be71e61
+      - dd82b5ab-d2d3-43b4-91b9-defe516209f1
     status: 200 OK
     code: 200
     duration: ""
@@ -1347,10 +1237,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics/571414af-161b-46c5-9d73-df1ea12a8fa3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:31.128681+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:52:49.517427+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1359,7 +1249,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:35 GMT
+      - Thu, 22 Feb 2024 07:52:54 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1369,7 +1259,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18aadb6e-b546-4616-831a-f84aeb9a8530
+      - bcf2f1ed-10c1-4da3-b45f-ad8379517d4d
     status: 200 OK
     code: 200
     duration: ""
@@ -1380,10 +1270,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics/571414af-161b-46c5-9d73-df1ea12a8fa3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:31.128681+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:52:49.517427+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1392,7 +1282,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:41 GMT
+      - Thu, 22 Feb 2024 07:52:59 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1402,7 +1292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a4706c11-5577-431d-94b0-87371caa3a8b
+      - ff244da8-3a70-46ae-bd76-32fa3a7da916
     status: 200 OK
     code: 200
     duration: ""
@@ -1413,10 +1303,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics/571414af-161b-46c5-9d73-df1ea12a8fa3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:31.128681+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:52:49.517427+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1425,7 +1315,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:46 GMT
+      - Thu, 22 Feb 2024 07:53:04 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1435,7 +1325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 47052c06-6121-41d8-b349-a1844b1b4764
+      - 4e7ae746-8993-4d17-b7b4-60e8cb6abc8f
     status: 200 OK
     code: 200
     duration: ""
@@ -1446,10 +1336,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics/571414af-161b-46c5-9d73-df1ea12a8fa3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:31.128681+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:52:49.517427+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1458,7 +1348,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:51 GMT
+      - Thu, 22 Feb 2024 07:53:09 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1468,7 +1358,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 75c598c9-0b6d-4e04-8442-73a5bfc49169
+      - da488a0f-f0a9-4c41-bc51-3e17b873175b
     status: 200 OK
     code: 200
     duration: ""
@@ -1479,10 +1369,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics/571414af-161b-46c5-9d73-df1ea12a8fa3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:31.128681+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:52:49.517427+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1491,7 +1381,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:32:56 GMT
+      - Thu, 22 Feb 2024 07:53:14 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1501,7 +1391,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8def64b7-eb7c-4020-b9a5-68023c1e5cc6
+      - d766f6f1-b648-4934-95d1-88d54c1ac8d0
     status: 200 OK
     code: 200
     duration: ""
@@ -1512,10 +1402,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics/571414af-161b-46c5-9d73-df1ea12a8fa3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:31.128681+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:52:49.517427+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1524,7 +1414,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:01 GMT
+      - Thu, 22 Feb 2024 07:53:19 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1534,7 +1424,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09de4606-5757-4ec0-8957-f2a34c351070
+      - 11d852b1-fd1e-4135-a69d-5d24f5ff8acd
     status: 200 OK
     code: 200
     duration: ""
@@ -1545,10 +1435,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics/571414af-161b-46c5-9d73-df1ea12a8fa3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:53:20.045761+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1557,7 +1447,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:06 GMT
+      - Thu, 22 Feb 2024 07:53:24 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1567,7 +1457,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5687083a-8920-417d-b3c0-1253be54e420
+      - 737d2289-0539-4bc4-9046-00398f1bded0
     status: 200 OK
     code: 200
     duration: ""
@@ -1578,10 +1468,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics/571414af-161b-46c5-9d73-df1ea12a8fa3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:53:20.045761+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1590,7 +1480,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:06 GMT
+      - Thu, 22 Feb 2024 07:53:25 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1600,7 +1490,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f6e7fb8-be77-4c9e-b112-bf7daf1e0bea
+      - afed3181-42d7-4b9e-b60e-f9dbee22b274
     status: 200 OK
     code: 200
     duration: ""
@@ -1611,27 +1501,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:28.133090+00:00","name":"Scaleway
-      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:52:46.921187+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.194.118.13","private_nics":[{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:53:20.045761+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3142"
+      - "3143"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:06 GMT
+      - Thu, 22 Feb 2024 07:53:25 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1641,7 +1531,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 06cbcbe9-b38f-459e-8565-c732608a8b24
+      - ec100655-aa19-47dc-b088-9c1c50c659fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1652,7 +1542,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1664,7 +1554,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:06 GMT
+      - Thu, 22 Feb 2024 07:53:25 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1674,7 +1564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c3d1d2e8-57c3-4e2b-a690-41b77ee4a342
+      - f42c3242-eb0c-40b8-a232-74c4192ccf88
     status: 200 OK
     code: 200
     duration: ""
@@ -1685,10 +1575,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:53:20.045761+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1697,9 +1587,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:06 GMT
+      - Thu, 22 Feb 2024 07:53:25 GMT
       Link:
-      - </servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics?page=1&per_page=50&>;
+      - </servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
@@ -1710,7 +1600,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b70f52e0-045e-4b72-830c-0c7efc9aa821
+      - a12d1bd2-59aa-435c-80a1-ce1246c1a4d4
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1723,10 +1613,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/788f74d0-71d6-4b92-88f5-745dad4446d3
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -1735,7 +1625,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:06 GMT
+      - Thu, 22 Feb 2024 07:53:25 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1745,12 +1635,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 226543de-252c-4261-8761-0ee3b4822d86
+      - f519ad11-9c2d-487e-a90d-adb55d146f0e
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_network_id":"7f34391b-600e-4fb2-94b4-436182f0218d","mac_address":"02:00:00:18:8b:b3","ip_address":"10.0.0.3"}'
+    body: '{"gateway_network_id":"788f74d0-71d6-4b92-88f5-745dad4446d3","mac_address":"02:00:00:18:8b:d0","ip_address":"10.0.0.3"}'
     form: {}
     headers:
       Content-Type:
@@ -1761,7 +1651,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries
     method: POST
   response:
-    body: '{"created_at":"2024-02-22T07:32:31.054225Z","gateway_network_id":"7f34391b-600e-4fb2-94b4-436182f0218d","hostname":"scaleway-instance","id":"bc086d9e-55cc-4719-a5eb-cc40d8a98e9f","ip_address":"10.0.0.3","mac_address":"02:00:00:18:8b:b3","type":"reservation","updated_at":"2024-02-22T07:33:07.009439Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:52:49.456212Z","gateway_network_id":"788f74d0-71d6-4b92-88f5-745dad4446d3","hostname":"scaleway-instance","id":"59d8e2c5-62a7-41cd-a535-6329b153bd94","ip_address":"10.0.0.3","mac_address":"02:00:00:18:8b:d0","type":"reservation","updated_at":"2024-02-22T07:53:25.703211Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "327"
@@ -1770,7 +1660,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:07 GMT
+      - Thu, 22 Feb 2024 07:53:25 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1780,7 +1670,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f871a54-3032-44ae-a959-44b892a35601
+      - e35eb040-302c-4f1f-b76e-182f24a1e6cd
     status: 200 OK
     code: 200
     duration: ""
@@ -1791,10 +1681,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/788f74d0-71d6-4b92-88f5-745dad4446d3
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -1803,7 +1693,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:07 GMT
+      - Thu, 22 Feb 2024 07:53:25 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1813,7 +1703,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4790ba45-aeb1-4773-9b1d-7f6ac4cb0a9c
+      - 70e4c3f7-681d-4030-ac42-602e3c6c8d3e
     status: 200 OK
     code: 200
     duration: ""
@@ -1824,10 +1714,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/bc086d9e-55cc-4719-a5eb-cc40d8a98e9f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/59d8e2c5-62a7-41cd-a535-6329b153bd94
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:31.054225Z","gateway_network_id":"7f34391b-600e-4fb2-94b4-436182f0218d","hostname":"scaleway-instance","id":"bc086d9e-55cc-4719-a5eb-cc40d8a98e9f","ip_address":"10.0.0.3","mac_address":"02:00:00:18:8b:b3","type":"reservation","updated_at":"2024-02-22T07:33:07.009439Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:52:49.456212Z","gateway_network_id":"788f74d0-71d6-4b92-88f5-745dad4446d3","hostname":"scaleway-instance","id":"59d8e2c5-62a7-41cd-a535-6329b153bd94","ip_address":"10.0.0.3","mac_address":"02:00:00:18:8b:d0","type":"reservation","updated_at":"2024-02-22T07:53:25.703211Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "327"
@@ -1836,7 +1726,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:07 GMT
+      - Thu, 22 Feb 2024 07:53:25 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1846,7 +1736,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c79e89ee-2cdb-4dc5-ada8-44dc0c4581a6
+      - d7c0c5a2-fc83-44cd-9b76-6a90f35ede6f
     status: 200 OK
     code: 200
     duration: ""
@@ -1857,20 +1747,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:46.596236Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1995"
+      - "1993"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:07 GMT
+      - Thu, 22 Feb 2024 07:53:25 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1880,7 +1770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f5e7a725-ac04-4147-a880-dca8aa412037
+      - dd210fac-6df9-4008-9e85-6612483dbd3e
     status: 200 OK
     code: 200
     duration: ""
@@ -1891,20 +1781,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:46.596236Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1995"
+      - "1993"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:07 GMT
+      - Thu, 22 Feb 2024 07:53:25 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1914,12 +1804,12 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 67b78c81-28cd-47f3-aeaa-ae797ba72520
+      - cd05546f-4ddb-4053-a4f3-1f2d7229664a
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","public_port":2023,"private_ip":"10.0.0.3","private_port":22,"protocol":"tcp"}'
+    body: '{"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","public_port":2023,"private_ip":"10.0.0.3","private_port":22,"protocol":"tcp"}'
     form: {}
     headers:
       Content-Type:
@@ -1930,7 +1820,7 @@ interactions:
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules
     method: POST
   response:
-    body: '{"created_at":"2024-02-22T07:33:07.261806Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"19f0c7e9-c3da-435e-9729-c4e1da734bf6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:33:07.261806Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:53:26.058533Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"0c3c4667-917d-40c6-b171-2bc08e7e072e","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:53:26.058533Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "287"
@@ -1939,7 +1829,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:07 GMT
+      - Thu, 22 Feb 2024 07:53:26 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1949,7 +1839,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16eb6145-d14e-4a73-bcaa-c37f27b4fd0c
+      - 3a78f1f5-7c9c-4753-b38a-af7744922c2a
     status: 200 OK
     code: 200
     duration: ""
@@ -1960,20 +1850,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:46.596236Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1995"
+      - "1993"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:07 GMT
+      - Thu, 22 Feb 2024 07:53:26 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -1983,7 +1873,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bbb6ee0-6754-4a7d-a5e5-aa5aff47a1f1
+      - 69e7386f-6094-45b1-bf77-bed0af290a87
     status: 200 OK
     code: 200
     duration: ""
@@ -1994,10 +1884,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/19f0c7e9-c3da-435e-9729-c4e1da734bf6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/0c3c4667-917d-40c6-b171-2bc08e7e072e
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:33:07.261806Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"19f0c7e9-c3da-435e-9729-c4e1da734bf6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:33:07.261806Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:53:26.058533Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"0c3c4667-917d-40c6-b171-2bc08e7e072e","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:53:26.058533Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "287"
@@ -2006,7 +1896,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:07 GMT
+      - Thu, 22 Feb 2024 07:53:26 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2016,7 +1906,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 52bd2de7-5233-4ccf-90e4-3148350d0d21
+      - 358c8aad-abe7-47e5-a142-53715a1f97f5
     status: 200 OK
     code: 200
     duration: ""
@@ -2027,10 +1917,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/0d51c640-64c6-4a4a-8323-6f256cff01e2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/4d0baa73-0126-417f-9e7a-2d137c408b51
     method: GET
   response:
-    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "574"
@@ -2039,7 +1929,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:07 GMT
+      - Thu, 22 Feb 2024 07:53:26 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2049,7 +1939,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 42ffb13e-68e9-41a4-a75d-73b5971a28f9
+      - 3300e4fe-6009-4777-a2aa-6d16896f0ae0
     status: 200 OK
     code: 200
     duration: ""
@@ -2060,10 +1950,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/19f0c7e9-c3da-435e-9729-c4e1da734bf6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/0c3c4667-917d-40c6-b171-2bc08e7e072e
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:33:07.261806Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"19f0c7e9-c3da-435e-9729-c4e1da734bf6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:33:07.261806Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:53:26.058533Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"0c3c4667-917d-40c6-b171-2bc08e7e072e","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:53:26.058533Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "287"
@@ -2072,7 +1962,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:07 GMT
+      - Thu, 22 Feb 2024 07:53:26 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2082,7 +1972,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 11aa3ae2-d2e2-4703-9161-3206edcd3c00
+      - 4ee6e426-bb32-4805-b048-91ef1b09a161
     status: 200 OK
     code: 200
     duration: ""
@@ -2093,43 +1983,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/1c9ba85d-8322-494b-8a83-3580caaa1c38
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/4d0baa73-0126-417f-9e7a-2d137c408b51
     method: GET
   response:
-    body: '{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "403"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:33:08 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 75922dc8-5cdc-4f1c-b8ba-d0acd56c8e74
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/0d51c640-64c6-4a4a-8323-6f256cff01e2
-    method: GET
-  response:
-    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "574"
@@ -2138,7 +1995,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:08 GMT
+      - Thu, 22 Feb 2024 07:53:26 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2148,7 +2005,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2789dee8-b129-4bd7-80f5-209796bd92e5
+      - 48c745f2-6cc2-41f1-9634-c58ca4a85c23
     status: 200 OK
     code: 200
     duration: ""
@@ -2159,11 +2016,44 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c32d6278-5c7d-4b15-a946-45c8a3487f84
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/9fd1efc6-ef55-47e5-86fc-e68066f1c01a
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:06.793480Z","dhcp_enabled":true,"id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","name":"My
-      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.793480Z","id":"cfab4620-880e-43af-b87a-d21bcb08aab9","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:09.219464Z"},{"created_at":"2024-02-22T07:32:06.793480Z","id":"fc7dce1e-4f21-462a-ba78-911b75248f3f","subnet":"fd5f:519c:6d46:e5e0::/64","updated_at":"2024-02-22T07:32:09.222655Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.744585Z","vpc_id":"7f8ca777-3b28-467d-95c6-e3505bdb07a7"}'
+    body: '{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "401"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:53:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e18dea4c-ce64-48af-9ac4-a97ced8b87fa
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cb91e992-5ba8-4734-ab36-0f5425ed4ffa
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-22T07:52:29.659146Z","dhcp_enabled":true,"id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","name":"My
+      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:52:29.659146Z","id":"57ac5911-b190-4eea-884a-2d52125d8532","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:35.891341Z"},{"created_at":"2024-02-22T07:52:29.659146Z","id":"9af9ab8a-ed48-496f-a509-ad3f8023d4e1","subnet":"fd5f:519c:6d46:32c7::/64","updated_at":"2024-02-22T07:52:35.896271Z"}],"tags":[],"updated_at":"2024-02-22T07:52:43.826843Z","vpc_id":"3b348a0e-5f9c-4f3c-98bf-b12bfe2399ce"}'
     headers:
       Content-Length:
       - "716"
@@ -2172,7 +2062,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:08 GMT
+      - Thu, 22 Feb 2024 07:53:26 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2182,7 +2072,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18ca3fb3-be43-42ae-a04f-94b03b183d3f
+      - 7539727c-4e43-4cfd-9e50-e68e49553a2a
     status: 200 OK
     code: 200
     duration: ""
@@ -2193,20 +2083,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:46.596236Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1995"
+      - "1993"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:08 GMT
+      - Thu, 22 Feb 2024 07:53:27 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2216,7 +2106,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9431da3b-26b9-436a-82f0-17c70dedd8bf
+      - b641331d-4a9d-4381-b2d8-f2d91d5e5720
     status: 200 OK
     code: 200
     duration: ""
@@ -2227,77 +2117,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/788f74d0-71d6-4b92-88f5-745dad4446d3
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "984"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:33:08 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e1f0b871-a80c-495f-b8d1-4851ddb2a6ca
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1995"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:33:08 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bd1e5bf5-4937-435c-ad12-08ed4fe048c9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -2306,7 +2129,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:08 GMT
+      - Thu, 22 Feb 2024 07:53:27 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2316,7 +2139,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64419ecb-97c9-47e0-8eb4-4bd13ed3651e
+      - a97f5140-3822-48c6-952a-97912a48f026
     status: 200 OK
     code: 200
     duration: ""
@@ -2327,27 +2150,61 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:46.596236Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1993"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:53:27 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 157eb935-9572-43e1-885a-8e858189e96e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:28.133090+00:00","name":"Scaleway
-      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:52:46.921187+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.194.118.13","private_nics":[{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:53:20.045761+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3142"
+      - "3143"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:08 GMT
+      - Thu, 22 Feb 2024 07:53:27 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2357,7 +2214,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bfe096e2-0327-4981-86e1-1f9bf527b436
+      - bd60e7d0-9570-4817-9070-9516a6ef38ab
     status: 200 OK
     code: 200
     duration: ""
@@ -2368,7 +2225,40 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/user_data
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/788f74d0-71d6-4b92-88f5-745dad4446d3
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:53:27 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - f761a34f-eeed-4082-868a-bda14f49fa0e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2380,7 +2270,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:08 GMT
+      - Thu, 22 Feb 2024 07:53:27 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2390,7 +2280,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4301ce2-0979-4cb8-a4e7-c03c42081502
+      - 92d37290-1328-4f3c-b8d8-8b662228a2b2
     status: 200 OK
     code: 200
     duration: ""
@@ -2401,10 +2291,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:53:20.045761+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2413,9 +2303,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:08 GMT
+      - Thu, 22 Feb 2024 07:53:27 GMT
       Link:
-      - </servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics?page=1&per_page=50&>;
+      - </servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
@@ -2426,7 +2316,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7146ee47-063e-4ce6-82ef-75d4b7d34409
+      - 63f7f708-edbc-409a-b083-c3b6b2d2ffcc
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2439,10 +2329,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/bc086d9e-55cc-4719-a5eb-cc40d8a98e9f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/59d8e2c5-62a7-41cd-a535-6329b153bd94
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:32:31.054225Z","gateway_network_id":"7f34391b-600e-4fb2-94b4-436182f0218d","hostname":"scaleway-instance","id":"bc086d9e-55cc-4719-a5eb-cc40d8a98e9f","ip_address":"10.0.0.3","mac_address":"02:00:00:18:8b:b3","type":"reservation","updated_at":"2024-02-22T07:33:07.009439Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:52:49.456212Z","gateway_network_id":"788f74d0-71d6-4b92-88f5-745dad4446d3","hostname":"scaleway-instance","id":"59d8e2c5-62a7-41cd-a535-6329b153bd94","ip_address":"10.0.0.3","mac_address":"02:00:00:18:8b:d0","type":"reservation","updated_at":"2024-02-22T07:53:25.703211Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "327"
@@ -2451,7 +2341,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:08 GMT
+      - Thu, 22 Feb 2024 07:53:27 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2461,7 +2351,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a83bd1c5-d8b3-4ec4-86ba-e1ebd7867c9f
+      - 1e7912eb-7528-4054-81f4-df29375a4aa9
     status: 200 OK
     code: 200
     duration: ""
@@ -2472,10 +2362,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/19f0c7e9-c3da-435e-9729-c4e1da734bf6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/0c3c4667-917d-40c6-b171-2bc08e7e072e
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:33:07.261806Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"19f0c7e9-c3da-435e-9729-c4e1da734bf6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:33:07.261806Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:53:26.058533Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"0c3c4667-917d-40c6-b171-2bc08e7e072e","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:53:26.058533Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "287"
@@ -2484,7 +2374,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:08 GMT
+      - Thu, 22 Feb 2024 07:53:27 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2494,7 +2384,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 272558c7-0a10-43ca-9521-12c190950fc5
+      - 2f08cd90-273c-4563-b8ed-79540faf3c4f
     status: 200 OK
     code: 200
     duration: ""
@@ -2505,10 +2395,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/19f0c7e9-c3da-435e-9729-c4e1da734bf6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/0c3c4667-917d-40c6-b171-2bc08e7e072e
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T07:33:07.261806Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"19f0c7e9-c3da-435e-9729-c4e1da734bf6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:33:07.261806Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:53:26.058533Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"0c3c4667-917d-40c6-b171-2bc08e7e072e","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:53:26.058533Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "287"
@@ -2517,7 +2407,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:09 GMT
+      - Thu, 22 Feb 2024 07:53:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2527,7 +2417,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2313b1f3-f125-4a2b-9268-081eca1e7b11
+      - cac0bc4d-978f-4f7d-8efa-741d93d694cd
     status: 200 OK
     code: 200
     duration: ""
@@ -2538,20 +2428,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:46.596236Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1995"
+      - "1993"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:09 GMT
+      - Thu, 22 Feb 2024 07:53:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2561,7 +2451,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99c84039-d3c0-42f0-a050-c55ac50c8f9e
+      - 534c675b-e829-4434-834c-6aeb35cbdba0
     status: 200 OK
     code: 200
     duration: ""
@@ -2572,7 +2462,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/19f0c7e9-c3da-435e-9729-c4e1da734bf6
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/0c3c4667-917d-40c6-b171-2bc08e7e072e
     method: DELETE
   response:
     body: ""
@@ -2582,7 +2472,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:09 GMT
+      - Thu, 22 Feb 2024 07:53:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2592,7 +2482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7da100f8-93db-4252-bf10-9faae3db9a22
+      - 58442720-54a3-4e6e-b508-dabe26f8555e
     status: 204 No Content
     code: 204
     duration: ""
@@ -2603,20 +2493,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:46.596236Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1995"
+      - "1993"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:09 GMT
+      - Thu, 22 Feb 2024 07:53:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2626,7 +2516,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d5477e59-4de5-4eb0-aa87-fde1061306d5
+      - bd3b62bb-b5b6-4dd9-a416-6ac860ffaa0b
     status: 200 OK
     code: 200
     duration: ""
@@ -2637,10 +2527,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/788f74d0-71d6-4b92-88f5-745dad4446d3
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -2649,7 +2539,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:09 GMT
+      - Thu, 22 Feb 2024 07:53:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2659,7 +2549,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84515892-5442-443a-8347-aa1bbac4b649
+      - 5633d047-6aa1-4a63-8107-6d9d938e9d88
     status: 200 OK
     code: 200
     duration: ""
@@ -2670,7 +2560,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/bc086d9e-55cc-4719-a5eb-cc40d8a98e9f
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/59d8e2c5-62a7-41cd-a535-6329b153bd94
     method: DELETE
   response:
     body: ""
@@ -2680,7 +2570,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:09 GMT
+      - Thu, 22 Feb 2024 07:53:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2690,7 +2580,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 84ef1db1-d60a-4a30-a800-1ec41d7772ea
+      - 4df98209-1aec-4b6b-95e0-7c93ae6c1333
     status: 204 No Content
     code: 204
     duration: ""
@@ -2701,10 +2591,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/788f74d0-71d6-4b92-88f5-745dad4446d3
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -2713,7 +2603,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:09 GMT
+      - Thu, 22 Feb 2024 07:53:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2723,7 +2613,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8cc7210a-5727-42f2-baeb-d6b8a8cbf35c
+      - c4f77931-bfb7-45ca-a80a-8e4a8524ed40
     status: 200 OK
     code: 200
     duration: ""
@@ -2734,10 +2624,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/788f74d0-71d6-4b92-88f5-745dad4446d3
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"ready","updated_at":"2024-02-22T07:52:46.441473Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -2746,7 +2636,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:09 GMT
+      - Thu, 22 Feb 2024 07:53:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2756,7 +2646,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fd69e478-fb3f-4968-aea5-dd11df0f2a2f
+      - 7d9cab86-0671-4842-b0bf-58d5ac2fcda0
     status: 200 OK
     code: 200
     duration: ""
@@ -2767,27 +2657,58 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/788f74d0-71d6-4b92-88f5-745dad4446d3?cleanup_dhcp=true
+    method: DELETE
+  response:
+    body: ""
+    headers:
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:53:28 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b6b3b924-8c10-4b91-93d8-bd6bb3e385cc
+    status: 204 No Content
+    code: 204
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:28.133090+00:00","name":"Scaleway
-      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:52:46.921187+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.194.118.13","private_nics":[{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:53:20.045761+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3142"
+      - "3143"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:09 GMT
+      - Thu, 22 Feb 2024 07:53:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2797,7 +2718,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c12a8a71-aee6-49b6-943f-3b9387e4b1ff
+      - c5d39118-e210-49db-a895-c61782b7be50
     status: 200 OK
     code: 200
     duration: ""
@@ -2808,41 +2729,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d?cleanup_dhcp=true
-    method: DELETE
-  response:
-    body: ""
-    headers:
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:33:09 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bf8b0700-ba34-4a26-af07-3f3a08c74ff7
-    status: 204 No Content
-    code: 204
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/788f74d0-71d6-4b92-88f5-745dad4446d3
     method: GET
   response:
-    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"detaching","updated_at":"2024-02-22T07:33:09.474960Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:52:37.229497Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:52:29.667418Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"4d0baa73-0126-417f-9e7a-2d137c408b51","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:52:29.667418Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"788f74d0-71d6-4b92-88f5-745dad4446d3","ipam_config":null,"mac_address":"02:00:00:18:8B:CF","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","status":"detaching","updated_at":"2024-02-22T07:53:28.479324Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "988"
@@ -2851,7 +2741,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:09 GMT
+      - Thu, 22 Feb 2024 07:53:28 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2861,7 +2751,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9c0aa93b-55e6-42cb-ba00-3e8a6ab0869b
+      - 3df52163-7ea4-4ed1-9c64-f09bf0ca0d57
     status: 200 OK
     code: 200
     duration: ""
@@ -2874,10 +2764,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/action","href_result":"/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8","id":"f9457351-10f6-4b02-833d-2a353e38504e","started_at":"2024-02-22T07:33:09.689033+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/action","href_result":"/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920","id":"6da89f82-d795-422c-ab68-0907b63ece1f","started_at":"2024-02-22T07:53:28.720235+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -2886,9 +2776,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:09 GMT
+      - Thu, 22 Feb 2024 07:53:28 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/f9457351-10f6-4b02-833d-2a353e38504e
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6da89f82-d795-422c-ab68-0907b63ece1f
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2898,7 +2788,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 726a6af1-7206-471f-a841-fae056a9b22b
+      - f6ba74fe-8e67-4f42-83d6-9e14a11f246f
     status: 202 Accepted
     code: 202
     duration: ""
@@ -2909,27 +2799,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:33:09.541927+00:00","name":"Scaleway
-      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:53:28.576301+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.194.118.13","private_nics":[{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:53:20.045761+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3110"
+      - "3111"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:10 GMT
+      - Thu, 22 Feb 2024 07:53:29 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2939,7 +2829,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7dfecd14-79e7-4a9d-a125-9b855ef2c8c5
+      - 51ec66a2-aec3-4389-bbb4-b4ed07f632f2
     status: 200 OK
     code: 200
     duration: ""
@@ -2950,10 +2840,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/788f74d0-71d6-4b92-88f5-745dad4446d3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"7f34391b-600e-4fb2-94b4-436182f0218d","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"788f74d0-71d6-4b92-88f5-745dad4446d3","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2962,7 +2852,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:53:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -2972,7 +2862,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3586798e-9ee6-4365-b8a6-5ddc5947bdb7
+      - 757b4bd1-82cf-4520-b8e4-5624684a6c70
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2983,20 +2873,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:46.596236Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1011"
+      - "1009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:53:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3006,7 +2896,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e09c97c6-4a04-4765-b440-96eec089deb7
+      - 2bee0a10-9cb6-4302-8f55-bc48b246ab14
     status: 200 OK
     code: 200
     duration: ""
@@ -3017,10 +2907,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/0d51c640-64c6-4a4a-8323-6f256cff01e2
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/4d0baa73-0126-417f-9e7a-2d137c408b51
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"4d0baa73-0126-417f-9e7a-2d137c408b51","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -3029,7 +2919,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:53:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3039,7 +2929,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2a45a23-490a-4ef7-a118-69074b07fdd0
+      - c183e50d-29ba-405b-a14a-b12b9b846c87
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3050,20 +2940,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:52:46.596236Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1011"
+      - "1009"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:53:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3073,7 +2963,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c444b2b-4e94-4327-a8e8-97679351bf8d
+      - b73a95bb-8eae-4aa3-9748-ebae7d4a2af4
     status: 200 OK
     code: 200
     duration: ""
@@ -3084,7 +2974,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -3094,7 +2984,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:53:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3104,7 +2994,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 993f8a35-2dfc-4a31-91b2-2a1893e335b9
+      - 9d4fdfe4-5836-4627-9425-1a5fad3930ec
     status: 204 No Content
     code: 204
     duration: ""
@@ -3115,20 +3005,20 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"deleting","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:33:14.699842Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:52:30.366833Z","gateway_networks":[],"id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","ip":{"address":"51.15.231.133","created_at":"2024-02-22T07:52:30.250009Z","gateway_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","id":"9fd1efc6-ef55-47e5-86fc-e68066f1c01a","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"133-231-15-51.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:52:30.250009Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"deleting","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:53:33.700062Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1012"
+      - "1010"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:14 GMT
+      - Thu, 22 Feb 2024 07:53:33 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3138,7 +3028,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8046062a-d0fa-4916-82a5-c7f9f0fbc3e8
+      - e392874b-b90a-4379-8404-8ab22735a9d8
     status: 200 OK
     code: 200
     duration: ""
@@ -3149,27 +3039,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:33:09.541927+00:00","name":"Scaleway
-      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:53:28.576301+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.194.118.13","private_nics":[{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:53:20.045761+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3110"
+      - "3111"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:15 GMT
+      - Thu, 22 Feb 2024 07:53:34 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3179,7 +3069,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 08ed79cd-7dba-47df-91e1-a6dbcaa60cf3
+      - 19d37123-ec33-4782-a08b-9e77d5b27191
     status: 200 OK
     code: 200
     duration: ""
@@ -3190,10 +3080,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"6b6f3eeb-d8c2-4692-8727-a0f9acd3f81d","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3202,7 +3092,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:19 GMT
+      - Thu, 22 Feb 2024 07:53:38 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3212,7 +3102,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c45628f9-3d41-45d9-85d7-5e49741dd634
+      - b47acbd6-bb10-48ec-bc40-2b3d2a5ca48c
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3223,7 +3113,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/1c9ba85d-8322-494b-8a83-3580caaa1c38
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/9fd1efc6-ef55-47e5-86fc-e68066f1c01a
     method: DELETE
   response:
     body: ""
@@ -3233,7 +3123,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:20 GMT
+      - Thu, 22 Feb 2024 07:53:39 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3243,7 +3133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3930c47e-232e-4110-86d9-9388d8b8f56a
+      - 77b733b0-fcac-45db-ac34-ff3b203ebdb4
     status: 204 No Content
     code: 204
     duration: ""
@@ -3254,27 +3144,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:33:09.541927+00:00","name":"Scaleway
-      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:53:28.576301+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.194.118.13","private_nics":[{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:53:20.045761+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3110"
+      - "3111"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:20 GMT
+      - Thu, 22 Feb 2024 07:53:39 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3284,7 +3174,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 45c7a775-cb68-4da1-89ac-7b95ff03cefb
+      - beda1bf6-dd6b-4ccc-a795-1b85cb9597fc
     status: 200 OK
     code: 200
     duration: ""
@@ -3295,27 +3185,27 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:33:09.541927+00:00","name":"Scaleway
-      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"54","hypervisor_id":"101","node_id":"7","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:53:28.576301+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.194.118.13","private_nics":[{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:53:20.045761+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3110"
+      - "3111"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:25 GMT
+      - Thu, 22 Feb 2024 07:53:44 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3325,7 +3215,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2b77eb56-3cb1-4f31-9941-a2360a2359cc
+      - c6a01c6b-f2cd-447b-8320-5c2f1acda069
     status: 200 OK
     code: 200
     duration: ""
@@ -3336,58 +3226,17 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:33:09.541927+00:00","name":"Scaleway
-      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
-      Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3110"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 07:33:30 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-3;edge01)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3adabb40-3c4c-4349-a7c7-95c66eec2058
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:33:33.989893+00:00","name":"Scaleway
-      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:53:47.729724+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:53:20.045761+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
@@ -3397,7 +3246,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:35 GMT
+      - Thu, 22 Feb 2024 07:53:49 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3407,7 +3256,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1449482a-62b5-48e9-900d-b1de7750209b
+      - 758a7bf8-e7d2-4dc9-883b-9dad09c4bc8b
     status: 200 OK
     code: 200
     duration: ""
@@ -3418,10 +3267,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:53:20.045761+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3430,9 +3279,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:35 GMT
+      - Thu, 22 Feb 2024 07:53:50 GMT
       Link:
-      - </servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics?page=1&per_page=50&>;
+      - </servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
@@ -3443,7 +3292,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a16f5434-b575-4f85-b8f9-46adf53e462d
+      - ca87ab1c-2dc2-4971-ac59-c89fa14b05d3
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3456,10 +3305,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics/571414af-161b-46c5-9d73-df1ea12a8fa3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:52:48.751065+00:00","id":"571414af-161b-46c5-9d73-df1ea12a8fa3","mac_address":"02:00:00:18:8b:d0","modification_date":"2024-02-22T07:53:20.045761+00:00","private_network_id":"cb91e992-5ba8-4734-ab36-0f5425ed4ffa","server_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -3468,7 +3317,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:35 GMT
+      - Thu, 22 Feb 2024 07:53:50 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3478,7 +3327,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d735b40-e850-4ae9-b409-4cf3f4d1759e
+      - c68b8b74-d13b-4549-a688-34b912bf0da6
     status: 200 OK
     code: 200
     duration: ""
@@ -3489,7 +3338,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics/571414af-161b-46c5-9d73-df1ea12a8fa3
     method: DELETE
   response:
     body: ""
@@ -3497,7 +3346,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 22 Feb 2024 07:33:36 GMT
+      - Thu, 22 Feb 2024 07:53:50 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3507,7 +3356,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe50abdf-68e1-4562-a1a3-f5a1d48ed9b5
+      - e7cbf9b0-4728-436d-a933-1a8179e5d7d8
     status: 204 No Content
     code: 204
     duration: ""
@@ -3518,10 +3367,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920/private_nics/571414af-161b-46c5-9d73-df1ea12a8fa3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"571414af-161b-46c5-9d73-df1ea12a8fa3","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -3530,7 +3379,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:36 GMT
+      - Thu, 22 Feb 2024 07:53:50 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3540,7 +3389,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 64dd79cd-dfc5-4dc3-8292-c444d2fe5ca4
+      - b28720a8-7925-409d-93af-a297744a3577
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3551,17 +3400,17 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:52:30.812937+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
       Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:33:33.989893+00:00","name":"Scaleway
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:02:29","maintenances":[],"modification_date":"2024-02-22T07:53:47.729724+00:00","name":"Scaleway
       Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
-      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:52:30.812937+00:00","export_uri":null,"id":"152e4971-a930-4fd6-b11c-fd1eccd16ae4","modification_date":"2024-02-22T07:52:30.812937+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
@@ -3571,7 +3420,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:36 GMT
+      - Thu, 22 Feb 2024 07:53:50 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3581,7 +3430,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ce58adf-0fd8-45a8-a849-ff9945fd5294
+      - f6bc7e73-a682-4a9e-89dc-4561cf8b11ac
     status: 200 OK
     code: 200
     duration: ""
@@ -3592,7 +3441,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: DELETE
   response:
     body: ""
@@ -3600,7 +3449,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 22 Feb 2024 07:33:36 GMT
+      - Thu, 22 Feb 2024 07:53:51 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3610,7 +3459,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d09904ba-ac03-43bb-a865-700b98072eb4
+      - f087b633-994e-4948-a2cf-843796cbe959
     status: 204 No Content
     code: 204
     duration: ""
@@ -3621,10 +3470,10 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/2e77d7eb-9b10-4591-9ee7-f32f54733920
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"2e77d7eb-9b10-4591-9ee7-f32f54733920","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -3633,7 +3482,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:36 GMT
+      - Thu, 22 Feb 2024 07:53:51 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3643,7 +3492,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ce7d3f03-cf34-42db-acbb-d2347784c0bc
+      - 89a79038-9d1c-4f79-86f3-e9f9dd21eefe
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3654,7 +3503,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0cc59ce5-9da0-4638-96d9-d26bb6d3091e
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/152e4971-a930-4fd6-b11c-fd1eccd16ae4
     method: DELETE
   response:
     body: ""
@@ -3662,7 +3511,7 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Thu, 22 Feb 2024 07:33:36 GMT
+      - Thu, 22 Feb 2024 07:53:51 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3672,7 +3521,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 57a10a4a-8ab7-4a2b-91f9-736b3a08ab99
+      - cf2fc7be-8358-408c-b82c-04a09948fc3f
     status: 204 No Content
     code: 204
     duration: ""
@@ -3683,7 +3532,7 @@ interactions:
       User-Agent:
       - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c32d6278-5c7d-4b15-a946-45c8a3487f84
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/cb91e992-5ba8-4734-ab36-0f5425ed4ffa
     method: DELETE
   response:
     body: ""
@@ -3693,7 +3542,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 07:33:38 GMT
+      - Thu, 22 Feb 2024 07:53:52 GMT
       Server:
       - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
@@ -3703,7 +3552,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4d40e5b6-f1d3-4474-8e95-c7b4728cc734
+      - 5778e66a-ca36-4a1f-90d4-288562f87ea6
     status: 204 No Content
     code: 204
     duration: ""

--- a/scaleway/testdata/vpc-public-gateway-pat-rule-with-instance.cassette.yaml
+++ b/scaleway/testdata/vpc-public-gateway-pat-rule-with-instance.cassette.yaml
@@ -2,18 +2,18 @@
 version: 1
 interactions:
 - request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","subnet":"10.0.0.0/24","address":null,"pool_low":null,"pool_high":null,"enable_dynamic":null,"valid_lifetime":null,"renew_timer":null,"rebind_timer":null,"push_default_route":null,"push_dns_server":null,"dns_servers_override":null,"dns_search":null,"dns_local_name":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","subnet":"10.0.0.0/24"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps
     method: POST
   response:
-    body: '{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "574"
@@ -22,9 +22,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:49 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -32,7 +32,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c10234c0-b484-4ec5-a272-c2746baf441d
+      - f0f28eb6-2f5f-4f67-bd0f-4471b6a534dc
     status: 200 OK
     code: 200
     duration: ""
@@ -41,12 +41,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/9905b816-982c-4533-95df-9c1fb6652616
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/0d51c640-64c6-4a4a-8323-6f256cff01e2
     method: GET
   response:
-    body: '{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "574"
@@ -55,9 +55,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:49 GMT
+      - Thu, 22 Feb 2024 07:32:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -65,59 +65,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 63b6a6f9-acd4-4830-ab61-7d0936879939
+      - 3b76da3a-0f91-45a7-9439-4951a5aff8e6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"My Private Network","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null,"subnets":null,"vpc_id":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[]}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
-    method: POST
-  response:
-    body: '{"created_at":"2023-10-27T09:19:49.667169Z","dhcp_enabled":true,"id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","name":"My
-      Private Network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T09:19:49.667169Z","id":"de489d07-0287-4658-860f-6125d7ecb7e0","subnet":"172.16.68.0/22","updated_at":"2023-10-27T09:19:49.667169Z"},{"created_at":"2023-10-27T09:19:49.667169Z","id":"0cb1d3db-cf3e-4571-914e-8d8fdd6951bd","subnet":"fd46:78ab:30b8:f7b5::/64","updated_at":"2023-10-27T09:19:49.667169Z"}],"tags":[],"updated_at":"2023-10-27T09:19:49.667169Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
-    headers:
-      Content-Length:
-      - "719"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:19:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - cb652a47-1fae-489a-939d-8d2fa850a700
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","tags":null}'
-    form: {}
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips
     method: POST
   response:
-    body: '{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":null,"id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":null,"id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "369"
@@ -126,9 +90,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:50 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -136,7 +100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98f45b98-5d67-49b3-bfc0-e0784bebd948
+      - 756feac1-f1ea-4365-a04d-45d9a2cb98e4
     status: 200 OK
     code: 200
     duration: ""
@@ -145,12 +109,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/57d892b9-1f4d-4e63-be19-8f3646cc417b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/1c9ba85d-8322-494b-8a83-3580caaa1c38
     method: GET
   response:
-    body: '{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":null,"id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":null,"id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "369"
@@ -159,9 +123,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:50 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -169,103 +133,36 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3312383e-8ba5-45ab-b354-32be81aecbde
+      - e4bae936-edfe-42b7-86af-252f034c56cf
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b8a24e1f-a121-4288-b171-6ba30a5f9ced
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-27T09:19:49.667169Z","dhcp_enabled":true,"id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","name":"My
-      Private Network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T09:19:49.667169Z","id":"de489d07-0287-4658-860f-6125d7ecb7e0","subnet":"172.16.68.0/22","updated_at":"2023-10-27T09:19:49.667169Z"},{"created_at":"2023-10-27T09:19:49.667169Z","id":"0cb1d3db-cf3e-4571-914e-8d8fdd6951bd","subnet":"fd46:78ab:30b8:f7b5::/64","updated_at":"2023-10-27T09:19:49.667169Z"}],"tags":[],"updated_at":"2023-10-27T09:19:49.667169Z","vpc_id":"086a5171-f7ab-4667-a231-840a81203f19"}'
-    headers:
-      Content-Length:
-      - "719"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:19:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 72e866ee-40f5-47ac-a073-e7df2931eb25
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=debian_bullseye&order_by=created_at_asc&type=instance_local&zone=fr-par-1
-    method: GET
-  response:
-    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","label":"debian_bullseye","type":"unknown_type","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"7691a260-ab4a-4692-8c54-862e08826deb","label":"debian_bullseye","type":"unknown_type","zone":"fr-par-1"}],"total_count":2}'
-    headers:
-      Content-Length:
-      - "1262"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:19:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f8d281a8-5300-4278-85b5-12fe21b194c4
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","name":"The Public
-      Gateway","tags":null,"type":"VPC-GW-S","upstream_dns_servers":null,"ip_id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","enable_smtp":false,"enable_bastion":false,"bastion_port":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"The Public
+      Gateway","tags":[],"type":"VPC-GW-S","upstream_dns_servers":[],"ip_id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","enable_smtp":false,"enable_bastion":false}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways
     method: POST
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":false,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:19:50.463377Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:03.281397Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "983"
+      - "1012"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:50 GMT
+      - Thu, 22 Feb 2024 07:32:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -273,7 +170,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41ad5028-0cf0-4907-8d7a-1c1f5c9286b3
+      - 360c6dc5-14f5-494a-9fe4-850c1979bdc3
     status: 200 OK
     code: 200
     duration: ""
@@ -282,26 +179,198 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:03.281397Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1012"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:03 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 738b50c1-2c73-41ec-8a33-4cb4c1496b6b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"name":"My Private Network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"message":"internal error"}'
+    headers:
+      Content-Length:
+      - "28"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:04 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7b9fbd60-cf5b-42a2-90de-640d4e4831b5
+    status: 500 Internal Server Error
+    code: 500
+    duration: ""
+- request:
+    body: '{"name":"My Private Network","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+    method: POST
+  response:
+    body: '{"created_at":"2024-02-22T07:32:06.793480Z","dhcp_enabled":true,"id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","name":"My
+      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.793480Z","id":"cfab4620-880e-43af-b87a-d21bcb08aab9","subnet":"172.16.116.0/22","updated_at":"2024-02-22T07:32:06.793480Z"},{"created_at":"2024-02-22T07:32:06.793480Z","id":"fc7dce1e-4f21-462a-ba78-911b75248f3f","subnet":"fd5f:519c:6d46:e5e0::/64","updated_at":"2024-02-22T07:32:06.793480Z"}],"tags":[],"updated_at":"2024-02-22T07:32:06.793480Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "720"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:07 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 37466253-23da-4bf2-a516-73dcb4cc566a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c32d6278-5c7d-4b15-a946-45c8a3487f84
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-22T07:32:06.793480Z","dhcp_enabled":true,"id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","name":"My
+      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.793480Z","id":"cfab4620-880e-43af-b87a-d21bcb08aab9","subnet":"172.16.116.0/22","updated_at":"2024-02-22T07:32:06.793480Z"},{"created_at":"2024-02-22T07:32:06.793480Z","id":"fc7dce1e-4f21-462a-ba78-911b75248f3f","subnet":"fd5f:519c:6d46:e5e0::/64","updated_at":"2024-02-22T07:32:06.793480Z"}],"tags":[],"updated_at":"2024-02-22T07:32:06.793480Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+    headers:
+      Content-Length:
+      - "720"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:07 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 573a5042-97f9-46c6-976e-ca1757c02a5e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/marketplace/v2/local-images?image_label=debian_bullseye&order_by=created_at_asc&type=instance_local&zone=fr-par-1
+    method: GET
+  response:
+    body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","label":"debian_bullseye","type":"instance_local","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"75b9767f-ccfd-49ed-bb8a-6bcd717e3eaa","label":"debian_bullseye","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+    headers:
+      Content-Length:
+      - "1266"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:07 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4dd62fad-4309-4475-9e87-988137239227
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
     method: GET
   response:
-    body: '{"servers":{"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}},"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}}}}'
+    body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["rescue","local"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
     headers:
       Content-Length:
-      - "38421"
+      - "38183"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:50 GMT
+      - Thu, 22 Feb 2024 07:32:07 GMT
       Link:
       - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -309,9 +378,9 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88286796-1f46-4045-87c9-0d7c842eaffb
+      - c52e38b0-e1d4-42b2-9527-605f5f2620e6
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
@@ -320,60 +389,26 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":false,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"allocating","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:19:50.463377Z","upstream_dns_servers":[],"version":null,"zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "983"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:19:50 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 3eda5afb-5389-47a0-b998-b61c3c850f1b
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
     method: GET
   response:
-    body: '{"servers":{"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+    body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["bootscript","rescue","local"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
     headers:
       Content-Length:
-      - "4865"
+      - "8882"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:50 GMT
+      - Thu, 22 Feb 2024 07:32:07 GMT
       Link:
       - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>;
         rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -381,46 +416,46 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8f9f369a-d3f4-4903-9fd7-1397e1f4f16e
+      - 4be534cc-2c52-4c5b-8af6-d1c5362d2985
       X-Total-Count:
-      - "56"
+      - "61"
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"Scaleway Instance","dynamic_ip_required":false,"routed_ip_enabled":false,"commercial_type":"DEV1-S","image":"92e694e8-5f29-420f-b48d-c3cb88de283d","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5"}'
+    body: '{"name":"Scaleway Instance","dynamic_ip_required":false,"commercial_type":"DEV1-S","image":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","volumes":{"0":{"boot":false,"size":20000000000,"volume_type":"l_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
     method: POST
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2606"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:51 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -428,7 +463,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 297a0234-95e1-4a06-8ada-764487034001
+      - 9b3afffa-a735-41ee-8a84-36a758b637ca
     status: 201 Created
     code: 201
     duration: ""
@@ -437,31 +472,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
-      Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.429950Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2606"
+      - "1012"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:51 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -469,7 +497,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5bf3f07-47cd-4dca-99b8-595fa7750db6
+      - 1ecb967e-f845-45cc-b09d-76b18497639c
     status: 200 OK
     code: 200
     duration: ""
@@ -478,31 +506,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
     method: GET
   response:
-    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
-      Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.429950Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "2606"
+      - "1012"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:51 GMT
+      - Thu, 22 Feb 2024 07:32:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -510,7 +531,123 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f7071a3-ca1c-436e-82cf-5153b5dd01d1
+      - ab11ac40-c50a-477d-9131-08af930315b4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":false,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:04.429950Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1012"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0f942647-887c-4d5d-b5bd-0759821cd461
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5e232c8a-35ba-43d3-83df-bc02e18e974a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2628"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7ba92cb8-fb0b-400e-a2ba-febc75be051f
     status: 200 OK
     code: 200
     duration: ""
@@ -521,12 +658,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/action
     method: POST
   response:
-    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/098846b5-7816-4025-9b0d-fed4391018de/action","href_result":"/servers/098846b5-7816-4025-9b0d-fed4391018de","id":"734e48f5-59b1-41e0-92b9-1775e2b8a567","started_at":"2023-10-27T09:19:52.046526+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/action","href_result":"/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8","id":"a0196bd7-28a2-4668-aa6c-79c66f20b070","started_at":"2024-02-22T07:32:08.831437+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "322"
@@ -535,11 +672,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:52 GMT
+      - Thu, 22 Feb 2024 07:32:09 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/734e48f5-59b1-41e0-92b9-1775e2b8a567
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/a0196bd7-28a2-4668-aa6c-79c66f20b070
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -547,7 +684,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cefb6297-b0d8-46d3-ab8f-e49013c064da
+      - 503a84a2-9ba5-4cd5-8f86-de46bfcae8d8
     status: 202 Accepted
     code: 202
     duration: ""
@@ -556,31 +693,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:19:51.745031+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:08.685734+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2628"
+      - "2650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:52 GMT
+      - Thu, 22 Feb 2024 07:32:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -588,125 +725,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - afe8920f-07e3-4bed-9b5b-7f72d75b891c
+      - c36ee950-4ff0-49d3-b96c-ab1b24c18ad6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":false,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:19:51.254694Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "983"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:19:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 5085acc8-7223-47b3-ba69-1bc3c4c0730c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":false,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:19:51.254694Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "983"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:19:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 04b89fde-a32d-4997-8dde-18a8ae72c2a3
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":false,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:19:51.254694Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "983"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:19:55 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 45e4b524-7f9b-4b6e-b391-645a9eb7d4b9
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: '{"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"9905b816-982c-4533-95df-9c1fb6652616"}'
+    body: '{"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","enable_masquerade":true,"enable_dhcp":true,"dhcp_id":"0d51c640-64c6-4a4a-8323-6f256cff01e2"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks
     method: POST
   response:
-    body: '{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":null,"private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"created","updated_at":"2023-10-27T09:19:57.154011Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":null,"private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"created","updated_at":"2024-02-22T07:32:11.108412Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "971"
@@ -715,9 +750,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:57 GMT
+      - Thu, 22 Feb 2024 07:32:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -725,7 +760,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49c228e2-a174-4eb8-b4c8-28dcf9efff34
+      - e81b4fab-4a12-4cb8-8c13-f0b58ddd8fd0
     status: 200 OK
     code: 200
     duration: ""
@@ -734,31 +769,65 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":null,"private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"created","updated_at":"2024-02-22T07:32:11.108412Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.125663Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1986"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:11 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 31c57f94-6091-4c58-9e0f-99b29f1df7ba
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1701","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:19:51.745031+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.64.224.31","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:08.685734+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2738"
+      - "2650"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:57 GMT
+      - Thu, 22 Feb 2024 07:32:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -766,7 +835,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6ba9c56c-9f80-4078-af1c-9bcc9350413b
+      - e6266861-4a69-46d9-8b81-09bedc760cf9
     status: 200 OK
     code: 200
     duration: ""
@@ -775,24 +844,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":null,"private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"created","updated_at":"2023-10-27T09:19:57.154011Z","zone":"fr-par-1"}],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:19:57.362159Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":null,"private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"created","updated_at":"2024-02-22T07:32:11.108412Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.347441Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1957"
+      - "1986"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:19:57 GMT
+      - Thu, 22 Feb 2024 07:32:16 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -800,7 +869,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0a414786-bcfc-49b2-aac7-451d803e02e5
+      - 8229ba57-83ad-454a-b91b-cd89b9ea1d02
     status: 200 OK
     code: 200
     duration: ""
@@ -809,65 +878,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"configuring","updated_at":"2023-10-27T09:20:01.180151Z","zone":"fr-par-1"}],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:19:57.362159Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1976"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:20:02 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 970185e9-621d-4c6e-ae06-df14e38bce2d
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1701","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:19:51.745031+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.64.224.31","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:08.685734+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2738"
+      - "2758"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:02 GMT
+      - Thu, 22 Feb 2024 07:32:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -875,7 +910,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5d69fa2d-ff37-4200-8e5a-bb4d6bc81e3c
+      - 48c277f9-c4b2-480f-935f-8d84bc1c3d8f
     status: 200 OK
     code: 200
     duration: ""
@@ -884,24 +919,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:20:04.051485Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"configuring","updated_at":"2024-02-22T07:32:17.467298Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"configuring","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:11.347441Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1966"
+      - "2005"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:07 GMT
+      - Thu, 22 Feb 2024 07:32:21 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -909,7 +944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9d8337e5-542d-4faf-be9e-3c342668c13b
+      - 48fe28f7-3353-4a79-9c5f-0202fe53c4ea
     status: 200 OK
     code: 200
     duration: ""
@@ -918,12 +953,87 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/dfbbd5d4-417b-4201-81ac-839de38905cb
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}'
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:08.685734+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "2758"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:24 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2b7c2de3-f88e-431f-93b8-9355fd085378
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ff35bf79-dbe1-4d02-a465-f6c26f639ec3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -932,9 +1042,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:07 GMT
+      - Thu, 22 Feb 2024 07:32:26 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -942,7 +1052,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 721c8acb-f097-48e2-b8fa-3e853078fb4b
+      - 354f5dbb-21d0-499e-8357-ee007061cf60
     status: 200 OK
     code: 200
     duration: ""
@@ -951,31 +1061,131 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b7be661b-6d65-441f-a45a-d9a81f441b9a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    method: GET
+  response:
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1995"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e6636fe6-39a4-4683-9add-a0fccc57434b
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:32:26 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c52c683d-2a23-4da4-92a6-8b7749769244
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1701","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:20:04.786446+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.64.224.31","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:28.133090+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2769"
+      - "2789"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:07 GMT
+      - Thu, 22 Feb 2024 07:32:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -983,7 +1193,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3eec3edb-ec11-4b02-94f6-c890d543f1d8
+      - 7b2f5353-12de-411b-8a78-01b22ff13ed1
     status: 200 OK
     code: 200
     duration: ""
@@ -992,80 +1202,13 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/dfbbd5d4-417b-4201-81ac-839de38905cb
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c32d6278-5c7d-4b15-a946-45c8a3487f84
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "984"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - f20d6fa4-130c-4071-b423-84783c8e274c
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
-    method: GET
-  response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:20:04.051485Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "1966"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 9a35c189-2ac5-44fd-9086-401091ac8bbc
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b8a24e1f-a121-4288-b171-6ba30a5f9ced
-    method: GET
-  response:
-    body: '{"created_at":"2023-10-27T09:19:49.667169Z","dhcp_enabled":true,"id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","name":"My
-      Private Network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T09:19:49.667169Z","id":"de489d07-0287-4658-860f-6125d7ecb7e0","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:56.143052Z"},{"created_at":"2023-10-27T09:19:49.667169Z","id":"0cb1d3db-cf3e-4571-914e-8d8fdd6951bd","subnet":"fd46:78ab:30b8:f7b5::/64","updated_at":"2023-10-27T09:19:56.148154Z"}],"tags":[],"updated_at":"2023-10-27T09:20:01.540972Z","vpc_id":"94132e03-8daf-4987-a793-e5382d24aa44"}'
+    body: '{"created_at":"2024-02-22T07:32:06.793480Z","dhcp_enabled":true,"id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","name":"My
+      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.793480Z","id":"cfab4620-880e-43af-b87a-d21bcb08aab9","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:09.219464Z"},{"created_at":"2024-02-22T07:32:06.793480Z","id":"fc7dce1e-4f21-462a-ba78-911b75248f3f","subnet":"fd5f:519c:6d46:e5e0::/64","updated_at":"2024-02-22T07:32:09.222655Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.744585Z","vpc_id":"7f8ca777-3b28-467d-95c6-e3505bdb07a7"}'
     headers:
       Content-Length:
       - "716"
@@ -1074,9 +1217,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:07 GMT
+      - Thu, 22 Feb 2024 07:32:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1084,7 +1227,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 99bb92df-769c-401f-8977-e956f57d1cf3
+      - 617cdf5e-9ac5-43d1-8d4f-63ad2dc2e38a
     status: 200 OK
     code: 200
     duration: ""
@@ -1093,64 +1236,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/dfbbd5d4-417b-4201-81ac-839de38905cb
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "984"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:20:07 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7fc49f58-10fe-4f91-a3b2-f824e352dabf
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1701","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:20:04.786446+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.64.224.31","private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:28.133090+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2769"
+      - "2789"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:07 GMT
+      - Thu, 22 Feb 2024 07:32:29 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1158,23 +1268,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 21c6e07b-9a3b-4120-b110-ae69a5eb8ee2
+      - 12cab566-eb25-4df5-a701-beb5e94152e6
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced"}'
+    body: '{"private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics
     method: POST
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:07.872536+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:29.962647+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1183,9 +1293,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:08 GMT
+      - Thu, 22 Feb 2024 07:32:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1193,7 +1303,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 850e86ef-3bff-4365-990a-bbde4c19fb3a
+      - 1d3767a8-f794-405e-bd9d-6fde8ab10110
     status: 201 Created
     code: 201
     duration: ""
@@ -1202,12 +1312,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics/671b4e09-8d51-49e9-b29f-97a63b3ab666
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:07.872536+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:29.962647+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1216,9 +1326,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:08 GMT
+      - Thu, 22 Feb 2024 07:32:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1226,7 +1336,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2008bd0b-85ee-4fc9-a9a5-f17318976054
+      - 270b9569-2427-4872-8082-638d9be71e61
     status: 200 OK
     code: 200
     duration: ""
@@ -1235,12 +1345,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics/671b4e09-8d51-49e9-b29f-97a63b3ab666
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:09.015021+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:31.128681+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1249,9 +1359,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:13 GMT
+      - Thu, 22 Feb 2024 07:32:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1259,7 +1369,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09444758-c934-4bb3-840b-931ceb72b2eb
+      - 18aadb6e-b546-4616-831a-f84aeb9a8530
     status: 200 OK
     code: 200
     duration: ""
@@ -1268,12 +1378,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics/671b4e09-8d51-49e9-b29f-97a63b3ab666
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:09.015021+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:31.128681+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1282,9 +1392,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:18 GMT
+      - Thu, 22 Feb 2024 07:32:41 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1292,7 +1402,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dccf2235-58d7-4ca4-9ee1-b261509af260
+      - a4706c11-5577-431d-94b0-87371caa3a8b
     status: 200 OK
     code: 200
     duration: ""
@@ -1301,12 +1411,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics/671b4e09-8d51-49e9-b29f-97a63b3ab666
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:09.015021+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:31.128681+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1315,9 +1425,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:23 GMT
+      - Thu, 22 Feb 2024 07:32:46 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1325,7 +1435,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cbb82725-0d3b-4b28-9d66-87b4a9d82479
+      - 47052c06-6121-41d8-b349-a1844b1b4764
     status: 200 OK
     code: 200
     duration: ""
@@ -1334,12 +1444,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics/671b4e09-8d51-49e9-b29f-97a63b3ab666
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:09.015021+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:31.128681+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1348,9 +1458,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:29 GMT
+      - Thu, 22 Feb 2024 07:32:51 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1358,7 +1468,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ceabcdb0-4241-4fd9-b026-a960899399c9
+      - 75c598c9-0b6d-4e04-8442-73a5bfc49169
     status: 200 OK
     code: 200
     duration: ""
@@ -1367,12 +1477,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics/671b4e09-8d51-49e9-b29f-97a63b3ab666
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:09.015021+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:31.128681+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1381,9 +1491,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:34 GMT
+      - Thu, 22 Feb 2024 07:32:56 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1391,7 +1501,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c969cd7-4253-4240-b48e-133257cd4069
+      - 8def64b7-eb7c-4020-b9a5-68023c1e5cc6
     status: 200 OK
     code: 200
     duration: ""
@@ -1400,12 +1510,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics/671b4e09-8d51-49e9-b29f-97a63b3ab666
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:09.015021+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:32:31.128681+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"syncing","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "376"
@@ -1414,9 +1524,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:39 GMT
+      - Thu, 22 Feb 2024 07:33:01 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1424,7 +1534,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13e5a36f-264b-4344-91f7-deb9d02772af
+      - 09de4606-5757-4ec0-8957-f2a34c351070
     status: 200 OK
     code: 200
     duration: ""
@@ -1433,12 +1543,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics/671b4e09-8d51-49e9-b29f-97a63b3ab666
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1447,9 +1557,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:44 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1457,7 +1567,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50c2947b-274f-4704-ab6d-f836fc52dd43
+      - 5687083a-8920-417d-b3c0-1253be54e420
     status: 200 OK
     code: 200
     duration: ""
@@ -1466,12 +1576,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics/671b4e09-8d51-49e9-b29f-97a63b3ab666
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -1480,9 +1590,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:44 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1490,7 +1600,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c234c5d4-7bdf-43f9-9240-ba4752653297
+      - 5f6e7fb8-be77-4c9e-b112-bf7daf1e0bea
     status: 200 OK
     code: 200
     duration: ""
@@ -1499,31 +1609,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1701","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:20:04.786446+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.64.224.31","private_nics":[{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:28.133090+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3122"
+      - "3142"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:44 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1531,7 +1641,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - abba8430-d907-4ee6-aa5e-ce8088e37af7
+      - 06cbcbe9-b38f-459e-8565-c732608a8b24
     status: 200 OK
     code: 200
     duration: ""
@@ -1540,9 +1650,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -1554,9 +1664,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:44 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1564,7 +1674,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8756830a-0e5e-43be-9acd-b6e67d900d85
+      - c3d1d2e8-57c3-4e2b-a690-41b77ee4a342
     status: 200 OK
     code: 200
     duration: ""
@@ -1573,12 +1683,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -1587,12 +1697,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:44 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Link:
-      - </servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics?page=1&per_page=50&>;
+      - </servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1600,7 +1710,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b848728-eb24-472d-a158-606b416be031
+      - b70f52e0-045e-4b72-830c-0c7efc9aa821
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -1611,12 +1721,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/dfbbd5d4-417b-4201-81ac-839de38905cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -1625,9 +1735,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:44 GMT
+      - Thu, 22 Feb 2024 07:33:06 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1635,23 +1745,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7a580049-83a6-4b77-babe-fdfdbc6b1958
+      - 226543de-252c-4261-8761-0ee3b4822d86
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_network_id":"dfbbd5d4-417b-4201-81ac-839de38905cb","mac_address":"02:00:00:14:74:1b","ip_address":"10.0.0.3"}'
+    body: '{"gateway_network_id":"7f34391b-600e-4fb2-94b4-436182f0218d","mac_address":"02:00:00:18:8b:b3","ip_address":"10.0.0.3"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries
     method: POST
   response:
-    body: '{"created_at":"2023-10-27T09:20:08.891703Z","gateway_network_id":"dfbbd5d4-417b-4201-81ac-839de38905cb","hostname":"scaleway-instance","id":"ae9c6642-9b34-4c5f-a978-e1172c114822","ip_address":"10.0.0.3","mac_address":"02:00:00:14:74:1b","type":"reservation","updated_at":"2023-10-27T09:20:44.956263Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:31.054225Z","gateway_network_id":"7f34391b-600e-4fb2-94b4-436182f0218d","hostname":"scaleway-instance","id":"bc086d9e-55cc-4719-a5eb-cc40d8a98e9f","ip_address":"10.0.0.3","mac_address":"02:00:00:18:8b:b3","type":"reservation","updated_at":"2024-02-22T07:33:07.009439Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "327"
@@ -1660,9 +1770,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:44 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1670,7 +1780,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 195994f6-6444-474c-b7f5-56f4064a5265
+      - 0f871a54-3032-44ae-a959-44b892a35601
     status: 200 OK
     code: 200
     duration: ""
@@ -1679,12 +1789,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/dfbbd5d4-417b-4201-81ac-839de38905cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -1693,9 +1803,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:45 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1703,7 +1813,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 450adbb4-fc16-4f99-a3ce-8ba3c839ab63
+      - 4790ba45-aeb1-4773-9b1d-7f6ac4cb0a9c
     status: 200 OK
     code: 200
     duration: ""
@@ -1712,12 +1822,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ae9c6642-9b34-4c5f-a978-e1172c114822
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/bc086d9e-55cc-4719-a5eb-cc40d8a98e9f
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T09:20:08.891703Z","gateway_network_id":"dfbbd5d4-417b-4201-81ac-839de38905cb","hostname":"scaleway-instance","id":"ae9c6642-9b34-4c5f-a978-e1172c114822","ip_address":"10.0.0.3","mac_address":"02:00:00:14:74:1b","type":"reservation","updated_at":"2023-10-27T09:20:44.956263Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:31.054225Z","gateway_network_id":"7f34391b-600e-4fb2-94b4-436182f0218d","hostname":"scaleway-instance","id":"bc086d9e-55cc-4719-a5eb-cc40d8a98e9f","ip_address":"10.0.0.3","mac_address":"02:00:00:18:8b:b3","type":"reservation","updated_at":"2024-02-22T07:33:07.009439Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "327"
@@ -1726,9 +1836,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:45 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1736,7 +1846,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6409a9c-b751-4ebd-b5d0-c6b89cd850ae
+      - c79e89ee-2cdb-4dc5-ada8-44dc0c4581a6
     status: 200 OK
     code: 200
     duration: ""
@@ -1745,24 +1855,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:20:04.051485Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1966"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:45 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1770,7 +1880,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f935c6f1-1a65-4945-889b-59aa857fca8a
+      - f5e7a725-ac04-4147-a880-dca8aa412037
     status: 200 OK
     code: 200
     duration: ""
@@ -1779,24 +1889,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:20:04.051485Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1966"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:45 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1804,23 +1914,23 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18524a0b-5671-4817-a097-c8b4c9cb98db
+      - 67b78c81-28cd-47f3-aeaa-ae797ba72520
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","public_port":2023,"private_ip":"10.0.0.3","private_port":22,"protocol":"tcp"}'
+    body: '{"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","public_port":2023,"private_ip":"10.0.0.3","private_port":22,"protocol":"tcp"}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules
     method: POST
   response:
-    body: '{"created_at":"2023-10-27T09:20:45.373605Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"9f9b12cc-f21c-4706-8465-a3cfdd9de4f3","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-10-27T09:20:45.373605Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:33:07.261806Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"19f0c7e9-c3da-435e-9729-c4e1da734bf6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:33:07.261806Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "287"
@@ -1829,9 +1939,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:45 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1839,7 +1949,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a7b214e0-07fe-4a4a-ab63-6fab64ab106b
+      - 16eb6145-d14e-4a73-bcaa-c37f27b4fd0c
     status: 200 OK
     code: 200
     duration: ""
@@ -1848,24 +1958,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:20:04.051485Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1966"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:45 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1873,7 +1983,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f322f95-e089-4762-993e-579efe1ecea2
+      - 3bbb6ee0-6754-4a7d-a5e5-aa5aff47a1f1
     status: 200 OK
     code: 200
     duration: ""
@@ -1882,12 +1992,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9f9b12cc-f21c-4706-8465-a3cfdd9de4f3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/19f0c7e9-c3da-435e-9729-c4e1da734bf6
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T09:20:45.373605Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"9f9b12cc-f21c-4706-8465-a3cfdd9de4f3","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-10-27T09:20:45.373605Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:33:07.261806Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"19f0c7e9-c3da-435e-9729-c4e1da734bf6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:33:07.261806Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "287"
@@ -1896,9 +2006,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:45 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1906,7 +2016,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fad9692b-2695-42cc-a2f9-b803559abc15
+      - 52bd2de7-5233-4ccf-90e4-3148350d0d21
     status: 200 OK
     code: 200
     duration: ""
@@ -1915,12 +2025,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/9905b816-982c-4533-95df-9c1fb6652616
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/0d51c640-64c6-4a4a-8323-6f256cff01e2
     method: GET
   response:
-    body: '{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "574"
@@ -1929,9 +2039,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:45 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1939,7 +2049,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 94612d32-c526-4507-8e42-038d5bc6bb28
+      - 42ffb13e-68e9-41a4-a75d-73b5971a28f9
     status: 200 OK
     code: 200
     duration: ""
@@ -1948,12 +2058,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9f9b12cc-f21c-4706-8465-a3cfdd9de4f3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/19f0c7e9-c3da-435e-9729-c4e1da734bf6
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T09:20:45.373605Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"9f9b12cc-f21c-4706-8465-a3cfdd9de4f3","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-10-27T09:20:45.373605Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:33:07.261806Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"19f0c7e9-c3da-435e-9729-c4e1da734bf6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:33:07.261806Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "287"
@@ -1962,9 +2072,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:45 GMT
+      - Thu, 22 Feb 2024 07:33:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1972,7 +2082,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5c9929a1-7f4d-4289-9720-8eefe0656187
+      - 11aa3ae2-d2e2-4703-9161-3206edcd3c00
     status: 200 OK
     code: 200
     duration: ""
@@ -1981,45 +2091,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/9905b816-982c-4533-95df-9c1fb6652616
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/1c9ba85d-8322-494b-8a83-3580caaa1c38
     method: GET
   response:
-    body: '{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "574"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:20:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 1f0990b6-e88f-4aea-b689-9b0169242a45
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/57d892b9-1f4d-4e63-be19-8f3646cc417b
-    method: GET
-  response:
-    body: '{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"}'
+    body: '{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "403"
@@ -2028,9 +2105,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:46 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2038,7 +2115,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61e9a089-d980-415b-8864-d8c1f249521f
+      - 75922dc8-5cdc-4f1c-b8ba-d0acd56c8e74
     status: 200 OK
     code: 200
     duration: ""
@@ -2047,13 +2124,46 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b8a24e1f-a121-4288-b171-6ba30a5f9ced
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/0d51c640-64c6-4a4a-8323-6f256cff01e2
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T09:19:49.667169Z","dhcp_enabled":true,"id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","name":"My
-      Private Network","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","region":"fr-par","subnets":[{"created_at":"2023-10-27T09:19:49.667169Z","id":"de489d07-0287-4658-860f-6125d7ecb7e0","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:56.143052Z"},{"created_at":"2023-10-27T09:19:49.667169Z","id":"0cb1d3db-cf3e-4571-914e-8d8fdd6951bd","subnet":"fd46:78ab:30b8:f7b5::/64","updated_at":"2023-10-27T09:19:56.148154Z"}],"tags":[],"updated_at":"2023-10-27T09:20:01.540972Z","vpc_id":"94132e03-8daf-4987-a793-e5382d24aa44"}'
+    body: '{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "574"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 2789dee8-b129-4bd7-80f5-209796bd92e5
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c32d6278-5c7d-4b15-a946-45c8a3487f84
+    method: GET
+  response:
+    body: '{"created_at":"2024-02-22T07:32:06.793480Z","dhcp_enabled":true,"id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","name":"My
+      Private Network","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-02-22T07:32:06.793480Z","id":"cfab4620-880e-43af-b87a-d21bcb08aab9","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:09.219464Z"},{"created_at":"2024-02-22T07:32:06.793480Z","id":"fc7dce1e-4f21-462a-ba78-911b75248f3f","subnet":"fd5f:519c:6d46:e5e0::/64","updated_at":"2024-02-22T07:32:09.222655Z"}],"tags":[],"updated_at":"2024-02-22T07:32:17.744585Z","vpc_id":"7f8ca777-3b28-467d-95c6-e3505bdb07a7"}'
     headers:
       Content-Length:
       - "716"
@@ -2062,9 +2172,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:46 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2072,7 +2182,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 04927c82-fc39-46f9-8b22-66bc909dbf78
+      - 18ca3fb3-be43-42ae-a04f-94b03b183d3f
     status: 200 OK
     code: 200
     duration: ""
@@ -2081,24 +2191,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:20:04.051485Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1966"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:46 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2106,7 +2216,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dbb7f47e-9e56-4020-bff4-dbc1bbd5c416
+      - 9431da3b-26b9-436a-82f0-17c70dedd8bf
     status: 200 OK
     code: 200
     duration: ""
@@ -2115,12 +2225,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/dfbbd5d4-417b-4201-81ac-839de38905cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -2129,9 +2239,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:46 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2139,7 +2249,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6a1fcb9-f7a6-44f0-ae1c-9badec190169
+      - e1f0b871-a80c-495f-b8d1-4851ddb2a6ca
     status: 200 OK
     code: 200
     duration: ""
@@ -2148,24 +2258,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:20:04.051485Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1966"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:46 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2173,7 +2283,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8ad9056-6d4d-477b-a24d-bba0410bb638
+      - bd1e5bf5-4937-435c-ad12-08ed4fe048c9
     status: 200 OK
     code: 200
     duration: ""
@@ -2182,31 +2292,64 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
+    method: GET
+  response:
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "984"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:08 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 64419ecb-97c9-47e0-8eb4-4bd13ed3651e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1701","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:20:04.786446+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.64.224.31","private_nics":[{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:28.133090+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3122"
+      - "3142"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:46 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2214,7 +2357,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 81a029fd-cf1f-4c02-9a1d-172b2eaf572a
+      - bfe096e2-0327-4981-86e1-1f9bf527b436
     status: 200 OK
     code: 200
     duration: ""
@@ -2223,42 +2366,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/dfbbd5d4-417b-4201-81ac-839de38905cb
-    method: GET
-  response:
-    body: '{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "984"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:20:46 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 7eb52930-d368-486e-9baa-ad8c27d3c422
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/user_data
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/user_data
     method: GET
   response:
     body: '{"user_data":[]}'
@@ -2270,9 +2380,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:46 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2280,7 +2390,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e72d364-de1e-4215-bb30-5a8cf892c891
+      - f4301ce2-0979-4cb8-a4e7-c03c42081502
     status: 200 OK
     code: 200
     duration: ""
@@ -2289,12 +2399,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -2303,12 +2413,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:46 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Link:
-      - </servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics?page=1&per_page=50&>;
+      - </servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2316,7 +2426,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c97ea461-098a-4325-88dd-668154e65b7a
+      - 7146ee47-063e-4ce6-82ef-75d4b7d34409
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -2327,12 +2437,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ae9c6642-9b34-4c5f-a978-e1172c114822
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/bc086d9e-55cc-4719-a5eb-cc40d8a98e9f
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T09:20:08.891703Z","gateway_network_id":"dfbbd5d4-417b-4201-81ac-839de38905cb","hostname":"scaleway-instance","id":"ae9c6642-9b34-4c5f-a978-e1172c114822","ip_address":"10.0.0.3","mac_address":"02:00:00:14:74:1b","type":"reservation","updated_at":"2023-10-27T09:20:44.956263Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:32:31.054225Z","gateway_network_id":"7f34391b-600e-4fb2-94b4-436182f0218d","hostname":"scaleway-instance","id":"bc086d9e-55cc-4719-a5eb-cc40d8a98e9f","ip_address":"10.0.0.3","mac_address":"02:00:00:18:8b:b3","type":"reservation","updated_at":"2024-02-22T07:33:07.009439Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "327"
@@ -2341,9 +2451,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:46 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2351,7 +2461,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c6ff371-1aa0-473f-aef5-35b65f733f75
+      - a83bd1c5-d8b3-4ec4-86ba-e1ebd7867c9f
     status: 200 OK
     code: 200
     duration: ""
@@ -2360,12 +2470,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9f9b12cc-f21c-4706-8465-a3cfdd9de4f3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/19f0c7e9-c3da-435e-9729-c4e1da734bf6
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T09:20:45.373605Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"9f9b12cc-f21c-4706-8465-a3cfdd9de4f3","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-10-27T09:20:45.373605Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:33:07.261806Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"19f0c7e9-c3da-435e-9729-c4e1da734bf6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:33:07.261806Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "287"
@@ -2374,9 +2484,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:46 GMT
+      - Thu, 22 Feb 2024 07:33:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2384,7 +2494,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7f0036b4-0ecb-457c-a036-7dcf37206919
+      - 272558c7-0a10-43ca-9521-12c190950fc5
     status: 200 OK
     code: 200
     duration: ""
@@ -2393,12 +2503,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9f9b12cc-f21c-4706-8465-a3cfdd9de4f3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/19f0c7e9-c3da-435e-9729-c4e1da734bf6
     method: GET
   response:
-    body: '{"created_at":"2023-10-27T09:20:45.373605Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"9f9b12cc-f21c-4706-8465-a3cfdd9de4f3","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2023-10-27T09:20:45.373605Z","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-02-22T07:33:07.261806Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"19f0c7e9-c3da-435e-9729-c4e1da734bf6","private_ip":"10.0.0.3","private_port":22,"protocol":"tcp","public_port":2023,"updated_at":"2024-02-22T07:33:07.261806Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "287"
@@ -2407,9 +2517,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:47 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2417,7 +2527,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6babbc0a-1aa1-4c65-9137-2428e873540e
+      - 2313b1f3-f125-4a2b-9268-081eca1e7b11
     status: 200 OK
     code: 200
     duration: ""
@@ -2426,24 +2536,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:20:04.051485Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1966"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:47 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2451,7 +2561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fb821775-f27f-49ba-8cf6-f8d2d7a3b6c4
+      - 99c84039-d3c0-42f0-a050-c55ac50c8f9e
     status: 200 OK
     code: 200
     duration: ""
@@ -2460,9 +2570,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/9f9b12cc-f21c-4706-8465-a3cfdd9de4f3
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/pat-rules/19f0c7e9-c3da-435e-9729-c4e1da734bf6
     method: DELETE
   response:
     body: ""
@@ -2472,9 +2582,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:47 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2482,7 +2592,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aaaee53c-28ec-4cc7-9a40-d9fb41faf55e
+      - 7da100f8-93db-4252-bf10-9faae3db9a22
     status: 204 No Content
     code: 204
     duration: ""
@@ -2491,24 +2601,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:20:04.051485Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1966"
+      - "1995"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:47 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2516,7 +2626,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ca0a576-083f-44fd-8a41-61e680ea2172
+      - d5477e59-4de5-4eb0-aa87-fde1061306d5
     status: 200 OK
     code: 200
     duration: ""
@@ -2525,12 +2635,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/dfbbd5d4-417b-4201-81ac-839de38905cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -2539,9 +2649,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:47 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2549,7 +2659,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49f1cf7f-78ac-4e92-b9cf-abbed0681146
+      - 84515892-5442-443a-8347-aa1bbac4b649
     status: 200 OK
     code: 200
     duration: ""
@@ -2558,9 +2668,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/ae9c6642-9b34-4c5f-a978-e1172c114822
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcp-entries/bc086d9e-55cc-4719-a5eb-cc40d8a98e9f
     method: DELETE
   response:
     body: ""
@@ -2570,9 +2680,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:48 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2580,7 +2690,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43bcb52b-3fe9-4842-b5d9-5708e7d58800
+      - 84ef1db1-d60a-4a30-a800-1ec41d7772ea
     status: 204 No Content
     code: 204
     duration: ""
@@ -2589,12 +2699,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/dfbbd5d4-417b-4201-81ac-839de38905cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -2603,9 +2713,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:48 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2613,7 +2723,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3f278dfe-7f73-42bc-aa52-e591f440743b
+      - 8cc7210a-5727-42f2-baeb-d6b8a8cbf35c
     status: 200 OK
     code: 200
     duration: ""
@@ -2622,12 +2732,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/dfbbd5d4-417b-4201-81ac-839de38905cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"ready","updated_at":"2023-10-27T09:20:03.884564Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"ready","updated_at":"2024-02-22T07:32:23.739704Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "984"
@@ -2636,9 +2746,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:48 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2646,7 +2756,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - df833086-3e03-4b4e-a1ab-b83c7958f59c
+      - fd69e478-fb3f-4968-aea5-dd11df0f2a2f
     status: 200 OK
     code: 200
     duration: ""
@@ -2655,31 +2765,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1701","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:20:04.786446+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.64.224.31","private_nics":[{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:32:28.133090+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"running","state_detail":"booted","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3122"
+      - "3142"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:48 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2687,7 +2797,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d781fec0-71ff-425a-9bf8-67401c4480c7
+      - c12a8a71-aee6-49b6-943f-3b9387e4b1ff
     status: 200 OK
     code: 200
     duration: ""
@@ -2696,9 +2806,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/dfbbd5d4-417b-4201-81ac-839de38905cb?cleanup_dhcp=true
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d?cleanup_dhcp=true
     method: DELETE
   response:
     body: ""
@@ -2708,9 +2818,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:48 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2718,7 +2828,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dc0cd9f2-e482-4b05-bba2-cca18be4faea
+      - bf8b0700-ba34-4a26-af07-3f3a08c74ff7
     status: 204 No Content
     code: 204
     duration: ""
@@ -2727,12 +2837,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/dfbbd5d4-417b-4201-81ac-839de38905cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
     method: GET
   response:
-    body: '{"address":null,"created_at":"2023-10-27T09:19:57.154011Z","dhcp":{"address":"10.0.0.1","created_at":"2023-10-27T09:19:49.662547Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"9905b816-982c-4533-95df-9c1fb6652616","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2023-10-27T09:19:49.662547Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"dfbbd5d4-417b-4201-81ac-839de38905cb","ipam_config":null,"mac_address":"02:00:00:14:74:1A","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","status":"detaching","updated_at":"2023-10-27T09:20:48.777464Z","zone":"fr-par-1"}'
+    body: '{"address":null,"created_at":"2024-02-22T07:32:11.108412Z","dhcp":{"address":"10.0.0.1","created_at":"2024-02-22T07:32:02.407497Z","dns_local_name":"priv","dns_search":[],"dns_servers_override":[],"enable_dynamic":true,"id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","pool_high":"10.0.0.254","pool_low":"10.0.0.2","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","push_default_route":true,"push_dns_server":true,"rebind_timer":"3060s","renew_timer":"3000s","subnet":"10.0.0.0/24","updated_at":"2024-02-22T07:32:02.407497Z","valid_lifetime":"3600s","zone":"fr-par-1"},"enable_dhcp":true,"enable_masquerade":true,"gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"7f34391b-600e-4fb2-94b4-436182f0218d","ipam_config":null,"mac_address":"02:00:00:18:8B:B0","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","status":"detaching","updated_at":"2024-02-22T07:33:09.474960Z","zone":"fr-par-1"}'
     headers:
       Content-Length:
       - "988"
@@ -2741,9 +2851,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:48 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2751,7 +2861,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d1ef9a3c-74df-40c7-a8f5-fe784e58a3c1
+      - 9c0aa93b-55e6-42cb-ba00-3e8a6ab0869b
     status: 200 OK
     code: 200
     duration: ""
@@ -2762,12 +2872,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/action
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/action
     method: POST
   response:
-    body: '{"task":{"description":"server_poweroff","href_from":"/servers/098846b5-7816-4025-9b0d-fed4391018de/action","href_result":"/servers/098846b5-7816-4025-9b0d-fed4391018de","id":"6973802a-7976-40a0-baa4-c91d2019e485","started_at":"2023-10-27T09:20:49.425474+00:00","status":"pending","terminated_at":null}}'
+    body: '{"task":{"description":"server_poweroff","href_from":"/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/action","href_result":"/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8","id":"f9457351-10f6-4b02-833d-2a353e38504e","started_at":"2024-02-22T07:33:09.689033+00:00","status":"pending","terminated_at":null}}'
     headers:
       Content-Length:
       - "317"
@@ -2776,11 +2886,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:49 GMT
+      - Thu, 22 Feb 2024 07:33:09 GMT
       Location:
-      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/6973802a-7976-40a0-baa4-c91d2019e485
+      - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/f9457351-10f6-4b02-833d-2a353e38504e
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2788,7 +2898,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 12491dc7-c7a1-4929-860f-46a6be815951
+      - 726a6af1-7206-471f-a841-fae056a9b22b
     status: 202 Accepted
     code: 202
     duration: ""
@@ -2797,31 +2907,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1701","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:20:48.795381+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.64.224.31","private_nics":[{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:33:09.541927+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3090"
+      - "3110"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:49 GMT
+      - Thu, 22 Feb 2024 07:33:10 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2829,7 +2939,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4b686493-8b57-473e-9987-597cbcbc18ca
+      - 7dfecd14-79e7-4a9d-a125-9b855ef2c8c5
     status: 200 OK
     code: 200
     duration: ""
@@ -2838,12 +2948,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/dfbbd5d4-417b-4201-81ac-839de38905cb
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateway-networks/7f34391b-600e-4fb2-94b4-436182f0218d
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"dfbbd5d4-417b-4201-81ac-839de38905cb","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"gateway_network","resource_id":"7f34391b-600e-4fb2-94b4-436182f0218d","type":"not_found"}'
     headers:
       Content-Length:
       - "136"
@@ -2852,9 +2962,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:53 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2862,7 +2972,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea4a5800-fad2-45df-9c8b-443dfacef843
+      - 3586798e-9ee6-4365-b8a6-5ddc5947bdb7
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2871,24 +2981,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:20:04.051485Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "982"
+      - "1011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:53 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2896,7 +3006,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a5a0f8f8-f52e-4b35-8e08-cd496506a4e9
+      - e09c97c6-4a04-4765-b440-96eec089deb7
     status: 200 OK
     code: 200
     duration: ""
@@ -2905,12 +3015,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/9905b816-982c-4533-95df-9c1fb6652616
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/dhcps/0d51c640-64c6-4a4a-8323-6f256cff01e2
     method: DELETE
   response:
-    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"9905b816-982c-4533-95df-9c1fb6652616","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"dhcp","resource_id":"0d51c640-64c6-4a4a-8323-6f256cff01e2","type":"not_found"}'
     headers:
       Content-Length:
       - "125"
@@ -2919,9 +3029,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:53 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2929,7 +3039,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bf9cdb93-3b57-49d0-b0f5-c1c2ddea5eae
+      - a2a45a23-490a-4ef7-a118-69074b07fdd0
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2938,24 +3048,24 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
     method: GET
   response:
-    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2023-10-27T09:19:50.463377Z","gateway_networks":[],"id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","ip":{"address":"51.158.103.254","created_at":"2023-10-27T09:19:50.275799Z","gateway_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","id":"57d892b9-1f4d-4e63-be19-8f3646cc417b","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","reverse":"254-103-158-51.instances.scw.cloud","tags":[],"updated_at":"2023-10-27T09:19:50.275799Z","zone":"fr-par-1"},"is_legacy":true,"name":"The
-      Public Gateway","organization_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project_id":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2023-10-27T09:20:04.051485Z","upstream_dns_servers":[],"version":"0.6.0","zone":"fr-par-1"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"running","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:32:23.912869Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "982"
+      - "1011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:53 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2963,7 +3073,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0cd15011-38f3-4ef8-9f11-5481b2c5769a
+      - 6c444b2b-4e94-4327-a8e8-97679351bf8d
     status: 200 OK
     code: 200
     duration: ""
@@ -2972,9 +3082,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c?cleanup_dhcp=false
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c?cleanup_dhcp=false
     method: DELETE
   response:
     body: ""
@@ -2984,9 +3094,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:54 GMT
+      - Thu, 22 Feb 2024 07:33:14 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2994,7 +3104,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 71189819-7675-4f26-bbf3-c5cacba83830
+      - 993f8a35-2dfc-4a31-91b2-2a1893e335b9
     status: 204 No Content
     code: 204
     duration: ""
@@ -3003,12 +3113,87 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/3442e2a0-edcd-4bb6-b074-0e7edb22254c
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"gateway","resource_id":"3442e2a0-edcd-4bb6-b074-0e7edb22254c","type":"not_found"}'
+    body: '{"bastion_enabled":false,"bastion_port":61000,"can_upgrade_to":null,"created_at":"2024-02-22T07:32:03.281397Z","gateway_networks":[],"id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","ip":{"address":"163.172.141.22","created_at":"2024-02-22T07:32:03.057130Z","gateway_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","id":"1c9ba85d-8322-494b-8a83-3580caaa1c38","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","reverse":"22-141-172-163.instances.scw.cloud","tags":[],"updated_at":"2024-02-22T07:32:03.057130Z","zone":"fr-par-1"},"ip_mobility_enabled":false,"is_legacy":true,"name":"The
+      Public Gateway","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","smtp_enabled":false,"status":"deleting","tags":[],"type":{"bandwidth":100000000,"name":"VPC-GW-S","zone":"fr-par-1"},"updated_at":"2024-02-22T07:33:14.699842Z","upstream_dns_servers":[],"version":"0.6.1","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "1012"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8046062a-d0fa-4916-82a5-c7f9f0fbc3e8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
+    method: GET
+  response:
+    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
+      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:33:09.541927+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
+      Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+    headers:
+      Content-Length:
+      - "3110"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 22 Feb 2024 07:33:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 08ed79cd-7dba-47df-91e1-a6dbcaa60cf3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/gateways/bbcbe69a-1749-44f8-8667-b2f15690e13c
+    method: GET
+  response:
+    body: '{"message":"resource is not found","resource":"gateway","resource_id":"bbcbe69a-1749-44f8-8667-b2f15690e13c","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -3017,9 +3202,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:54 GMT
+      - Thu, 22 Feb 2024 07:33:19 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3027,7 +3212,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ac57e21-8fe2-4df1-bdc3-31ef71eb9eb7
+      - c45628f9-3d41-45d9-85d7-5e49741dd634
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3036,9 +3221,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/57d892b9-1f4d-4e63-be19-8f3646cc417b
+    url: https://api.scaleway.com/vpc-gw/v1/zones/fr-par-1/ips/1c9ba85d-8322-494b-8a83-3580caaa1c38
     method: DELETE
   response:
     body: ""
@@ -3048,9 +3233,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:54 GMT
+      - Thu, 22 Feb 2024 07:33:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3058,7 +3243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c1051e0b-4803-4cf7-92e7-cc7c23fcfc76
+      - 3930c47e-232e-4110-86d9-9388d8b8f56a
     status: 204 No Content
     code: 204
     duration: ""
@@ -3067,31 +3252,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1701","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:20:48.795381+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.64.224.31","private_nics":[{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:33:09.541927+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3090"
+      - "3110"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:54 GMT
+      - Thu, 22 Feb 2024 07:33:20 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3099,7 +3284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 69f9dca3-4554-4dfc-9e89-3ed95e30cef5
+      - 45c7a775-cb68-4da1-89ac-7b95ff03cefb
     status: 200 OK
     code: 200
     duration: ""
@@ -3108,31 +3293,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1701","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:20:48.795381+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.64.224.31","private_nics":[{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:33:09.541927+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3090"
+      - "3110"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:20:59 GMT
+      - Thu, 22 Feb 2024 07:33:25 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3140,7 +3325,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3789261f-8f5b-4e2f-946c-0c64377570d2
+      - 2b77eb56-3cb1-4f31-9941-a2360a2359cc
     status: 200 OK
     code: 200
     duration: ""
@@ -3149,31 +3334,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
     body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1701","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:20:48.795381+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.64.224.31","private_nics":[{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"31","hypervisor_id":"704","node_id":"24","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:33:09.541927+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":"10.72.54.47","private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "3090"
+      - "3110"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:21:05 GMT
+      - Thu, 22 Feb 2024 07:33:30 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3181,7 +3366,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 61996e63-589a-4a31-91f4-bfc94c11b9c1
+      - 3adabb40-3c4c-4349-a7c7-95c66eec2058
     status: 200 OK
     code: 200
     duration: ""
@@ -3190,72 +3375,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
-    method: GET
-  response:
-    body: '{"server":{"allowed_actions":["stop_in_place","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
-      scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"17","hypervisor_id":"1701","node_id":"16","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:20:48.795381+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":"10.64.224.31","private_nics":[{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
-      Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
-    headers:
-      Content-Length:
-      - "3090"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 27 Oct 2023 09:21:10 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - e5913d7e-5f58-4cca-8d1c-d36787213897
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:21:13.023467+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:33:33.989893+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2967"
+      - "2989"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:21:15 GMT
+      - Thu, 22 Feb 2024 07:33:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3263,7 +3407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3201d3db-df2f-4286-b73b-7321ad3feca9
+      - 1449482a-62b5-48e9-900d-b1de7750209b
     status: 200 OK
     code: 200
     duration: ""
@@ -3272,12 +3416,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics
     method: GET
   response:
-    body: '{"private_nics":[{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}]}'
+    body: '{"private_nics":[{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}]}'
     headers:
       Content-Length:
       - "381"
@@ -3286,12 +3430,12 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:21:15 GMT
+      - Thu, 22 Feb 2024 07:33:35 GMT
       Link:
-      - </servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics?page=1&per_page=50&>;
+      - </servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics?page=1&per_page=50&>;
         rel="last"
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3299,7 +3443,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b6a46b4a-766c-4b61-9fa8-df12e54c5cb5
+      - a16f5434-b575-4f85-b8f9-46adf53e462d
       X-Total-Count:
       - "1"
     status: 200 OK
@@ -3310,12 +3454,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics/671b4e09-8d51-49e9-b29f-97a63b3ab666
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
     method: GET
   response:
-    body: '{"private_nic":{"creation_date":"2023-10-27T09:20:07.872536+00:00","id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","mac_address":"02:00:00:14:74:1b","modification_date":"2023-10-27T09:20:39.805933+00:00","private_network_id":"b8a24e1f-a121-4288-b171-6ba30a5f9ced","server_id":"098846b5-7816-4025-9b0d-fed4391018de","state":"available","tags":[],"zone":"fr-par-1"}}'
+    body: '{"private_nic":{"creation_date":"2024-02-22T07:32:29.962647+00:00","id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","mac_address":"02:00:00:18:8b:b3","modification_date":"2024-02-22T07:33:01.579264+00:00","private_network_id":"c32d6278-5c7d-4b15-a946-45c8a3487f84","server_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","state":"available","tags":[],"zone":"fr-par-1"}}'
     headers:
       Content-Length:
       - "378"
@@ -3324,9 +3468,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:21:15 GMT
+      - Thu, 22 Feb 2024 07:33:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3334,7 +3478,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb7af2c6-cb87-4f42-8ca8-d46eabaf700c
+      - 8d735b40-e850-4ae9-b409-4cf3f4d1759e
     status: 200 OK
     code: 200
     duration: ""
@@ -3343,9 +3487,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics/671b4e09-8d51-49e9-b29f-97a63b3ab666
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
     method: DELETE
   response:
     body: ""
@@ -3353,9 +3497,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 27 Oct 2023 09:21:15 GMT
+      - Thu, 22 Feb 2024 07:33:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3363,7 +3507,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4eeae46e-146e-4bdc-9672-440a2d21a42d
+      - fe50abdf-68e1-4562-a1a3-f5a1d48ed9b5
     status: 204 No Content
     code: 204
     duration: ""
@@ -3372,12 +3516,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de/private_nics/671b4e09-8d51-49e9-b29f-97a63b3ab666
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8/private_nics/830e2954-1f39-402b-a8eb-5390bd8d06b3
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"671b4e09-8d51-49e9-b29f-97a63b3ab666","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"830e2954-1f39-402b-a8eb-5390bd8d06b3","type":"not_found"}'
     headers:
       Content-Length:
       - "148"
@@ -3386,9 +3530,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:21:15 GMT
+      - Thu, 22 Feb 2024 07:33:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3396,7 +3540,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7485c3cf-5a92-40ef-b8b0-9a2fe35a7389
+      - 64dd79cd-dfc5-4dc3-8292-c444d2fe5ca4
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3405,31 +3549,31 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
     body: '{"server":{"allowed_actions":["poweron","backup","enable_routed_ip"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON
       scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64
-      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2023-10-27T09:19:51.076352+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"098846b5-7816-4025-9b0d-fed4391018de","image":{"arch":"x86_64","creation_date":"2023-10-12T11:24:29.302007+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"92e694e8-5f29-420f-b48d-c3cb88de283d","modification_date":"2023-10-12T11:24:29.302007+00:00","name":"Debian
-      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"7d4fc60d-3d56-453e-9749-8704fe502fa3","name":"Debian
-      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:2a:be:51","maintenances":[],"modification_date":"2023-10-27T09:21:13.023467+00:00","name":"Scaleway
-      Instance","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","placement_group":null,"private_ip":null,"private_nics":[],"project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"ac7c7160-8415-425b-8cf0-9976ee15ccd1","name":"Default
-      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2023-10-27T09:19:51.076352+00:00","export_uri":null,"id":"f8850b0a-6bf1-4423-b6b4-dedbcaf24282","modification_date":"2023-10-27T09:19:51.076352+00:00","name":"Debian
-      Bullseye","organization":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","project":"564aa517-68b0-4fd7-8c8c-d21c4bcdcbd5","server":{"id":"098846b5-7816-4025-9b0d-fed4391018de","name":"Scaleway
+      mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"DEV1-S","creation_date":"2024-02-22T07:32:07.702433+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"scaleway-instance","id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","image":{"arch":"x86_64","creation_date":"2024-01-31T16:12:06.845568+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"ea23ab71-0b8c-45a1-bf9a-147c69a76eb5","modification_date":"2024-01-31T16:12:06.845568+00:00","name":"Debian
+      Bullseye","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"5907e6a8-411b-4a22-a71b-242f439bf872","name":"Debian
+      Bullseye","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:40:01:bb","maintenances":[],"modification_date":"2024-02-22T07:33:33.989893+00:00","name":"Scaleway
+      Instance","organization":"105bdce1-64c0-48ab-899d-868455867ecf","os_family":"linux","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":false,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default
+      security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-02-22T07:32:07.702433+00:00","export_uri":null,"id":"0cc59ce5-9da0-4638-96d9-d26bb6d3091e","modification_date":"2024-02-22T07:32:07.702433+00:00","name":"Debian
+      Bullseye","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","name":"Scaleway
       Instance"},"size":20000000000,"state":"available","tags":[],"volume_type":"l_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
     headers:
       Content-Length:
-      - "2606"
+      - "2628"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:21:15 GMT
+      - Thu, 22 Feb 2024 07:33:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3437,7 +3581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6b81587-bc8a-488b-8d8e-cfac57f7aa5b
+      - 9ce58adf-0fd8-45a8-a849-ff9945fd5294
     status: 200 OK
     code: 200
     duration: ""
@@ -3446,9 +3590,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: DELETE
   response:
     body: ""
@@ -3456,9 +3600,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 27 Oct 2023 09:21:16 GMT
+      - Thu, 22 Feb 2024 07:33:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3466,7 +3610,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b9f628ca-31d8-4929-b3f6-80975f88f9ba
+      - d09904ba-ac03-43bb-a865-700b98072eb4
     status: 204 No Content
     code: 204
     duration: ""
@@ -3475,12 +3619,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/098846b5-7816-4025-9b0d-fed4391018de
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/e8032029-3974-4dc1-ba0f-570bf091bcb8
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"098846b5-7816-4025-9b0d-fed4391018de","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance_server","resource_id":"e8032029-3974-4dc1-ba0f-570bf091bcb8","type":"not_found"}'
     headers:
       Content-Length:
       - "143"
@@ -3489,9 +3633,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:21:16 GMT
+      - Thu, 22 Feb 2024 07:33:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3499,7 +3643,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c2c55156-2cdb-4ba5-8595-b2f0943e010c
+      - ce7d3f03-cf34-42db-acbb-d2347784c0bc
     status: 404 Not Found
     code: 404
     duration: ""
@@ -3508,9 +3652,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/f8850b0a-6bf1-4423-b6b4-dedbcaf24282
+    url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/0cc59ce5-9da0-4638-96d9-d26bb6d3091e
     method: DELETE
   response:
     body: ""
@@ -3518,9 +3662,9 @@ interactions:
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Date:
-      - Fri, 27 Oct 2023 09:21:16 GMT
+      - Thu, 22 Feb 2024 07:33:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3528,7 +3672,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9ca79d2a-66d9-477a-bdc0-824189845f41
+      - 57a10a4a-8ab7-4a2b-91f9-736b3a08ab99
     status: 204 No Content
     code: 204
     duration: ""
@@ -3537,9 +3681,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.3; darwin; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.1; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/b8a24e1f-a121-4288-b171-6ba30a5f9ced
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/c32d6278-5c7d-4b15-a946-45c8a3487f84
     method: DELETE
   response:
     body: ""
@@ -3549,9 +3693,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Oct 2023 09:21:16 GMT
+      - Thu, 22 Feb 2024 07:33:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3559,7 +3703,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0afe6460-ab89-4e42-a390-cc4b719bb875
+      - 4d40e5b6-f1d3-4474-8e95-c7b4728cc734
     status: 204 No Content
     code: 204
     duration: ""

--- a/scaleway/validate_cassettes_test.go
+++ b/scaleway/validate_cassettes_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/dnaeon/go-vcr/cassette"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,7 +39,7 @@ func TestAccScalewayCassettes_Validator(t *testing.T) {
 	for name := range files {
 		c, err := cassette.Load(fmt.Sprintf("%s%s", testDirectory, name))
 		require.NoError(t, err)
-		require.NoError(t, checkErrorCode(c))
+		assert.NoError(t, checkErrorCode(c))
 	}
 }
 


### PR DESCRIPTION
This allow the terraform provider to rely on API's default for this field.
Resource `scaleway_instance_ip` already used API's default for its type.