### PR TITLE
test(redis): remove subnet from vpc to avoid `subnet overlap in vpc`

### DIFF
--- a/scaleway/resource_redis_cluster_test.go
+++ b/scaleway/resource_redis_cluster_test.go
@@ -293,11 +293,7 @@ func TestAccScalewayRedisCluster_MigrateClusterSizeWithStaticEndpoint(t *testing
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-				resource scaleway_vpc_private_network private_network {
-					ipv4_subnet {
-						subnet = "192.168.99.0/24"
-					}
-				}
+				resource scaleway_vpc_private_network private_network {}
 			
 				resource "scaleway_redis_cluster" "main" {
 				  name         = "test_redis_migrate_cluster_size_static"
@@ -331,11 +327,7 @@ func TestAccScalewayRedisCluster_MigrateClusterSizeWithStaticEndpoint(t *testing
 			},
 			{
 				Config: fmt.Sprintf(`
-				resource scaleway_vpc_private_network private_network {
-					ipv4_subnet {
-						subnet = "192.168.99.0/24"
-					}
-				}
+				resource scaleway_vpc_private_network private_network {}
 
 				resource "scaleway_redis_cluster" "main" {
 				  name         = "test_redis_migrate_cluster_size_static"
@@ -377,11 +369,7 @@ func TestAccScalewayRedisCluster_MigrateClusterSizeWithStaticEndpoint(t *testing
 			},
 			{
 				Config: fmt.Sprintf(`
-				resource scaleway_vpc_private_network private_network {
-					ipv4_subnet {
-						subnet = "192.168.99.0/24"
-					}
-				}
+				resource scaleway_vpc_private_network private_network {}
 
 				resource "scaleway_redis_cluster" "main" {
 				  name         = "test_redis_migrate_cluster_size_static"

--- a/scaleway/testdata/redis-cluster-migrate-cluster-size-with-static-endpoint.cassette.yaml
+++ b/scaleway/testdata/redis-cluster-migrate-cluster-size-with-static-endpoint.cassette.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/redis/v1/zones/fr-par-1/cluster-versions?include_beta=false&include_deprecated=false&include_disabled=false
     method: GET
@@ -24,15 +24,15 @@ interactions:
       the keyspace event notification feature","max_value":null,"min_value":null,"name":"notify-keyspace-events","regex":"^(?:([KEg$lshzxetdm])(?!.*\\1))+$","type":"STRING"}],"end_of_life_at":"2023-02-28T00:00:00Z","logo_url":"https://s3.fr-par.scw.cloud/scw-rkv-logos/logo.svg","version":"6.2.7","zone":"fr-par-1"}]}'
     headers:
       Content-Length:
-      - "2775"
+      - "2687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:18:36 GMT
+      - Mon, 04 Mar 2024 17:06:00 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -40,34 +40,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c80d21ee-ed3a-44d5-af3c-d109ea32c36d
+      - 8cd2ca10-70a0-4f48-a205-62ce78fc0166
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"name":"tf-pn-determined-williamson","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","tags":[],"subnets":["192.168.99.0/24"]}'
+    body: '{"name":"tf-pn-magical-mirzakhani","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
     method: POST
   response:
-    body: '{"created_at":"2024-02-22T18:18:37.481183Z","dhcp_enabled":true,"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","name":"tf-pn-determined-williamson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-22T18:18:37.481183Z","id":"4c052d2b-b5ae-4e1f-96ec-b61d2fd35b5a","subnet":"192.168.99.0/24","updated_at":"2024-02-22T18:18:37.481183Z"},{"created_at":"2024-02-22T18:18:37.481183Z","id":"abcdee36-300e-46b2-94a7-978ed5330c6e","subnet":"fd63:256c:45f7:444b::/64","updated_at":"2024-02-22T18:18:37.481183Z"}],"tags":[],"updated_at":"2024-02-22T18:18:37.481183Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2024-03-04T17:06:01.017456Z","dhcp_enabled":true,"id":"627871f8-e5ae-4206-a73c-fee60507c1af","name":"tf-pn-magical-mirzakhani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-03-04T17:06:01.017456Z","id":"cb58c7b5-c3c9-4dd4-a2b6-9a6f77bba55e","subnet":"172.16.28.0/22","updated_at":"2024-03-04T17:06:01.017456Z"},{"created_at":"2024-03-04T17:06:01.017456Z","id":"73935ea7-d676-4ec4-86f7-14d000f580a9","subnet":"fd5f:519c:6d46:2830::/64","updated_at":"2024-03-04T17:06:01.017456Z"}],"tags":[],"updated_at":"2024-03-04T17:06:01.017456Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "729"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:18:37 GMT
+      - Mon, 04 Mar 2024 17:06:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -75,7 +75,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad20c3bf-5459-4eb1-9359-d9fe33db9591
+      - b334fb1d-554b-4981-8a2f-10eb3cd11fa7
     status: 200 OK
     code: 200
     duration: ""
@@ -84,23 +84,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/34761e5b-cf85-4777-aef9-07c8fe068eb9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/627871f8-e5ae-4206-a73c-fee60507c1af
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T18:18:37.481183Z","dhcp_enabled":true,"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","name":"tf-pn-determined-williamson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-22T18:18:37.481183Z","id":"4c052d2b-b5ae-4e1f-96ec-b61d2fd35b5a","subnet":"192.168.99.0/24","updated_at":"2024-02-22T18:18:37.481183Z"},{"created_at":"2024-02-22T18:18:37.481183Z","id":"abcdee36-300e-46b2-94a7-978ed5330c6e","subnet":"fd63:256c:45f7:444b::/64","updated_at":"2024-02-22T18:18:37.481183Z"}],"tags":[],"updated_at":"2024-02-22T18:18:37.481183Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2024-03-04T17:06:01.017456Z","dhcp_enabled":true,"id":"627871f8-e5ae-4206-a73c-fee60507c1af","name":"tf-pn-magical-mirzakhani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-03-04T17:06:01.017456Z","id":"cb58c7b5-c3c9-4dd4-a2b6-9a6f77bba55e","subnet":"172.16.28.0/22","updated_at":"2024-03-04T17:06:01.017456Z"},{"created_at":"2024-03-04T17:06:01.017456Z","id":"73935ea7-d676-4ec4-86f7-14d000f580a9","subnet":"fd5f:519c:6d46:2830::/64","updated_at":"2024-03-04T17:06:01.017456Z"}],"tags":[],"updated_at":"2024-03-04T17:06:01.017456Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "729"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:18:38 GMT
+      - Mon, 04 Mar 2024 17:06:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -108,34 +108,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - deb9cea0-ade0-4666-b76d-fe737b53acd5
+      - f008b8c3-7e25-47f8-b7d8-0473d80b1026
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test_redis_migrate_cluster_size_static","version":"7.0.5","tags":null,"node_type":"RED1-XS","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","cluster_size":1,"acl_rules":null,"endpoints":[{"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","service_ips":["192.168.99.1/24"],"ipam_config":null}}],"tls_enabled":true,"cluster_settings":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test_redis_migrate_cluster_size_static","version":"7.0.5","tags":null,"node_type":"RED1-XS","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","cluster_size":1,"acl_rules":null,"endpoints":[{"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","service_ips":["192.168.99.1/24"],"ipam_config":null}}],"tls_enabled":true,"cluster_settings":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters
     method: POST
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:18:39 GMT
+      - Mon, 04 Mar 2024 17:06:02 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -143,7 +143,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e981e2f3-93b2-44bb-a7ee-4931f5f74140
+      - 328f6c54-9295-43d2-a097-2893484a58f7
     status: 200 OK
     code: 200
     duration: ""
@@ -152,23 +152,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:18:39 GMT
+      - Mon, 04 Mar 2024 17:06:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -176,7 +176,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93a31b3a-9e01-48d8-b1c4-cbd068c46f6f
+      - 17306cd9-5f98-4343-9605-8bf216d71fff
     status: 200 OK
     code: 200
     duration: ""
@@ -185,23 +185,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:18:44 GMT
+      - Mon, 04 Mar 2024 17:06:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -209,7 +209,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1715e34c-463b-487a-b3d3-f7bbc9d7e325
+      - 03040eb8-ca55-4fb5-80cb-1af76b653f23
     status: 200 OK
     code: 200
     duration: ""
@@ -218,23 +218,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:18:49 GMT
+      - Mon, 04 Mar 2024 17:06:13 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -242,7 +242,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6c6ea6b9-3a6c-456d-a2f4-c62c3df21e01
+      - 25b1a769-7985-45cb-81d2-907a74bdc2b1
     status: 200 OK
     code: 200
     duration: ""
@@ -251,23 +251,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:18:54 GMT
+      - Mon, 04 Mar 2024 17:06:18 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -275,7 +275,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5234fe1a-fe20-4327-a88e-1d3c598ea1b5
+      - bbbb4102-4d9a-4663-9cb2-1a0b8b9ef8c0
     status: 200 OK
     code: 200
     duration: ""
@@ -284,23 +284,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:19:00 GMT
+      - Mon, 04 Mar 2024 17:06:24 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -308,7 +308,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f87bf5ef-fb6f-47d8-874d-d76be4ee507c
+      - 70ca2282-7ad4-4d22-b6ec-17f3c884fb1c
     status: 200 OK
     code: 200
     duration: ""
@@ -317,23 +317,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:19:05 GMT
+      - Mon, 04 Mar 2024 17:06:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -341,7 +341,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 79a1fea0-9d09-4754-bbb1-8ed9ff63f854
+      - 7dcd4dcb-9246-410c-890a-34ca06a9feda
     status: 200 OK
     code: 200
     duration: ""
@@ -350,23 +350,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:19:10 GMT
+      - Mon, 04 Mar 2024 17:06:34 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -374,7 +374,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8ac79315-eb5a-4ced-8066-a2a69dae8d48
+      - fe1b69c6-4b5d-4f85-8fd9-c5c0e0572dde
     status: 200 OK
     code: 200
     duration: ""
@@ -383,23 +383,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:19:15 GMT
+      - Mon, 04 Mar 2024 17:06:39 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -407,7 +407,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 745ead1f-ca5a-43d9-a494-876ebf94d693
+      - 64158bd8-d380-4e9f-b7c4-1f6ee2cc7428
     status: 200 OK
     code: 200
     duration: ""
@@ -416,23 +416,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:19:20 GMT
+      - Mon, 04 Mar 2024 17:06:44 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -440,7 +440,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 705297f1-7112-433b-b985-2644e03934a8
+      - 7641a6aa-717d-47ce-a306-ebb4bd9383f3
     status: 200 OK
     code: 200
     duration: ""
@@ -449,23 +449,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:19:25 GMT
+      - Mon, 04 Mar 2024 17:06:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -473,7 +473,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 247612c1-655f-4bf1-bcd1-65243337efab
+      - 161483bf-795c-4a60-85db-5c17a378fe14
     status: 200 OK
     code: 200
     duration: ""
@@ -482,23 +482,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:19:31 GMT
+      - Mon, 04 Mar 2024 17:06:55 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -506,7 +506,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ada822ef-1e86-4f9d-a611-92d93417f831
+      - a7b22122-30fc-44b2-b9e8-9192b2cf68de
     status: 200 OK
     code: 200
     duration: ""
@@ -515,23 +515,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:19:36 GMT
+      - Mon, 04 Mar 2024 17:07:00 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -539,7 +539,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5dd5e9ad-c183-44ac-850a-32bc5d57959b
+      - 9f260bc1-d30f-4835-acc6-a50f964d90ba
     status: 200 OK
     code: 200
     duration: ""
@@ -548,23 +548,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:19:41 GMT
+      - Mon, 04 Mar 2024 17:07:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -572,7 +572,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8bec2308-4126-44fe-93b0-028328253985
+      - e6268494-8275-403f-b4dd-e383bff1cf4d
     status: 200 OK
     code: 200
     duration: ""
@@ -581,23 +581,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "666"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:19:46 GMT
+      - Mon, 04 Mar 2024 17:07:10 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -605,7 +605,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a22fa8d3-ab71-4735-ab63-d0f7bc65c1c7
+      - e56a43ab-f9d8-49fa-b308-c56a313e479f
     status: 200 OK
     code: 200
     duration: ""
@@ -614,23 +614,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:12.823732Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "688"
+      - "691"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:19:51 GMT
+      - Mon, 04 Mar 2024 17:07:15 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -638,7 +638,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc885b7c-af19-4e5c-91a3-2238aa3ad7a7
+      - 35261526-b6ff-4261-864c-cca6318d5cf0
     status: 200 OK
     code: 200
     duration: ""
@@ -647,23 +647,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:19:55.124250Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:12.823732Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "713"
+      - "691"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:19:56 GMT
+      - Mon, 04 Mar 2024 17:07:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -671,7 +671,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2c8da5d6-bc16-4058-b538-2f327091d7c2
+      - 832f1783-c829-40ba-b830-18656957fc0a
     status: 200 OK
     code: 200
     duration: ""
@@ -680,23 +680,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:19:55.124250Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:12.823732Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "713"
+      - "691"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:02 GMT
+      - Mon, 04 Mar 2024 17:07:26 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -704,7 +704,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bb3281de-dbb3-4994-be9c-a80601599d04
+      - e313b8fd-fe75-4298-8641-fe504f20ec40
     status: 200 OK
     code: 200
     duration: ""
@@ -713,23 +713,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:19:55.124250Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:12.823732Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "713"
+      - "691"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:07 GMT
+      - Mon, 04 Mar 2024 17:07:31 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -737,7 +737,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1f287a39-744b-4d53-8c87-69905a3aaaf3
+      - 51236466-917a-4c28-84b5-09a441ae769d
     status: 200 OK
     code: 200
     duration: ""
@@ -746,23 +746,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:19:55.124250Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:12.823732Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "713"
+      - "691"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:12 GMT
+      - Mon, 04 Mar 2024 17:07:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -770,7 +770,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 46401603-4b40-461b-b772-65d1649214a6
+      - a2d2652e-68ad-490a-a8b0-8882aaaa2dc4
     status: 200 OK
     code: 200
     duration: ""
@@ -779,23 +779,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:19:55.124250Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:12.823732Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "713"
+      - "691"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:17 GMT
+      - Mon, 04 Mar 2024 17:07:41 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -803,7 +803,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e07aa06e-0ddd-4d7b-b9c0-09fe4e580bfa
+      - 144ccd88-a9c1-488d-a8fb-df237906650c
     status: 200 OK
     code: 200
     duration: ""
@@ -812,23 +812,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:19:55.124250Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:12.823732Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "713"
+      - "691"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:23 GMT
+      - Mon, 04 Mar 2024 17:07:46 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -836,7 +836,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 527e7b9d-a4bd-43bd-9c8b-4429b0b2135a
+      - 84c7d11d-e753-40bd-933b-da85923f70dd
     status: 200 OK
     code: 200
     duration: ""
@@ -845,23 +845,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:19:55.124250Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:48.083684Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "713"
+      - "684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:28 GMT
+      - Mon, 04 Mar 2024 17:07:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -869,7 +869,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6a847404-9ee2-4759-8ab2-f9101cb39ea3
+      - ce6ee9f7-fd43-4f1c-978a-263c003c19ec
     status: 200 OK
     code: 200
     duration: ""
@@ -878,23 +878,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:19:55.124250Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:48.083684Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "713"
+      - "684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:33 GMT
+      - Mon, 04 Mar 2024 17:07:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -902,7 +902,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 32caf1c8-b391-4463-ae25-cc4b14420b85
+      - 92d3fb5e-fe0c-4ae2-baaa-1a939033e17a
     status: 200 OK
     code: 200
     duration: ""
@@ -911,23 +911,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1/certificate
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:20:38.016418Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3SUJBZ0lRUG9XYnJsaEc2L0FjQnppc25JYmV2ekFOQmdrcWhraUc5dzBCQVFzRkFEQXcKTVJZd0ZBWURWUVFLRXcxVFkyRnNaWGRoZVZKbFpHbHpNUll3RkFZRFZRUURFdzAxTVM0eE5TNHhNekV1TWpRNApNQjRYRFRJME1ETXdOREUzTURZeE5Gb1hEVE0wTURNd01qRTNNRFl4TkZvd01ERVdNQlFHQTFVRUNoTU5VMk5oCmJHVjNZWGxTWldScGN6RVdNQlFHQTFVRUF4TU5OVEV1TVRVdU1UTXhMakkwT0RDQ0FTSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQVBEWHBZUU9CaEtBRWFTWjNYWEhpSFdIeEZrUHNLT3h2ZnhQSUlZcAplQkg0TGQxeE9RRDVrM0tnL04xM2ZBZDNYRmh4Qk1kMkovNzdwYzZkSk5LbUNjRUVQUkFDQmhBTEJKWnBqL0lxClN5YjFTYzJuSHp3cjdlZVp4MkFLbVFEOGNPRmRTTWMva0NJeWQrZW1jK2ZtZ1dFVGw3ZFhTa0lZNFYvWU5KY0gKQU1QUDNmTUpFZ3hMNnNZTUkyQ3phek5Hc2h0YllyZTZ6eE9KSjB2cG41bStlQzFxRlAwa2J0YTZMTG9iYURxaApSNkNqR0RjRVltL3JOVktwVzhaSTBIMTlwOG9KNG0zWVFLZWtsTW5oMVJNVVcrc0QzdTFzTnRuamsvbzkzS0hFCjFGKytPa2RuUjlITFdhUm1vWEl1UG5RdjhoWUQ1bE1zT2FTN1BYRWZ5N0huZytjQ0F3RUFBYU14TUM4d0RnWUQKVlIwUEFRSC9CQVFEQWdXZ01Bd0dBMVVkRXdFQi93UUNNQUF3RHdZRFZSMFJCQWd3Qm9jRXdLaGpBVEFOQmdrcQpoa2lHOXcwQkFRc0ZBQU9DQVFFQVk0WGdZZDM4bkszWWlTUFRibFcrdUhGaE9SZENUczJPU01SbHAwanVSaytkCmNEUDZsTWZydjZWTDBvbWVZMHgyTXhGaEV5YlR5b1hQQ1BUQUl2UUlTdCs3YVJWY3BxWVQ3WitzMEFRa2U3M2IKd3czK09HWWQvcHlvTXNtUUZvZmIwTU9ORStFWnAzVEJucXY0aWVVdWhZOVhicENybVArV0dMeU52WTZORElVUApzL0FWZkQrQkJ0YjNsUFpPK3JEaExyYXdVMG5ZajdOUnRSMCs0MTZ6NjF3REZVWGU4cENZOU1VWCsrc0tJcXF2CjhZcUlicXU2WEZ4TmdsOFpFUTdLWXF4Y1l0MlprR3RwSWh3VWlKVnFxVWM5S2ExRXJVTDVGTy9EZWpkZFdUM2cKT21lS25XaExEOCtwTTRnelNZRFo4OTFPU3NCaFl6MWZtdG1rTlVPU0dnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "706"
+      - "1599"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:38 GMT
+      - Mon, 04 Mar 2024 17:07:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -935,7 +935,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 231eac18-baa0-4a4a-9f94-8e968fd3e4a9
+      - e39cb738-4ba8-4088-b5c5-47264c53717a
     status: 200 OK
     code: 200
     duration: ""
@@ -944,23 +944,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:20:38.016418Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:48.083684Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "706"
+      - "684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:38 GMT
+      - Mon, 04 Mar 2024 17:07:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -968,7 +968,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f260bbcc-48f1-4ac8-b9ed-cfaff5a61bc8
+      - 45237812-f91b-4ef8-9b44-e361a00095b1
     status: 200 OK
     code: 200
     duration: ""
@@ -977,23 +977,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/627871f8-e5ae-4206-a73c-fee60507c1af
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURIRENDQWdTZ0F3SUJBZ0lSQU42YVJ6TE42NzJUeHVYMjZrUzBEM3N3RFFZSktvWklodmNOQVFFTEJRQXcKTURFV01CUUdBMVVFQ2hNTlUyTmhiR1YzWVhsU1pXUnBjekVXTUJRR0ExVUVBeE1OTlRFdU1UVTRMakV3TkM0egpOakFlRncweU5EQXlNakl4T0RFNE5UQmFGdzB6TkRBeU1Ua3hPREU0TlRCYU1EQXhGakFVQmdOVkJBb1REVk5qCllXeGxkMkY1VW1Wa2FYTXhGakFVQmdOVkJBTVREVFV4TGpFMU9DNHhNRFF1TXpZd2dnRWlNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFEaCtJT3JjWGpHaXlVSDR6UVBWSXl3R1RQSVhuSzVUS2NYbWFvNgpRckcxakZaRENKZnBneDJzNUNIdit3TVBwRlptMXZERjVub01aUlNhOCtMVXFUTG84bDFiWjdhd2plWHV3QWJkCktLTWtObWppWmcvNjdWQ1BiWnVtbWhYc1BDNWRwdDFZK1FQQlp3V1d2V0hwdnE4bzRpenpGVHVzdUZ5bDVzUGcKb0taOW9GQWZTbTBBVWNNZENFSTc3bFZPelo5RWREZ1Z5eGM5T055NWhiYWRmRU5ad1dOZEpaQ3podzVycFZwVgpRM05IRGplZkpYVUlYclFobTlKZEtsU3JGRTZLTUx0MFRRS2hiWEFxQ054U05Ud2laQ2t6QXhYc0xSanprRWp4Cm5ESnhjcW01OWZNQ2JpNkdWbi8wMWE4SnI1UlpsUCszL2N0OU96bTV1VFNEMEhpQkFnTUJBQUdqTVRBdk1BNEcKQTFVZER3RUIvd1FFQXdJRm9EQU1CZ05WSFJNQkFmOEVBakFBTUE4R0ExVWRFUVFJTUFhSEJNQ29Zd0V3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFDM1loejNGZTFyYTYvWnFQSUQyczZBcTJTNG9Kd1BHRkE2ZE5YczMrRGNjCkFrQlB3T3VmQ3JJK0JQQVY4eUVoVWliTi92aWZKejBwT0dwbmlxdllvMkppMWZxYjhhMXAvT0U3NU8wT3VpRHUKVU1BM0hVMDJsdFd3KzY4ZjRKS0tVNzhtNnlFSlJDNm13OW1SSEZKeTBxckhkak5yNkxFYVZacXVjV24yeXpBRQpMMlFENW1QOVBsbHZaWUhlb2FPV0N5ajNTZEx0N1lTOXRyakRzK1NFT2lJWEtYTUVOUC9LUDA2Z3I1T1RtU0VIClQrZUxhVHhra2hqdEd0ZFJoOXY4dGJsbGlaYTFNWDU4SktaMW5velY3eWxQUG5VaHBoUFdkZVhGMjZ6S0ZrRXoKQUwycVBEQm82Ti8xVEEvNGRFNGlaUVdBR2NTU2QwN1YxME9UY3RvYmhGUT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"created_at":"2024-03-04T17:06:01.017456Z","dhcp_enabled":true,"id":"627871f8-e5ae-4206-a73c-fee60507c1af","name":"tf-pn-magical-mirzakhani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-03-04T17:06:01.017456Z","id":"cb58c7b5-c3c9-4dd4-a2b6-9a6f77bba55e","subnet":"172.16.28.0/22","updated_at":"2024-03-04T17:06:01.017456Z"},{"created_at":"2024-03-04T17:06:01.017456Z","id":"73935ea7-d676-4ec4-86f7-14d000f580a9","subnet":"fd5f:519c:6d46:2830::/64","updated_at":"2024-03-04T17:06:01.017456Z"}],"tags":[],"updated_at":"2024-03-04T17:06:01.017456Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1601"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:38 GMT
+      - Mon, 04 Mar 2024 17:07:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1001,7 +1001,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6014a254-e0b5-46df-b469-b62dd1f17219
+      - 7b90e570-1d81-4464-b624-e5e2ed25664b
     status: 200 OK
     code: 200
     duration: ""
@@ -1010,23 +1010,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:20:38.016418Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:48.083684Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "706"
+      - "684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:38 GMT
+      - Mon, 04 Mar 2024 17:07:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1034,7 +1034,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9b936797-9eed-41c1-8af2-c72ba9d12595
+      - b2f4d063-3149-43d8-89fd-f502e713809c
     status: 200 OK
     code: 200
     duration: ""
@@ -1043,23 +1043,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/34761e5b-cf85-4777-aef9-07c8fe068eb9
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1/certificate
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T18:18:37.481183Z","dhcp_enabled":true,"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","name":"tf-pn-determined-williamson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-22T18:18:37.481183Z","id":"4c052d2b-b5ae-4e1f-96ec-b61d2fd35b5a","subnet":"192.168.99.0/24","updated_at":"2024-02-22T18:18:37.481183Z"},{"created_at":"2024-02-22T18:18:37.481183Z","id":"abcdee36-300e-46b2-94a7-978ed5330c6e","subnet":"fd63:256c:45f7:444b::/64","updated_at":"2024-02-22T18:18:37.481183Z"}],"tags":[],"updated_at":"2024-02-22T18:18:37.481183Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3SUJBZ0lRUG9XYnJsaEc2L0FjQnppc25JYmV2ekFOQmdrcWhraUc5dzBCQVFzRkFEQXcKTVJZd0ZBWURWUVFLRXcxVFkyRnNaWGRoZVZKbFpHbHpNUll3RkFZRFZRUURFdzAxTVM0eE5TNHhNekV1TWpRNApNQjRYRFRJME1ETXdOREUzTURZeE5Gb1hEVE0wTURNd01qRTNNRFl4TkZvd01ERVdNQlFHQTFVRUNoTU5VMk5oCmJHVjNZWGxTWldScGN6RVdNQlFHQTFVRUF4TU5OVEV1TVRVdU1UTXhMakkwT0RDQ0FTSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQVBEWHBZUU9CaEtBRWFTWjNYWEhpSFdIeEZrUHNLT3h2ZnhQSUlZcAplQkg0TGQxeE9RRDVrM0tnL04xM2ZBZDNYRmh4Qk1kMkovNzdwYzZkSk5LbUNjRUVQUkFDQmhBTEJKWnBqL0lxClN5YjFTYzJuSHp3cjdlZVp4MkFLbVFEOGNPRmRTTWMva0NJeWQrZW1jK2ZtZ1dFVGw3ZFhTa0lZNFYvWU5KY0gKQU1QUDNmTUpFZ3hMNnNZTUkyQ3phek5Hc2h0YllyZTZ6eE9KSjB2cG41bStlQzFxRlAwa2J0YTZMTG9iYURxaApSNkNqR0RjRVltL3JOVktwVzhaSTBIMTlwOG9KNG0zWVFLZWtsTW5oMVJNVVcrc0QzdTFzTnRuamsvbzkzS0hFCjFGKytPa2RuUjlITFdhUm1vWEl1UG5RdjhoWUQ1bE1zT2FTN1BYRWZ5N0huZytjQ0F3RUFBYU14TUM4d0RnWUQKVlIwUEFRSC9CQVFEQWdXZ01Bd0dBMVVkRXdFQi93UUNNQUF3RHdZRFZSMFJCQWd3Qm9jRXdLaGpBVEFOQmdrcQpoa2lHOXcwQkFRc0ZBQU9DQVFFQVk0WGdZZDM4bkszWWlTUFRibFcrdUhGaE9SZENUczJPU01SbHAwanVSaytkCmNEUDZsTWZydjZWTDBvbWVZMHgyTXhGaEV5YlR5b1hQQ1BUQUl2UUlTdCs3YVJWY3BxWVQ3WitzMEFRa2U3M2IKd3czK09HWWQvcHlvTXNtUUZvZmIwTU9ORStFWnAzVEJucXY0aWVVdWhZOVhicENybVArV0dMeU52WTZORElVUApzL0FWZkQrQkJ0YjNsUFpPK3JEaExyYXdVMG5ZajdOUnRSMCs0MTZ6NjF3REZVWGU4cENZOU1VWCsrc0tJcXF2CjhZcUlicXU2WEZ4TmdsOFpFUTdLWXF4Y1l0MlprR3RwSWh3VWlKVnFxVWM5S2ExRXJVTDVGTy9EZWpkZFdUM2cKT21lS25XaExEOCtwTTRnelNZRFo4OTFPU3NCaFl6MWZtdG1rTlVPU0dnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "729"
+      - "1599"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:39 GMT
+      - Mon, 04 Mar 2024 17:07:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1067,7 +1067,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53a47d07-4eec-4d05-8d01-cdb260a3d842
+      - 5083ed2e-d534-4102-a5da-3bbc00fbda2f
     status: 200 OK
     code: 200
     duration: ""
@@ -1076,23 +1076,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/627871f8-e5ae-4206-a73c-fee60507c1af
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:20:38.016418Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"created_at":"2024-03-04T17:06:01.017456Z","dhcp_enabled":true,"id":"627871f8-e5ae-4206-a73c-fee60507c1af","name":"tf-pn-magical-mirzakhani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-03-04T17:06:01.017456Z","id":"cb58c7b5-c3c9-4dd4-a2b6-9a6f77bba55e","subnet":"172.16.28.0/22","updated_at":"2024-03-04T17:06:01.017456Z"},{"created_at":"2024-03-04T17:06:01.017456Z","id":"73935ea7-d676-4ec4-86f7-14d000f580a9","subnet":"fd5f:519c:6d46:2830::/64","updated_at":"2024-03-04T17:06:01.017456Z"}],"tags":[],"updated_at":"2024-03-04T17:06:01.017456Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "706"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:39 GMT
+      - Mon, 04 Mar 2024 17:07:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1100,7 +1100,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c0e3aec1-6f88-4873-ad3f-9180ef724ed7
+      - 888e4f27-c7a4-4842-9204-08ecde9f2284
     status: 200 OK
     code: 200
     duration: ""
@@ -1109,23 +1109,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1/certificate
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURIRENDQWdTZ0F3SUJBZ0lSQU42YVJ6TE42NzJUeHVYMjZrUzBEM3N3RFFZSktvWklodmNOQVFFTEJRQXcKTURFV01CUUdBMVVFQ2hNTlUyTmhiR1YzWVhsU1pXUnBjekVXTUJRR0ExVUVBeE1OTlRFdU1UVTRMakV3TkM0egpOakFlRncweU5EQXlNakl4T0RFNE5UQmFGdzB6TkRBeU1Ua3hPREU0TlRCYU1EQXhGakFVQmdOVkJBb1REVk5qCllXeGxkMkY1VW1Wa2FYTXhGakFVQmdOVkJBTVREVFV4TGpFMU9DNHhNRFF1TXpZd2dnRWlNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFEaCtJT3JjWGpHaXlVSDR6UVBWSXl3R1RQSVhuSzVUS2NYbWFvNgpRckcxakZaRENKZnBneDJzNUNIdit3TVBwRlptMXZERjVub01aUlNhOCtMVXFUTG84bDFiWjdhd2plWHV3QWJkCktLTWtObWppWmcvNjdWQ1BiWnVtbWhYc1BDNWRwdDFZK1FQQlp3V1d2V0hwdnE4bzRpenpGVHVzdUZ5bDVzUGcKb0taOW9GQWZTbTBBVWNNZENFSTc3bFZPelo5RWREZ1Z5eGM5T055NWhiYWRmRU5ad1dOZEpaQ3podzVycFZwVgpRM05IRGplZkpYVUlYclFobTlKZEtsU3JGRTZLTUx0MFRRS2hiWEFxQ054U05Ud2laQ2t6QXhYc0xSanprRWp4Cm5ESnhjcW01OWZNQ2JpNkdWbi8wMWE4SnI1UlpsUCszL2N0OU96bTV1VFNEMEhpQkFnTUJBQUdqTVRBdk1BNEcKQTFVZER3RUIvd1FFQXdJRm9EQU1CZ05WSFJNQkFmOEVBakFBTUE4R0ExVWRFUVFJTUFhSEJNQ29Zd0V3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFDM1loejNGZTFyYTYvWnFQSUQyczZBcTJTNG9Kd1BHRkE2ZE5YczMrRGNjCkFrQlB3T3VmQ3JJK0JQQVY4eUVoVWliTi92aWZKejBwT0dwbmlxdllvMkppMWZxYjhhMXAvT0U3NU8wT3VpRHUKVU1BM0hVMDJsdFd3KzY4ZjRKS0tVNzhtNnlFSlJDNm13OW1SSEZKeTBxckhkak5yNkxFYVZacXVjV24yeXpBRQpMMlFENW1QOVBsbHZaWUhlb2FPV0N5ajNTZEx0N1lTOXRyakRzK1NFT2lJWEtYTUVOUC9LUDA2Z3I1T1RtU0VIClQrZUxhVHhra2hqdEd0ZFJoOXY4dGJsbGlaYTFNWDU4SktaMW5velY3eWxQUG5VaHBoUFdkZVhGMjZ6S0ZrRXoKQUwycVBEQm82Ti8xVEEvNGRFNGlaUVdBR2NTU2QwN1YxME9UY3RvYmhGUT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:48.083684Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1601"
+      - "684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:39 GMT
+      - Mon, 04 Mar 2024 17:07:53 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1133,7 +1133,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - db606a74-6bb9-4149-b5f1-cadddb1a7143
+      - ee709d6f-83bf-4760-b81a-b5d459e7b04b
     status: 200 OK
     code: 200
     duration: ""
@@ -1142,23 +1142,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/34761e5b-cf85-4777-aef9-07c8fe068eb9
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1/certificate
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T18:18:37.481183Z","dhcp_enabled":true,"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","name":"tf-pn-determined-williamson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-22T18:18:37.481183Z","id":"4c052d2b-b5ae-4e1f-96ec-b61d2fd35b5a","subnet":"192.168.99.0/24","updated_at":"2024-02-22T18:18:37.481183Z"},{"created_at":"2024-02-22T18:18:37.481183Z","id":"abcdee36-300e-46b2-94a7-978ed5330c6e","subnet":"fd63:256c:45f7:444b::/64","updated_at":"2024-02-22T18:18:37.481183Z"}],"tags":[],"updated_at":"2024-02-22T18:18:37.481183Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURHekNDQWdPZ0F3SUJBZ0lRUG9XYnJsaEc2L0FjQnppc25JYmV2ekFOQmdrcWhraUc5dzBCQVFzRkFEQXcKTVJZd0ZBWURWUVFLRXcxVFkyRnNaWGRoZVZKbFpHbHpNUll3RkFZRFZRUURFdzAxTVM0eE5TNHhNekV1TWpRNApNQjRYRFRJME1ETXdOREUzTURZeE5Gb1hEVE0wTURNd01qRTNNRFl4TkZvd01ERVdNQlFHQTFVRUNoTU5VMk5oCmJHVjNZWGxTWldScGN6RVdNQlFHQTFVRUF4TU5OVEV1TVRVdU1UTXhMakkwT0RDQ0FTSXdEUVlKS29aSWh2Y04KQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQVBEWHBZUU9CaEtBRWFTWjNYWEhpSFdIeEZrUHNLT3h2ZnhQSUlZcAplQkg0TGQxeE9RRDVrM0tnL04xM2ZBZDNYRmh4Qk1kMkovNzdwYzZkSk5LbUNjRUVQUkFDQmhBTEJKWnBqL0lxClN5YjFTYzJuSHp3cjdlZVp4MkFLbVFEOGNPRmRTTWMva0NJeWQrZW1jK2ZtZ1dFVGw3ZFhTa0lZNFYvWU5KY0gKQU1QUDNmTUpFZ3hMNnNZTUkyQ3phek5Hc2h0YllyZTZ6eE9KSjB2cG41bStlQzFxRlAwa2J0YTZMTG9iYURxaApSNkNqR0RjRVltL3JOVktwVzhaSTBIMTlwOG9KNG0zWVFLZWtsTW5oMVJNVVcrc0QzdTFzTnRuamsvbzkzS0hFCjFGKytPa2RuUjlITFdhUm1vWEl1UG5RdjhoWUQ1bE1zT2FTN1BYRWZ5N0huZytjQ0F3RUFBYU14TUM4d0RnWUQKVlIwUEFRSC9CQVFEQWdXZ01Bd0dBMVVkRXdFQi93UUNNQUF3RHdZRFZSMFJCQWd3Qm9jRXdLaGpBVEFOQmdrcQpoa2lHOXcwQkFRc0ZBQU9DQVFFQVk0WGdZZDM4bkszWWlTUFRibFcrdUhGaE9SZENUczJPU01SbHAwanVSaytkCmNEUDZsTWZydjZWTDBvbWVZMHgyTXhGaEV5YlR5b1hQQ1BUQUl2UUlTdCs3YVJWY3BxWVQ3WitzMEFRa2U3M2IKd3czK09HWWQvcHlvTXNtUUZvZmIwTU9ORStFWnAzVEJucXY0aWVVdWhZOVhicENybVArV0dMeU52WTZORElVUApzL0FWZkQrQkJ0YjNsUFpPK3JEaExyYXdVMG5ZajdOUnRSMCs0MTZ6NjF3REZVWGU4cENZOU1VWCsrc0tJcXF2CjhZcUlicXU2WEZ4TmdsOFpFUTdLWXF4Y1l0MlprR3RwSWh3VWlKVnFxVWM5S2ExRXJVTDVGTy9EZWpkZFdUM2cKT21lS25XaExEOCtwTTRnelNZRFo4OTFPU3NCaFl6MWZtdG1rTlVPU0dnPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "729"
+      - "1599"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:39 GMT
+      - Mon, 04 Mar 2024 17:07:53 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1166,7 +1166,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f4eba9f4-3c06-46d1-9eea-138249edb71f
+      - 63bb0784-be3f-45dd-b41d-70f5d06ccb13
     status: 200 OK
     code: 200
     duration: ""
@@ -1175,23 +1175,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:20:38.016418Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:48.083684Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "706"
+      - "684"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:39 GMT
+      - Mon, 04 Mar 2024 17:07:53 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1199,7 +1199,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 20234366-90bb-4e15-a9af-af87c53e5a27
+      - 4be77e8c-6189-4a67-9ff2-d98f73da8fc5
     status: 200 OK
     code: 200
     duration: ""
@@ -1208,89 +1208,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1/certificate
-    method: GET
-  response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURIRENDQWdTZ0F3SUJBZ0lSQU42YVJ6TE42NzJUeHVYMjZrUzBEM3N3RFFZSktvWklodmNOQVFFTEJRQXcKTURFV01CUUdBMVVFQ2hNTlUyTmhiR1YzWVhsU1pXUnBjekVXTUJRR0ExVUVBeE1OTlRFdU1UVTRMakV3TkM0egpOakFlRncweU5EQXlNakl4T0RFNE5UQmFGdzB6TkRBeU1Ua3hPREU0TlRCYU1EQXhGakFVQmdOVkJBb1REVk5qCllXeGxkMkY1VW1Wa2FYTXhGakFVQmdOVkJBTVREVFV4TGpFMU9DNHhNRFF1TXpZd2dnRWlNQTBHQ1NxR1NJYjMKRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFEaCtJT3JjWGpHaXlVSDR6UVBWSXl3R1RQSVhuSzVUS2NYbWFvNgpRckcxakZaRENKZnBneDJzNUNIdit3TVBwRlptMXZERjVub01aUlNhOCtMVXFUTG84bDFiWjdhd2plWHV3QWJkCktLTWtObWppWmcvNjdWQ1BiWnVtbWhYc1BDNWRwdDFZK1FQQlp3V1d2V0hwdnE4bzRpenpGVHVzdUZ5bDVzUGcKb0taOW9GQWZTbTBBVWNNZENFSTc3bFZPelo5RWREZ1Z5eGM5T055NWhiYWRmRU5ad1dOZEpaQ3podzVycFZwVgpRM05IRGplZkpYVUlYclFobTlKZEtsU3JGRTZLTUx0MFRRS2hiWEFxQ054U05Ud2laQ2t6QXhYc0xSanprRWp4Cm5ESnhjcW01OWZNQ2JpNkdWbi8wMWE4SnI1UlpsUCszL2N0OU96bTV1VFNEMEhpQkFnTUJBQUdqTVRBdk1BNEcKQTFVZER3RUIvd1FFQXdJRm9EQU1CZ05WSFJNQkFmOEVBakFBTUE4R0ExVWRFUVFJTUFhSEJNQ29Zd0V3RFFZSgpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFDM1loejNGZTFyYTYvWnFQSUQyczZBcTJTNG9Kd1BHRkE2ZE5YczMrRGNjCkFrQlB3T3VmQ3JJK0JQQVY4eUVoVWliTi92aWZKejBwT0dwbmlxdllvMkppMWZxYjhhMXAvT0U3NU8wT3VpRHUKVU1BM0hVMDJsdFd3KzY4ZjRKS0tVNzhtNnlFSlJDNm13OW1SSEZKeTBxckhkak5yNkxFYVZacXVjV24yeXpBRQpMMlFENW1QOVBsbHZaWUhlb2FPV0N5ajNTZEx0N1lTOXRyakRzK1NFT2lJWEtYTUVOUC9LUDA2Z3I1T1RtU0VIClQrZUxhVHhra2hqdEd0ZFJoOXY4dGJsbGlaYTFNWDU4SktaMW5velY3eWxQUG5VaHBoUFdkZVhGMjZ6S0ZrRXoKQUwycVBEQm82Ti8xVEEvNGRFNGlaUVdBR2NTU2QwN1YxME9UY3RvYmhGUT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
-    headers:
-      Content-Length:
-      - "1601"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 18:20:39 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 6c8e6092-1b0d-438f-9766-d1434f856138
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
-    method: GET
-  response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:20:38.016418Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "706"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 18:20:40 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - fa0d6547-0a44-4a9d-b8b4-378369e6af25
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: DELETE
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:20:40.234023Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:53.736531Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "709"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:41 GMT
+      - Mon, 04 Mar 2024 17:07:54 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1298,7 +1232,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e616f861-2d34-4818-be45-ff27f2b4d022
+      - 981f5548-ca6b-45bc-81d6-6cbf41fc1992
     status: 200 OK
     code: 200
     duration: ""
@@ -1307,23 +1241,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:20:40.234023Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:53.736531Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "709"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:41 GMT
+      - Mon, 04 Mar 2024 17:07:54 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1331,7 +1265,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dab9f763-1d5c-45a2-b12c-b1a853871c14
+      - 074a5cb7-ec09-4285-92aa-d79c2aed55b7
     status: 200 OK
     code: 200
     duration: ""
@@ -1340,23 +1274,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:20:40.234023Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:53.736531Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "709"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:46 GMT
+      - Mon, 04 Mar 2024 17:07:59 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1364,7 +1298,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3f83e6c-4e35-4785-ba9e-787f74704ca7
+      - 9eaf72b8-d344-4461-b439-85a6f5825e7d
     status: 200 OK
     code: 200
     duration: ""
@@ -1373,23 +1307,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:20:40.234023Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:53.736531Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "709"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:51 GMT
+      - Mon, 04 Mar 2024 17:08:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1397,7 +1331,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a45daecb-fbd5-47f9-8270-a012a2108230
+      - fc802433-ef2f-4d15-986c-9a460fb0771f
     status: 200 OK
     code: 200
     duration: ""
@@ -1406,23 +1340,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:20:40.234023Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-03-04T17:06:02.129481Z","endpoints":[{"id":"6f441abc-44c6-4dd0-b836-0e0726669247","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:07:53.736531Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "709"
+      - "687"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:20:56 GMT
+      - Mon, 04 Mar 2024 17:08:10 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1430,7 +1364,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ef3fae4a-86da-41aa-ad1f-ed4a0aaa2646
+      - 2fdc4833-5694-4127-95c0-d3899c3835b4
     status: 200 OK
     code: 200
     duration: ""
@@ -1439,78 +1373,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/023910a4-df10-43d2-8e73-0b577ad0bbf1
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:20:40.234023Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "709"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 18:21:01 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 652ad47b-74ac-4b60-9e6d-312d26c53068
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
-    method: GET
-  response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":1,"created_at":"2024-02-22T18:18:38.503587Z","endpoints":[{"id":"f7aa8784-0eb9-49b7-b634-1a65081a8108","ips":["192.168.99.1"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24"],"zone":"fr-par-1"}}],"id":"41513ff8-f067-4308-8461-4614403a94e1","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:20:40.234023Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
-    headers:
-      Content-Length:
-      - "709"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Thu, 22 Feb 2024 18:21:07 GMT
-      Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - bbf96839-6858-4531-a4ed-3b1b4f91b19f
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/41513ff8-f067-4308-8461-4614403a94e1
-    method: GET
-  response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"41513ff8-f067-4308-8461-4614403a94e1","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"023910a4-df10-43d2-8e73-0b577ad0bbf1","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -1519,9 +1387,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:21:12 GMT
+      - Mon, 04 Mar 2024 17:08:15 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1529,34 +1397,34 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2e3de178-ade6-4782-b45a-0da49e46a031
+      - 51719af8-3a0a-4591-a6d1-6a3f3c4af298
     status: 404 Not Found
     code: 404
     duration: ""
 - request:
-    body: '{"project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","name":"test_redis_migrate_cluster_size_static","version":"7.0.5","tags":null,"node_type":"RED1-XS","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","cluster_size":3,"acl_rules":null,"endpoints":[{"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"ipam_config":null}}],"tls_enabled":true,"cluster_settings":null}'
+    body: '{"project_id":"105bdce1-64c0-48ab-899d-868455867ecf","name":"test_redis_migrate_cluster_size_static","version":"7.0.5","tags":null,"node_type":"RED1-XS","user_name":"my_initial_user","password":"thiZ_is_v\u0026ry_s3cret","cluster_size":3,"acl_rules":null,"endpoints":[{"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"ipam_config":null}}],"tls_enabled":true,"cluster_settings":null}'
     form: {}
     headers:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters
     method: POST
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:21:13 GMT
+      - Mon, 04 Mar 2024 17:08:16 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1564,7 +1432,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d120990c-b80e-4d74-912c-d8a8cae329f9
+      - bdd08e9c-4bf0-48fb-8104-7f0afb69ccba
     status: 200 OK
     code: 200
     duration: ""
@@ -1573,23 +1441,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:21:13 GMT
+      - Mon, 04 Mar 2024 17:08:17 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1597,7 +1465,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c747bc16-fed2-4319-a352-0cdcf2ae8613
+      - 9278c46b-b401-4c96-ba03-addeda73a88e
     status: 200 OK
     code: 200
     duration: ""
@@ -1606,23 +1474,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:21:18 GMT
+      - Mon, 04 Mar 2024 17:08:22 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1630,7 +1498,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3bb27558-81c0-4008-9b38-a995efab4bcb
+      - f3b52995-ea18-4003-987b-aa7c3392b076
     status: 200 OK
     code: 200
     duration: ""
@@ -1639,23 +1507,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:21:23 GMT
+      - Mon, 04 Mar 2024 17:08:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1663,7 +1531,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6f494896-0cde-489e-aafe-b93b071fd723
+      - 9ea9429a-cc32-424a-9b67-8d161ae25aca
     status: 200 OK
     code: 200
     duration: ""
@@ -1672,23 +1540,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:21:28 GMT
+      - Mon, 04 Mar 2024 17:08:32 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1696,7 +1564,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e9007d05-f0c4-4bff-b7c8-7d652f5e5d85
+      - 419e8968-365a-4c1d-a4b1-24cb732968f7
     status: 200 OK
     code: 200
     duration: ""
@@ -1705,23 +1573,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:21:33 GMT
+      - Mon, 04 Mar 2024 17:08:37 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1729,7 +1597,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f487eb22-a370-466d-97f0-b2f384ca6d9c
+      - 0fe8fa77-63e3-4835-9c2d-1227fd685f5d
     status: 200 OK
     code: 200
     duration: ""
@@ -1738,23 +1606,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:21:38 GMT
+      - Mon, 04 Mar 2024 17:08:42 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1762,7 +1630,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e8801e9a-0639-4651-b9ad-388da17d31ef
+      - e3d2031d-4404-43c3-822e-d25cd1004f17
     status: 200 OK
     code: 200
     duration: ""
@@ -1771,23 +1639,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:21:44 GMT
+      - Mon, 04 Mar 2024 17:08:48 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1795,7 +1663,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7da4a8b3-d846-4e80-a8b0-83eb6022d46a
+      - dcc1e541-67a2-4415-9a1c-7e99f3ab89b4
     status: 200 OK
     code: 200
     duration: ""
@@ -1804,23 +1672,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:21:49 GMT
+      - Mon, 04 Mar 2024 17:08:53 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1828,7 +1696,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bada45d6-23eb-4519-b8cb-1c1759ed9ebf
+      - 3e314cd5-6e49-4a14-8d1e-f8df962de26f
     status: 200 OK
     code: 200
     duration: ""
@@ -1837,23 +1705,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:21:54 GMT
+      - Mon, 04 Mar 2024 17:08:58 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1861,7 +1729,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 693470d1-f1b8-4a15-9e12-4bd3fee73f08
+      - e3a0350c-10d0-474e-a6e2-41b0d2268700
     status: 200 OK
     code: 200
     duration: ""
@@ -1870,23 +1738,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:21:59 GMT
+      - Mon, 04 Mar 2024 17:09:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1894,7 +1762,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8edb695c-d1d4-41a0-9b99-3f00c0f28d97
+      - cf59c0a8-67a4-493c-bc87-7bc8a67ab670
     status: 200 OK
     code: 200
     duration: ""
@@ -1903,23 +1771,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:22:04 GMT
+      - Mon, 04 Mar 2024 17:09:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1927,7 +1795,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da3ecb8f-9b72-4072-9936-f27cb77dd958
+      - b5143d61-2029-48d9-8eb5-dbcadb03b7f4
     status: 200 OK
     code: 200
     duration: ""
@@ -1936,23 +1804,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:22:09 GMT
+      - Mon, 04 Mar 2024 17:09:13 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1960,7 +1828,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5013c0b0-7dcc-4768-b357-e2f3f18d2837
+      - f20afb25-a842-4646-b871-d342b4dc6157
     status: 200 OK
     code: 200
     duration: ""
@@ -1969,23 +1837,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:22:15 GMT
+      - Mon, 04 Mar 2024 17:09:18 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1993,7 +1861,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 231fca29-09c3-4558-bf32-ed3e7d708ace
+      - 52fd0f80-9f63-4044-8fd7-e64afc762383
     status: 200 OK
     code: 200
     duration: ""
@@ -2002,23 +1870,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:22:20 GMT
+      - Mon, 04 Mar 2024 17:09:24 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2026,7 +1894,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14e92d64-1f10-4092-8ac2-8174fc38c52d
+      - 432f0263-ecd9-48c3-a1f2-9115933da019
     status: 200 OK
     code: 200
     duration: ""
@@ -2035,23 +1903,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:22:25 GMT
+      - Mon, 04 Mar 2024 17:09:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2059,7 +1927,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1558e1d1-0097-48fa-83c8-ca59f2901b3f
+      - c7ccf631-bfdb-4664-b40a-11738f8d815e
     status: 200 OK
     code: 200
     duration: ""
@@ -2068,23 +1936,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:22:30 GMT
+      - Mon, 04 Mar 2024 17:09:34 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2092,7 +1960,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 09c968de-d3de-4626-a228-2f94cd6f9a96
+      - 0ea988ad-75ec-4ced-8b33-b33328876ab5
     status: 200 OK
     code: 200
     duration: ""
@@ -2101,23 +1969,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "768"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:22:35 GMT
+      - Mon, 04 Mar 2024 17:09:39 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2125,7 +1993,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7d45b3d8-28c2-407e-9dc4-71eee4260ba8
+      - a48765a1-c9c5-4b83-a0a4-081af2590bb3
     status: 200 OK
     code: 200
     duration: ""
@@ -2134,23 +2002,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:22:41 GMT
+      - Mon, 04 Mar 2024 17:09:44 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2158,7 +2026,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e0771816-b397-48ad-be3c-0e1b53e6727b
+      - ec036136-253e-4a2d-87fc-a4ecd20c30ab
     status: 200 OK
     code: 200
     duration: ""
@@ -2167,23 +2035,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":null,"upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "796"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:22:46 GMT
+      - Mon, 04 Mar 2024 17:09:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2191,7 +2059,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 332cca72-cef6-4929-80b8-092dbabd35e9
+      - 723af25c-18be-4799-b17f-a129558ffbf6
     status: 200 OK
     code: 200
     duration: ""
@@ -2200,23 +2068,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:22:47.515533Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "821"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:22:51 GMT
+      - Mon, 04 Mar 2024 17:09:55 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2224,7 +2092,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e25c452f-ea01-43e4-930b-08018b361fd7
+      - 73fd94b7-6bab-4d54-8d13-297ef6c5fa52
     status: 200 OK
     code: 200
     duration: ""
@@ -2233,23 +2101,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:22:47.515533Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "821"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:22:56 GMT
+      - Mon, 04 Mar 2024 17:10:00 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2257,7 +2125,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b5ef887e-f9d0-430b-9c5c-01580654c964
+      - f0e5c83f-cde1-4184-84d8-13367fd13e44
     status: 200 OK
     code: 200
     duration: ""
@@ -2266,23 +2134,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:22:47.515533Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "821"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:23:01 GMT
+      - Mon, 04 Mar 2024 17:10:05 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2290,7 +2158,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59c2a0e4-d637-41f7-a4ea-d90eda984a16
+      - af44fbeb-a51b-40a5-b770-f9e9cf4cb8b0
     status: 200 OK
     code: 200
     duration: ""
@@ -2299,23 +2167,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:22:47.515533Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "821"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:23:06 GMT
+      - Mon, 04 Mar 2024 17:10:10 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2323,7 +2191,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 346a4c5d-f2ad-4a40-a8da-6fc92ee48bfe
+      - 1318137c-567d-4b53-aa0a-2c92ec696164
     status: 200 OK
     code: 200
     duration: ""
@@ -2332,23 +2200,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:22:47.515533Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "821"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:23:11 GMT
+      - Mon, 04 Mar 2024 17:10:15 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2356,7 +2224,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48ba3be1-eafc-4cce-bcd2-fe598ea7c0a6
+      - a048ab05-b686-41f0-ab44-674d038ba705
     status: 200 OK
     code: 200
     duration: ""
@@ -2365,23 +2233,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:22:47.515533Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "821"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:23:17 GMT
+      - Mon, 04 Mar 2024 17:10:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2389,7 +2257,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7b9fc59d-e7eb-497c-9c29-f74240c95e6d
+      - a17ed5f5-14d4-4864-9fd8-f5fc7e2470cb
     status: 200 OK
     code: 200
     duration: ""
@@ -2398,23 +2266,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:22:47.515533Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "821"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:23:22 GMT
+      - Mon, 04 Mar 2024 17:10:26 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2422,7 +2290,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d6a6d04d-63df-4c7f-a1b3-5fa0021d6ef2
+      - 67fdf8ca-a359-4b53-a30e-02cc98d1127a
     status: 200 OK
     code: 200
     duration: ""
@@ -2431,23 +2299,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:22:47.515533Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "821"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:23:27 GMT
+      - Mon, 04 Mar 2024 17:10:31 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2455,7 +2323,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 86147f5f-b359-4534-9489-06cfdbb7ed0d
+      - 094c562e-edf4-447e-a388-e7185e8949ab
     status: 200 OK
     code: 200
     duration: ""
@@ -2464,23 +2332,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:22:47.515533Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "821"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:23:32 GMT
+      - Mon, 04 Mar 2024 17:10:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2488,7 +2356,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bdd78324-78f4-46ef-8118-eb955127a5dd
+      - 45f6081c-02a1-4c0f-a382-69d7822375df
     status: 200 OK
     code: 200
     duration: ""
@@ -2497,23 +2365,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:22:47.515533Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "821"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:23:37 GMT
+      - Mon, 04 Mar 2024 17:10:41 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2521,7 +2389,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e879b6c6-860a-4452-851a-c0ffc655f98a
+      - 0030f0f1-4c70-4f53-817c-bab91c00fcb8
     status: 200 OK
     code: 200
     duration: ""
@@ -2530,23 +2398,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:22:47.515533Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "821"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:23:42 GMT
+      - Mon, 04 Mar 2024 17:10:46 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2554,7 +2422,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f993616d-526e-4c6f-8ee6-2b37b4763b39
+      - 16dcee37-752b-4ff1-9d86-99e1442aeb8d
     status: 200 OK
     code: 200
     duration: ""
@@ -2563,23 +2431,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:22:47.515533Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "821"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:23:47 GMT
+      - Mon, 04 Mar 2024 17:10:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2587,7 +2455,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 00ab2fdb-61fa-40fd-bd11-9e3d2f683642
+      - a4f91767-65b8-447d-b0e5-78bb93c7b147
     status: 200 OK
     code: 200
     duration: ""
@@ -2596,23 +2464,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:22:47.515533Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "821"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:23:52 GMT
+      - Mon, 04 Mar 2024 17:10:57 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2620,7 +2488,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - aadd9b71-ef0a-4bdf-8fa3-16d875ba4527
+      - a87caa14-99e1-4e96-9e4e-57e4bd28784f
     status: 200 OK
     code: 200
     duration: ""
@@ -2629,23 +2497,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:22:47.515533Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:09:44.473788Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "821"
+      - "793"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:23:58 GMT
+      - Mon, 04 Mar 2024 17:11:02 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2653,7 +2521,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2babb44-accc-43d7-aa02-cdb95fde0715
+      - 0edfe211-329d-4908-8dd8-d2138625d172
     status: 200 OK
     code: 200
     duration: ""
@@ -2662,23 +2530,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:23:59.756517Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:02.766390Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "814"
+      - "786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:03 GMT
+      - Mon, 04 Mar 2024 17:11:07 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2686,7 +2554,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 53797192-0fd5-4769-aed4-63cd7d247941
+      - 32bf71dd-5b66-43b9-9d25-475403b5cd6e
     status: 200 OK
     code: 200
     duration: ""
@@ -2695,23 +2563,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:23:59.756517Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:02.766390Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "814"
+      - "786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:03 GMT
+      - Mon, 04 Mar 2024 17:11:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2719,7 +2587,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39d60edd-56b9-4822-82cf-e113d0147bd8
+      - c2b28f89-e017-46e1-9423-2b9f8f8e04b6
     status: 200 OK
     code: 200
     duration: ""
@@ -2728,23 +2596,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01/certificate
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLakNDQWhLZ0F3SUJBZ0lSQUtyZXYwNDFmNHYzdEVCM2EzU2pKWm93RFFZSktvWklodmNOQVFFTEJRQXcKTVRFV01CUUdBMVVFQ2hNTlUyTmhiR1YzWVhsU1pXUnBjekVYTUJVR0ExVUVBeE1PTVRZekxqRTNNaTR4TkRRdQpOREl3SGhjTk1qUXdNakl5TVRneU1USTBXaGNOTXpRd01qRTVNVGd5TVRJMFdqQXhNUll3RkFZRFZRUUtFdzFUClkyRnNaWGRoZVZKbFpHbHpNUmN3RlFZRFZRUURFdzR4TmpNdU1UY3lMakUwTkM0ME1qQ0NBU0l3RFFZSktvWkkKaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPWGp2cXJsZ05mV3dmVzNqRm9FNGtwSlBmeUllb3gwSVdBWQp2djFKUStBUWoyVHF0a043MW53WXh5c3U0bWNaUXk0dlFYNmNTazNWT0FRN3l4ODlZRUlXS0hqQ3diRFNHcjBDCnhtMGx3WUk3NEx2SmZrQXUrd0RsaHJLc1ZZRnBYVTNYZUV2VTU3YWJBaHV6dUt2TEc1dlJqRnQ4NmUrV2htN2YKL0wyNWQrQXNqS3BVTWxPWVhGU01hSkFZajRJN05UMWV5RGRVdHJoUjd0U1pCYS8xdlBpbWxZTTc1bC9nQnRnegpLUFVNMGN4cCtZQy9vQTdNZG1NUUloL3VoanphNzBBMEpFZ3J4T1d5WDZCcjdYTkZmbGxKNWxKak9xSGpBbHhTClJaTHZGc1pKVGk2QkkzZzFNeUxmRFF6WFNFQ1N3MUhTelRuTThtaGt1SjFURU02ak5EY0NBd0VBQWFNOU1Ec3cKRGdZRFZSMFBBUUgvQkFRREFnV2dNQXdHQTFVZEV3RUIvd1FDTUFBd0d3WURWUjBSQkJRd0VvY0V3S2hqQVljRQp3S2hqQW9jRXdLaGpBekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBY25GOFRqUmlpSWFic0JCYWZCbzQ0TjBiCmJkeVVZYXhSajZrUnAvMVh1UVlNS1JlUEVpazJ0a3JmcElIM25lalZhbGNKN1ZmNUdVVCsyRlJaRVJLQ0MxWDkKbGFIV2phZDdYaGlxMitha21QL2R6Q3JIWlNiVmNlYWJ6U2tSYU1aVHhlMzlWVjgvOFNuRXV1THc4SVZzbVZwQQpiV3JSbi8xZHBKRzlNMmlrOGVLeWtCZnUzV1VZTkNqaExsU3BxbU1EcHhjYk1GM25mRWIvOXVLdE93NWdEV3MvCkpYNEpKT2l0RmFUTENxL250SUhpRFpWYkt6Mk1ydnNQSXErd0k2a3U0MkxSWmVOSjdMRnJhUExhMks4YnZ1eG4KQWxOQmFvaFpzaEliV0MzYnBubzFQY2ZYQVFvMHRhSGRZQmgvOG04cER3Smc4UTNCRk9WNGg0VWNYZUdjNWc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLakNDQWhLZ0F3SUJBZ0lSQUxLekVEcjZaMUZndlpRODhzQW12emt3RFFZSktvWklodmNOQVFFTEJRQXcKTVRFV01CUUdBMVVFQ2hNTlUyTmhiR1YzWVhsU1pXUnBjekVYTUJVR0ExVUVBeE1PTWpFeUxqUTNMakkwT0M0eApNamN3SGhjTk1qUXdNekEwTVRjd09ESTRXaGNOTXpRd016QXlNVGN3T0RJNFdqQXhNUll3RkFZRFZRUUtFdzFUClkyRnNaWGRoZVZKbFpHbHpNUmN3RlFZRFZRUURFdzR5TVRJdU5EY3VNalE0TGpFeU56Q0NBU0l3RFFZSktvWkkKaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPWVVBakl6TlpzVE02MlNYcUdUQURTOUMwMlBHV1RiTDQxSAo2a3RjQmVXb2ZGQ0N1NlFpa3E2OUVaVjViT0VoQXNYM2w0NmpucGNxRGF0SGwrUDZDQUl4L2FWbEw4YXdwY2NjClBXRnNwbFAzM2xoSnRBcDFteHhwbmQ1Z3BkSTIrSUtUanBaTUE5Y2wrSTV4NXlLYVQyS3U4ZGR5T1psNSt1VkQKM0E1NHZ4bkVMZnZkTVNtclVYejVHQVlZR21temVZenovamMxVHk5YXE2cm9FS0JLa2w0dVhtQ1ErY3RiNW8zWAprNVhkUjF4eUkxdDhDQWN3MXpPWlNsMDZpdzdHVUZYMk9CTnBsbXlVRWhLQ2RnZjlzUGNhU2NJVFZka3ZaT01GCjE3TlRGV1k0M2U3dVFKWlhVa2k2aE5ZZU1lWVQvSE1VOW1PMWNKWHpZY2ZWT0t0VGJ3TUNBd0VBQWFNOU1Ec3cKRGdZRFZSMFBBUUgvQkFRREFnV2dNQXdHQTFVZEV3RUIvd1FDTUFBd0d3WURWUjBSQkJRd0VvY0V3S2hqQVljRQp3S2hqQW9jRXdLaGpBekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBM0hxLytrcENJZzM3Y0gwN0VVQzNJdWF3CnlJYlRUUWphNGhmeWhwSzEwamJrNzNSRFNmL3NPWFIvaTk4cFJYNC9Xdmh4Y0QzWHhhcUdRcXFKWE5YNitIYk8Kb1NqR0NhY1I3WS9ud0dWQjlzaDhYeU5FNUFqYThmcjJRaUd5UHNFcEEzUkpyZTRuV3ZXYVNCZEJ5OWVKa3VzdwpXeXpGSkt6cXlwQUQrK1doMEZOOW1nV0hKRU1mN2NyWWNHWnVxV0EzNkZMWEJ1N0J1TUNBZ3hkWFE1YzkwS0IvCmtNdyt3eFNWbFZhOU1ZNjY1V0JheWJJWEoyRWNtMkxjL1lEUWwwZllIT0xSK1F4OG1NOFpnZ1JXWDJaNmNNRDgKMkRDRmFqOTI3WDM4SFAvdEU2YXQvK3ZqTWNYa0Q2SXY5cjlIV215RTJ4NEhlc3FBdUtkYUt5MmI0c2pFTlE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1629"
+      - "1627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:03 GMT
+      - Mon, 04 Mar 2024 17:11:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2752,7 +2620,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3a6bbccb-2593-4a46-84a8-a62ab8c2c635
+      - 40cb4195-c0d0-41d9-9ce4-82fb59cf8776
     status: 200 OK
     code: 200
     duration: ""
@@ -2761,23 +2629,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:23:59.756517Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:02.766390Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "814"
+      - "786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:03 GMT
+      - Mon, 04 Mar 2024 17:11:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2785,7 +2653,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a1dff677-c02e-4b0e-aa1e-4c8d3487d9da
+      - fd06852b-899e-489e-91fd-7f12a0ed36f3
     status: 200 OK
     code: 200
     duration: ""
@@ -2794,23 +2662,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/34761e5b-cf85-4777-aef9-07c8fe068eb9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/627871f8-e5ae-4206-a73c-fee60507c1af
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T18:18:37.481183Z","dhcp_enabled":true,"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","name":"tf-pn-determined-williamson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-22T18:18:37.481183Z","id":"4c052d2b-b5ae-4e1f-96ec-b61d2fd35b5a","subnet":"192.168.99.0/24","updated_at":"2024-02-22T18:18:37.481183Z"},{"created_at":"2024-02-22T18:18:37.481183Z","id":"abcdee36-300e-46b2-94a7-978ed5330c6e","subnet":"fd63:256c:45f7:444b::/64","updated_at":"2024-02-22T18:18:37.481183Z"}],"tags":[],"updated_at":"2024-02-22T18:18:37.481183Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2024-03-04T17:06:01.017456Z","dhcp_enabled":true,"id":"627871f8-e5ae-4206-a73c-fee60507c1af","name":"tf-pn-magical-mirzakhani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-03-04T17:06:01.017456Z","id":"cb58c7b5-c3c9-4dd4-a2b6-9a6f77bba55e","subnet":"172.16.28.0/22","updated_at":"2024-03-04T17:06:01.017456Z"},{"created_at":"2024-03-04T17:06:01.017456Z","id":"73935ea7-d676-4ec4-86f7-14d000f580a9","subnet":"fd5f:519c:6d46:2830::/64","updated_at":"2024-03-04T17:06:01.017456Z"}],"tags":[],"updated_at":"2024-03-04T17:06:01.017456Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "729"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:03 GMT
+      - Mon, 04 Mar 2024 17:11:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2818,7 +2686,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3ed1f9f-d441-489e-991b-3400fa5b47c8
+      - ec24acee-c3c6-4162-ad00-c87e644321f6
     status: 200 OK
     code: 200
     duration: ""
@@ -2827,23 +2695,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:23:59.756517Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:02.766390Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "814"
+      - "786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:03 GMT
+      - Mon, 04 Mar 2024 17:11:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2851,7 +2719,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f96bb605-a5c7-489f-bcb6-633e0f7a608e
+      - a2298dc0-6b4c-4350-830e-0e2cfcecb2bc
     status: 200 OK
     code: 200
     duration: ""
@@ -2860,23 +2728,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01/certificate
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLakNDQWhLZ0F3SUJBZ0lSQUtyZXYwNDFmNHYzdEVCM2EzU2pKWm93RFFZSktvWklodmNOQVFFTEJRQXcKTVRFV01CUUdBMVVFQ2hNTlUyTmhiR1YzWVhsU1pXUnBjekVYTUJVR0ExVUVBeE1PTVRZekxqRTNNaTR4TkRRdQpOREl3SGhjTk1qUXdNakl5TVRneU1USTBXaGNOTXpRd01qRTVNVGd5TVRJMFdqQXhNUll3RkFZRFZRUUtFdzFUClkyRnNaWGRoZVZKbFpHbHpNUmN3RlFZRFZRUURFdzR4TmpNdU1UY3lMakUwTkM0ME1qQ0NBU0l3RFFZSktvWkkKaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPWGp2cXJsZ05mV3dmVzNqRm9FNGtwSlBmeUllb3gwSVdBWQp2djFKUStBUWoyVHF0a043MW53WXh5c3U0bWNaUXk0dlFYNmNTazNWT0FRN3l4ODlZRUlXS0hqQ3diRFNHcjBDCnhtMGx3WUk3NEx2SmZrQXUrd0RsaHJLc1ZZRnBYVTNYZUV2VTU3YWJBaHV6dUt2TEc1dlJqRnQ4NmUrV2htN2YKL0wyNWQrQXNqS3BVTWxPWVhGU01hSkFZajRJN05UMWV5RGRVdHJoUjd0U1pCYS8xdlBpbWxZTTc1bC9nQnRnegpLUFVNMGN4cCtZQy9vQTdNZG1NUUloL3VoanphNzBBMEpFZ3J4T1d5WDZCcjdYTkZmbGxKNWxKak9xSGpBbHhTClJaTHZGc1pKVGk2QkkzZzFNeUxmRFF6WFNFQ1N3MUhTelRuTThtaGt1SjFURU02ak5EY0NBd0VBQWFNOU1Ec3cKRGdZRFZSMFBBUUgvQkFRREFnV2dNQXdHQTFVZEV3RUIvd1FDTUFBd0d3WURWUjBSQkJRd0VvY0V3S2hqQVljRQp3S2hqQW9jRXdLaGpBekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBY25GOFRqUmlpSWFic0JCYWZCbzQ0TjBiCmJkeVVZYXhSajZrUnAvMVh1UVlNS1JlUEVpazJ0a3JmcElIM25lalZhbGNKN1ZmNUdVVCsyRlJaRVJLQ0MxWDkKbGFIV2phZDdYaGlxMitha21QL2R6Q3JIWlNiVmNlYWJ6U2tSYU1aVHhlMzlWVjgvOFNuRXV1THc4SVZzbVZwQQpiV3JSbi8xZHBKRzlNMmlrOGVLeWtCZnUzV1VZTkNqaExsU3BxbU1EcHhjYk1GM25mRWIvOXVLdE93NWdEV3MvCkpYNEpKT2l0RmFUTENxL250SUhpRFpWYkt6Mk1ydnNQSXErd0k2a3U0MkxSWmVOSjdMRnJhUExhMks4YnZ1eG4KQWxOQmFvaFpzaEliV0MzYnBubzFQY2ZYQVFvMHRhSGRZQmgvOG04cER3Smc4UTNCRk9WNGg0VWNYZUdjNWc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLakNDQWhLZ0F3SUJBZ0lSQUxLekVEcjZaMUZndlpRODhzQW12emt3RFFZSktvWklodmNOQVFFTEJRQXcKTVRFV01CUUdBMVVFQ2hNTlUyTmhiR1YzWVhsU1pXUnBjekVYTUJVR0ExVUVBeE1PTWpFeUxqUTNMakkwT0M0eApNamN3SGhjTk1qUXdNekEwTVRjd09ESTRXaGNOTXpRd016QXlNVGN3T0RJNFdqQXhNUll3RkFZRFZRUUtFdzFUClkyRnNaWGRoZVZKbFpHbHpNUmN3RlFZRFZRUURFdzR5TVRJdU5EY3VNalE0TGpFeU56Q0NBU0l3RFFZSktvWkkKaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPWVVBakl6TlpzVE02MlNYcUdUQURTOUMwMlBHV1RiTDQxSAo2a3RjQmVXb2ZGQ0N1NlFpa3E2OUVaVjViT0VoQXNYM2w0NmpucGNxRGF0SGwrUDZDQUl4L2FWbEw4YXdwY2NjClBXRnNwbFAzM2xoSnRBcDFteHhwbmQ1Z3BkSTIrSUtUanBaTUE5Y2wrSTV4NXlLYVQyS3U4ZGR5T1psNSt1VkQKM0E1NHZ4bkVMZnZkTVNtclVYejVHQVlZR21temVZenovamMxVHk5YXE2cm9FS0JLa2w0dVhtQ1ErY3RiNW8zWAprNVhkUjF4eUkxdDhDQWN3MXpPWlNsMDZpdzdHVUZYMk9CTnBsbXlVRWhLQ2RnZjlzUGNhU2NJVFZka3ZaT01GCjE3TlRGV1k0M2U3dVFKWlhVa2k2aE5ZZU1lWVQvSE1VOW1PMWNKWHpZY2ZWT0t0VGJ3TUNBd0VBQWFNOU1Ec3cKRGdZRFZSMFBBUUgvQkFRREFnV2dNQXdHQTFVZEV3RUIvd1FDTUFBd0d3WURWUjBSQkJRd0VvY0V3S2hqQVljRQp3S2hqQW9jRXdLaGpBekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBM0hxLytrcENJZzM3Y0gwN0VVQzNJdWF3CnlJYlRUUWphNGhmeWhwSzEwamJrNzNSRFNmL3NPWFIvaTk4cFJYNC9Xdmh4Y0QzWHhhcUdRcXFKWE5YNitIYk8Kb1NqR0NhY1I3WS9ud0dWQjlzaDhYeU5FNUFqYThmcjJRaUd5UHNFcEEzUkpyZTRuV3ZXYVNCZEJ5OWVKa3VzdwpXeXpGSkt6cXlwQUQrK1doMEZOOW1nV0hKRU1mN2NyWWNHWnVxV0EzNkZMWEJ1N0J1TUNBZ3hkWFE1YzkwS0IvCmtNdyt3eFNWbFZhOU1ZNjY1V0JheWJJWEoyRWNtMkxjL1lEUWwwZllIT0xSK1F4OG1NOFpnZ1JXWDJaNmNNRDgKMkRDRmFqOTI3WDM4SFAvdEU2YXQvK3ZqTWNYa0Q2SXY5cjlIV215RTJ4NEhlc3FBdUtkYUt5MmI0c2pFTlE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1629"
+      - "1627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:04 GMT
+      - Mon, 04 Mar 2024 17:11:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2884,7 +2752,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 429f2bf5-62ba-417c-a450-5725c99693e7
+      - d571794a-922f-4858-bb90-aebdb3a588d7
     status: 200 OK
     code: 200
     duration: ""
@@ -2893,23 +2761,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/34761e5b-cf85-4777-aef9-07c8fe068eb9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/627871f8-e5ae-4206-a73c-fee60507c1af
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T18:18:37.481183Z","dhcp_enabled":true,"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","name":"tf-pn-determined-williamson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-22T18:18:37.481183Z","id":"4c052d2b-b5ae-4e1f-96ec-b61d2fd35b5a","subnet":"192.168.99.0/24","updated_at":"2024-02-22T18:18:37.481183Z"},{"created_at":"2024-02-22T18:18:37.481183Z","id":"abcdee36-300e-46b2-94a7-978ed5330c6e","subnet":"fd63:256c:45f7:444b::/64","updated_at":"2024-02-22T18:18:37.481183Z"}],"tags":[],"updated_at":"2024-02-22T18:18:37.481183Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"created_at":"2024-03-04T17:06:01.017456Z","dhcp_enabled":true,"id":"627871f8-e5ae-4206-a73c-fee60507c1af","name":"tf-pn-magical-mirzakhani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-03-04T17:06:01.017456Z","id":"cb58c7b5-c3c9-4dd4-a2b6-9a6f77bba55e","subnet":"172.16.28.0/22","updated_at":"2024-03-04T17:06:01.017456Z"},{"created_at":"2024-03-04T17:06:01.017456Z","id":"73935ea7-d676-4ec4-86f7-14d000f580a9","subnet":"fd5f:519c:6d46:2830::/64","updated_at":"2024-03-04T17:06:01.017456Z"}],"tags":[],"updated_at":"2024-03-04T17:06:01.017456Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "729"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:04 GMT
+      - Mon, 04 Mar 2024 17:11:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2917,7 +2785,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5a961416-2ad5-407f-b1e5-b8afcf21aaaa
+      - bccbd2df-2f80-4ac4-ac3b-a4789389091a
     status: 200 OK
     code: 200
     duration: ""
@@ -2926,23 +2794,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:23:59.756517Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:02.766390Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "814"
+      - "786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:04 GMT
+      - Mon, 04 Mar 2024 17:11:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2950,7 +2818,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eee354ad-9f4d-43f4-b7aa-33a1e926ca9d
+      - 5b87f8d9-107a-4a1d-894c-4f48683adfe4
     status: 200 OK
     code: 200
     duration: ""
@@ -2959,23 +2827,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01/certificate
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLakNDQWhLZ0F3SUJBZ0lSQUtyZXYwNDFmNHYzdEVCM2EzU2pKWm93RFFZSktvWklodmNOQVFFTEJRQXcKTVRFV01CUUdBMVVFQ2hNTlUyTmhiR1YzWVhsU1pXUnBjekVYTUJVR0ExVUVBeE1PTVRZekxqRTNNaTR4TkRRdQpOREl3SGhjTk1qUXdNakl5TVRneU1USTBXaGNOTXpRd01qRTVNVGd5TVRJMFdqQXhNUll3RkFZRFZRUUtFdzFUClkyRnNaWGRoZVZKbFpHbHpNUmN3RlFZRFZRUURFdzR4TmpNdU1UY3lMakUwTkM0ME1qQ0NBU0l3RFFZSktvWkkKaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPWGp2cXJsZ05mV3dmVzNqRm9FNGtwSlBmeUllb3gwSVdBWQp2djFKUStBUWoyVHF0a043MW53WXh5c3U0bWNaUXk0dlFYNmNTazNWT0FRN3l4ODlZRUlXS0hqQ3diRFNHcjBDCnhtMGx3WUk3NEx2SmZrQXUrd0RsaHJLc1ZZRnBYVTNYZUV2VTU3YWJBaHV6dUt2TEc1dlJqRnQ4NmUrV2htN2YKL0wyNWQrQXNqS3BVTWxPWVhGU01hSkFZajRJN05UMWV5RGRVdHJoUjd0U1pCYS8xdlBpbWxZTTc1bC9nQnRnegpLUFVNMGN4cCtZQy9vQTdNZG1NUUloL3VoanphNzBBMEpFZ3J4T1d5WDZCcjdYTkZmbGxKNWxKak9xSGpBbHhTClJaTHZGc1pKVGk2QkkzZzFNeUxmRFF6WFNFQ1N3MUhTelRuTThtaGt1SjFURU02ak5EY0NBd0VBQWFNOU1Ec3cKRGdZRFZSMFBBUUgvQkFRREFnV2dNQXdHQTFVZEV3RUIvd1FDTUFBd0d3WURWUjBSQkJRd0VvY0V3S2hqQVljRQp3S2hqQW9jRXdLaGpBekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBY25GOFRqUmlpSWFic0JCYWZCbzQ0TjBiCmJkeVVZYXhSajZrUnAvMVh1UVlNS1JlUEVpazJ0a3JmcElIM25lalZhbGNKN1ZmNUdVVCsyRlJaRVJLQ0MxWDkKbGFIV2phZDdYaGlxMitha21QL2R6Q3JIWlNiVmNlYWJ6U2tSYU1aVHhlMzlWVjgvOFNuRXV1THc4SVZzbVZwQQpiV3JSbi8xZHBKRzlNMmlrOGVLeWtCZnUzV1VZTkNqaExsU3BxbU1EcHhjYk1GM25mRWIvOXVLdE93NWdEV3MvCkpYNEpKT2l0RmFUTENxL250SUhpRFpWYkt6Mk1ydnNQSXErd0k2a3U0MkxSWmVOSjdMRnJhUExhMks4YnZ1eG4KQWxOQmFvaFpzaEliV0MzYnBubzFQY2ZYQVFvMHRhSGRZQmgvOG04cER3Smc4UTNCRk9WNGg0VWNYZUdjNWc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLakNDQWhLZ0F3SUJBZ0lSQUxLekVEcjZaMUZndlpRODhzQW12emt3RFFZSktvWklodmNOQVFFTEJRQXcKTVRFV01CUUdBMVVFQ2hNTlUyTmhiR1YzWVhsU1pXUnBjekVYTUJVR0ExVUVBeE1PTWpFeUxqUTNMakkwT0M0eApNamN3SGhjTk1qUXdNekEwTVRjd09ESTRXaGNOTXpRd016QXlNVGN3T0RJNFdqQXhNUll3RkFZRFZRUUtFdzFUClkyRnNaWGRoZVZKbFpHbHpNUmN3RlFZRFZRUURFdzR5TVRJdU5EY3VNalE0TGpFeU56Q0NBU0l3RFFZSktvWkkKaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPWVVBakl6TlpzVE02MlNYcUdUQURTOUMwMlBHV1RiTDQxSAo2a3RjQmVXb2ZGQ0N1NlFpa3E2OUVaVjViT0VoQXNYM2w0NmpucGNxRGF0SGwrUDZDQUl4L2FWbEw4YXdwY2NjClBXRnNwbFAzM2xoSnRBcDFteHhwbmQ1Z3BkSTIrSUtUanBaTUE5Y2wrSTV4NXlLYVQyS3U4ZGR5T1psNSt1VkQKM0E1NHZ4bkVMZnZkTVNtclVYejVHQVlZR21temVZenovamMxVHk5YXE2cm9FS0JLa2w0dVhtQ1ErY3RiNW8zWAprNVhkUjF4eUkxdDhDQWN3MXpPWlNsMDZpdzdHVUZYMk9CTnBsbXlVRWhLQ2RnZjlzUGNhU2NJVFZka3ZaT01GCjE3TlRGV1k0M2U3dVFKWlhVa2k2aE5ZZU1lWVQvSE1VOW1PMWNKWHpZY2ZWT0t0VGJ3TUNBd0VBQWFNOU1Ec3cKRGdZRFZSMFBBUUgvQkFRREFnV2dNQXdHQTFVZEV3RUIvd1FDTUFBd0d3WURWUjBSQkJRd0VvY0V3S2hqQVljRQp3S2hqQW9jRXdLaGpBekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBM0hxLytrcENJZzM3Y0gwN0VVQzNJdWF3CnlJYlRUUWphNGhmeWhwSzEwamJrNzNSRFNmL3NPWFIvaTk4cFJYNC9Xdmh4Y0QzWHhhcUdRcXFKWE5YNitIYk8Kb1NqR0NhY1I3WS9ud0dWQjlzaDhYeU5FNUFqYThmcjJRaUd5UHNFcEEzUkpyZTRuV3ZXYVNCZEJ5OWVKa3VzdwpXeXpGSkt6cXlwQUQrK1doMEZOOW1nV0hKRU1mN2NyWWNHWnVxV0EzNkZMWEJ1N0J1TUNBZ3hkWFE1YzkwS0IvCmtNdyt3eFNWbFZhOU1ZNjY1V0JheWJJWEoyRWNtMkxjL1lEUWwwZllIT0xSK1F4OG1NOFpnZ1JXWDJaNmNNRDgKMkRDRmFqOTI3WDM4SFAvdEU2YXQvK3ZqTWNYa0Q2SXY5cjlIV215RTJ4NEhlc3FBdUtkYUt5MmI0c2pFTlE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1629"
+      - "1627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:04 GMT
+      - Mon, 04 Mar 2024 17:11:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2983,7 +2851,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 49d30a67-490a-4c8a-ac19-ada4bf630dbb
+      - 96dcadca-5054-4175-a52b-644d167ffafe
     status: 200 OK
     code: 200
     duration: ""
@@ -2992,23 +2860,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:23:59.756517Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:02.766390Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "814"
+      - "786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:04 GMT
+      - Mon, 04 Mar 2024 17:11:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3016,7 +2884,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0f4a0f47-3dfb-406c-ace4-6b2da90219ed
+      - 7e823387-df23-4333-80cc-6852a25368c6
     status: 200 OK
     code: 200
     duration: ""
@@ -3027,23 +2895,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: PATCH
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:04.887077Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:09.892589Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "814"
+      - "786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:04 GMT
+      - Mon, 04 Mar 2024 17:11:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3051,7 +2919,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad163a3f-58e4-410c-a2ca-c25d57b4737c
+      - 4ab8de97-eacd-406b-9784-dbb4402dee12
     status: 200 OK
     code: 200
     duration: ""
@@ -3060,23 +2928,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:04.887077Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":3,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:09.892589Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "814"
+      - "786"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:05 GMT
+      - Mon, 04 Mar 2024 17:11:10 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3084,7 +2952,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 731f958e-1f57-4a70-81ce-2e46e8a7ea8a
+      - b4dbe45b-283e-4b59-ab21-7c9e30857994
     status: 200 OK
     code: 200
     duration: ""
@@ -3095,23 +2963,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01/migrate
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b/migrate
     method: POST
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:05 GMT
+      - Mon, 04 Mar 2024 17:11:10 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3119,7 +2987,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41647360-6a12-405e-8a70-b44813767448
+      - 67744139-2380-49e2-a533-270c685a45d9
     status: 200 OK
     code: 200
     duration: ""
@@ -3128,23 +2996,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:05 GMT
+      - Mon, 04 Mar 2024 17:11:11 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3152,7 +3020,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6a96ed6-6a57-44f9-b804-eddaa9ed01e0
+      - 81bad7e5-3a9a-4a83-83f0-44988a02ae25
     status: 200 OK
     code: 200
     duration: ""
@@ -3161,23 +3029,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:11 GMT
+      - Mon, 04 Mar 2024 17:11:16 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3185,7 +3053,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d7c60bde-cccf-40a5-ba53-4b7eb214b699
+      - 63fb594c-4d5e-4e04-b43b-c9d86db04cb7
     status: 200 OK
     code: 200
     duration: ""
@@ -3194,23 +3062,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:16 GMT
+      - Mon, 04 Mar 2024 17:11:21 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3218,7 +3086,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f839b18d-b582-49c1-9591-f80bd756b649
+      - b6cf63da-888f-40d7-9a55-0fcf569d615d
     status: 200 OK
     code: 200
     duration: ""
@@ -3227,23 +3095,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:21 GMT
+      - Mon, 04 Mar 2024 17:11:26 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3251,7 +3119,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3beeaf00-7739-4628-9c52-ef17660eafff
+      - 7cf1c9f2-3400-465c-b179-3b4f28f75622
     status: 200 OK
     code: 200
     duration: ""
@@ -3260,23 +3128,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:26 GMT
+      - Mon, 04 Mar 2024 17:11:31 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3284,7 +3152,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 178be85a-4685-40de-8b7e-837f42f86a37
+      - 28e88755-9cb4-47c8-b27c-dcd1b3a595df
     status: 200 OK
     code: 200
     duration: ""
@@ -3293,23 +3161,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:31 GMT
+      - Mon, 04 Mar 2024 17:11:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3317,7 +3185,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43f15088-14fa-40c4-a577-aeb255b76737
+      - c53334c1-7a73-4a61-9d6a-bfbda9420f03
     status: 200 OK
     code: 200
     duration: ""
@@ -3326,23 +3194,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:36 GMT
+      - Mon, 04 Mar 2024 17:11:42 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3350,7 +3218,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24a94481-b295-40da-ad4f-54be892354fd
+      - d57db619-5cc5-48ad-a419-8f07d3334ac4
     status: 200 OK
     code: 200
     duration: ""
@@ -3359,23 +3227,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:42 GMT
+      - Mon, 04 Mar 2024 17:11:47 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3383,7 +3251,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2956301b-d551-4c30-983a-8737eaa5b339
+      - e4767871-bb8d-4749-b68a-ca74d5b4173d
     status: 200 OK
     code: 200
     duration: ""
@@ -3392,23 +3260,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:47 GMT
+      - Mon, 04 Mar 2024 17:11:52 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3416,7 +3284,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fbdc278d-945c-4123-86fc-048783519e0d
+      - a1df9d00-7698-4bfc-8a70-a8cd46c54172
     status: 200 OK
     code: 200
     duration: ""
@@ -3425,23 +3293,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:52 GMT
+      - Mon, 04 Mar 2024 17:11:57 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3449,7 +3317,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 50dd9c6b-e870-4eef-a236-9f233a5c17f7
+      - b1f677b6-0c6a-4b0b-b1f1-7cc196add8f3
     status: 200 OK
     code: 200
     duration: ""
@@ -3458,23 +3326,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:24:57 GMT
+      - Mon, 04 Mar 2024 17:12:02 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3482,7 +3350,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f458da7-1b8a-4ae9-881b-77d858804501
+      - d40bed6b-2c3e-4308-8d66-6a2874fb00d1
     status: 200 OK
     code: 200
     duration: ""
@@ -3491,23 +3359,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:25:02 GMT
+      - Mon, 04 Mar 2024 17:12:07 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3515,7 +3383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3af4d86-eb0c-4719-84d3-4df252dbf8cc
+      - 568c6444-acf8-4ad2-8d4f-246439fb1894
     status: 200 OK
     code: 200
     duration: ""
@@ -3524,23 +3392,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:25:07 GMT
+      - Mon, 04 Mar 2024 17:12:13 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3548,7 +3416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c95892da-3c9d-4cb7-9212-de00acad56de
+      - 15b977fd-5e44-41e8-9d34-03683ea8d383
     status: 200 OK
     code: 200
     duration: ""
@@ -3557,23 +3425,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:25:12 GMT
+      - Mon, 04 Mar 2024 17:12:18 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3581,7 +3449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 006e9170-8196-4b9c-b254-104a19702763
+      - cb139113-7121-4d70-803c-6393bc7094cb
     status: 200 OK
     code: 200
     duration: ""
@@ -3590,23 +3458,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:25:17 GMT
+      - Mon, 04 Mar 2024 17:12:23 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3614,7 +3482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc2a4b81-3a05-4dfa-be44-c4073d1d3b83
+      - d1d8ec6b-e1d2-4390-a9dc-fbca02e0fc6e
     status: 200 OK
     code: 200
     duration: ""
@@ -3623,23 +3491,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:25:23 GMT
+      - Mon, 04 Mar 2024 17:12:28 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3647,7 +3515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e5fc478a-2448-4dc5-b4a8-3b717afa7fdb
+      - b6aa0033-c92b-4100-b96b-d6281059f682
     status: 200 OK
     code: 200
     duration: ""
@@ -3656,23 +3524,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:11:10.223398Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:25:28 GMT
+      - Mon, 04 Mar 2024 17:12:33 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3680,7 +3548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10f2bd0c-dec8-4755-be9e-37135dd182b9
+      - ce6e1977-341d-4586-a4f4-a3c29272d345
     status: 200 OK
     code: 200
     duration: ""
@@ -3689,23 +3557,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"provisioning","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:24:05.258547Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:25:33 GMT
+      - Mon, 04 Mar 2024 17:12:39 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3713,7 +3581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2d2f378-bc7a-4403-8bd9-ef59c7438866
+      - 6a73ffc2-a55f-4403-b465-e9341925ab00
     status: 200 OK
     code: 200
     duration: ""
@@ -3722,23 +3590,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:25:38 GMT
+      - Mon, 04 Mar 2024 17:12:44 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3746,7 +3614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a2d59837-204c-4af1-a449-8b777ebd27df
+      - a13b90f4-f681-44ee-8fab-e626855bbc7c
     status: 200 OK
     code: 200
     duration: ""
@@ -3755,23 +3623,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:25:43 GMT
+      - Mon, 04 Mar 2024 17:12:49 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3779,7 +3647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 327a0e04-0aa4-4ed0-b12c-49b7d6441799
+      - 8d6afe6c-e42a-4289-b201-8eed16341574
     status: 200 OK
     code: 200
     duration: ""
@@ -3788,23 +3656,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:25:48 GMT
+      - Mon, 04 Mar 2024 17:12:54 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3812,7 +3680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8c9cd848-c7c6-4a2f-a2d5-babaff11dc35
+      - 5100e4a1-c875-40d5-8fc0-5417c522456c
     status: 200 OK
     code: 200
     duration: ""
@@ -3821,23 +3689,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:25:53 GMT
+      - Mon, 04 Mar 2024 17:12:59 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3845,7 +3713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59015f67-75d0-4493-9b8b-8dacf28c7226
+      - 714c754a-8827-48f9-ae1d-341564a405a6
     status: 200 OK
     code: 200
     duration: ""
@@ -3854,23 +3722,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:25:59 GMT
+      - Mon, 04 Mar 2024 17:13:04 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3878,7 +3746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8b56b1a5-50e5-470c-8ae2-30294e0df0bf
+      - 2720a030-a898-40cd-9a5e-795585ca6233
     status: 200 OK
     code: 200
     duration: ""
@@ -3887,23 +3755,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:26:04 GMT
+      - Mon, 04 Mar 2024 17:13:10 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3911,7 +3779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 62f3aa2e-21cd-4dc6-909f-8ad2cdb44933
+      - 2f6c01f7-b564-435e-b399-35cea492058e
     status: 200 OK
     code: 200
     duration: ""
@@ -3920,23 +3788,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:26:09 GMT
+      - Mon, 04 Mar 2024 17:13:15 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3944,7 +3812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7834b23-d21b-4573-9c90-7be907b6a746
+      - 9155192d-37d2-4b5a-bbb7-4ff65f2c3abe
     status: 200 OK
     code: 200
     duration: ""
@@ -3953,23 +3821,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:26:14 GMT
+      - Mon, 04 Mar 2024 17:13:20 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -3977,7 +3845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3e20a780-31a2-485d-8aa6-efe50d49b2b5
+      - 4a3947d2-20eb-45a9-aa99-6e66e24156de
     status: 200 OK
     code: 200
     duration: ""
@@ -3986,23 +3854,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:26:19 GMT
+      - Mon, 04 Mar 2024 17:13:25 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4010,7 +3878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 76618977-7e75-483a-93bc-5b46b6e87d18
+      - d466be5a-f563-4b8b-8093-21b5bb471e7e
     status: 200 OK
     code: 200
     duration: ""
@@ -4019,23 +3887,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:26:24 GMT
+      - Mon, 04 Mar 2024 17:13:30 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4043,7 +3911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 31666fd5-5750-463c-bcfb-01fac7da0e6f
+      - 399e7144-82bb-4495-9014-f3cc99a362a2
     status: 200 OK
     code: 200
     duration: ""
@@ -4052,23 +3920,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:26:30 GMT
+      - Mon, 04 Mar 2024 17:13:36 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4076,7 +3944,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 570ad2f4-f599-4e3a-8359-fa69e2806319
+      - d83ca176-b6bf-4ecd-aca8-e21236b8d1a9
     status: 200 OK
     code: 200
     duration: ""
@@ -4085,23 +3953,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:26:35 GMT
+      - Mon, 04 Mar 2024 17:13:41 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4109,7 +3977,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a52f6e2-07ed-4cbc-a4a1-9753d9f4408f
+      - 574ccd5a-c15b-4179-856e-1f4fc111026f
     status: 200 OK
     code: 200
     duration: ""
@@ -4118,23 +3986,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:26:40 GMT
+      - Mon, 04 Mar 2024 17:13:46 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4142,7 +4010,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f72b552b-2133-438f-ba6b-80a204995163
+      - 0dbd0f5c-f8e2-450e-aa13-ff208558eb56
     status: 200 OK
     code: 200
     duration: ""
@@ -4151,23 +4019,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:26:45 GMT
+      - Mon, 04 Mar 2024 17:13:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4175,7 +4043,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 865f4996-0b49-49c8-ad99-8b15175e1b4e
+      - 06ba8caf-507a-479f-a947-9446cf257d65
     status: 200 OK
     code: 200
     duration: ""
@@ -4184,23 +4052,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:26:50 GMT
+      - Mon, 04 Mar 2024 17:13:56 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4208,7 +4076,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c80d4b0d-10a5-4b91-b78e-030d91041926
+      - c8e90d2d-d503-4124-bf8f-911701bd8619
     status: 200 OK
     code: 200
     duration: ""
@@ -4217,23 +4085,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:26:56 GMT
+      - Mon, 04 Mar 2024 17:14:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4241,7 +4109,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dd075691-0414-413f-8a5e-5b3dbc96a2b5
+      - 77b88c19-4c94-49f9-abdf-90695fa0e074
     status: 200 OK
     code: 200
     duration: ""
@@ -4250,23 +4118,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:27:01 GMT
+      - Mon, 04 Mar 2024 17:14:07 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4274,7 +4142,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 24e5c549-abdf-4ba9-8edb-09a60ba633c2
+      - 4dc37a8f-d35a-4bf0-a704-31eae333df1b
     status: 200 OK
     code: 200
     duration: ""
@@ -4283,23 +4151,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:27:06 GMT
+      - Mon, 04 Mar 2024 17:14:12 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4307,7 +4175,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43ea87e6-2e48-4aba-9114-650f985d00f8
+      - 51a93404-d5ca-4db6-9774-096866ee09d9
     status: 200 OK
     code: 200
     duration: ""
@@ -4316,23 +4184,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:27:11 GMT
+      - Mon, 04 Mar 2024 17:14:17 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4340,7 +4208,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c937faff-ddc6-443d-8d41-bc0d28a33c11
+      - 818c99a5-65e7-4b08-b1ec-63dfb0290f8e
     status: 200 OK
     code: 200
     duration: ""
@@ -4349,23 +4217,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:27:16 GMT
+      - Mon, 04 Mar 2024 17:14:22 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4373,7 +4241,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43afbc5b-3311-4692-a7e3-295423fd855d
+      - c3cfd562-2868-4c15-8bdd-7a20a1b7f76d
     status: 200 OK
     code: 200
     duration: ""
@@ -4382,23 +4250,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:27:21 GMT
+      - Mon, 04 Mar 2024 17:14:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4406,7 +4274,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 080e156d-c460-4c07-b231-acf9625c82d4
+      - 6dabf8c3-4a24-4e46-b55a-c3094f9f8c90
     status: 200 OK
     code: 200
     duration: ""
@@ -4415,23 +4283,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:27:26 GMT
+      - Mon, 04 Mar 2024 17:14:32 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4439,7 +4307,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 41878a30-31e4-4189-a27b-d36f16468bc2
+      - c0681091-b6e1-428e-b805-385bf9df3a99
     status: 200 OK
     code: 200
     duration: ""
@@ -4448,23 +4316,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:27:31 GMT
+      - Mon, 04 Mar 2024 17:14:37 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4472,7 +4340,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 83e89b9c-20d7-4f36-ab4b-8d0fe271ea15
+      - c27508d8-90b8-416f-841b-d86f64f90d5c
     status: 200 OK
     code: 200
     duration: ""
@@ -4481,23 +4349,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:27:37 GMT
+      - Mon, 04 Mar 2024 17:14:43 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4505,7 +4373,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - dfeaaa55-0d62-41b6-8dd8-9147caa7cf14
+      - 8843fb18-728e-4518-aafe-4e0e7b7a220e
     status: 200 OK
     code: 200
     duration: ""
@@ -4514,23 +4382,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:27:42 GMT
+      - Mon, 04 Mar 2024 17:14:48 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4538,7 +4406,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59f35513-4e87-4e95-baa3-301298be408d
+      - 3a5e996b-ca24-4305-9609-c5a4992baac2
     status: 200 OK
     code: 200
     duration: ""
@@ -4547,23 +4415,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:27:47 GMT
+      - Mon, 04 Mar 2024 17:14:53 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4571,7 +4439,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f2468ac-6ac8-463d-8e5b-796b6d02f6e3
+      - 0a227405-e988-478c-b1b1-2e8bfd7578ec
     status: 200 OK
     code: 200
     duration: ""
@@ -4580,23 +4448,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:27:52 GMT
+      - Mon, 04 Mar 2024 17:14:58 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4604,7 +4472,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17f6b105-d3a7-4b52-afe7-325d830cbf09
+      - 12b3bfe1-3103-4951-b48f-f687d1cdb4d7
     status: 200 OK
     code: 200
     duration: ""
@@ -4613,23 +4481,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:27:57 GMT
+      - Mon, 04 Mar 2024 17:15:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4637,7 +4505,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e84455d5-958e-43bd-9470-bf8e9ec88f19
+      - e917617e-8654-4337-b398-a8c1804ff247
     status: 200 OK
     code: 200
     duration: ""
@@ -4646,23 +4514,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:28:03 GMT
+      - Mon, 04 Mar 2024 17:15:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4670,7 +4538,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9fb5714c-9ca3-4826-b46c-bb6b53792007
+      - 9d8facf9-1dac-4e31-a9c4-ee02a03929b4
     status: 200 OK
     code: 200
     duration: ""
@@ -4679,23 +4547,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:28:08 GMT
+      - Mon, 04 Mar 2024 17:15:13 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4703,7 +4571,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0c60b935-fe77-44c4-a758-fb116c40b1d7
+      - e2309656-c122-4d4b-bc5a-6aeec61f482a
     status: 200 OK
     code: 200
     duration: ""
@@ -4712,23 +4580,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:28:13 GMT
+      - Mon, 04 Mar 2024 17:15:19 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4736,7 +4604,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cce64213-0013-4507-b1fd-389b330378da
+      - d42bf67b-330a-4584-8f61-b3f1017112f4
     status: 200 OK
     code: 200
     duration: ""
@@ -4745,23 +4613,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:28:18 GMT
+      - Mon, 04 Mar 2024 17:15:24 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4769,7 +4637,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee5da9b3-0aa5-4aa8-b6aa-29a8e46a9e1c
+      - 59ae20c9-dcf5-418d-8328-e46996b8a75f
     status: 200 OK
     code: 200
     duration: ""
@@ -4778,23 +4646,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:28:23 GMT
+      - Mon, 04 Mar 2024 17:15:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4802,7 +4670,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 36553890-02e9-42aa-85fa-b58e866491e0
+      - 3454e84d-753d-41f7-8270-5a933f0a8296
     status: 200 OK
     code: 200
     duration: ""
@@ -4811,23 +4679,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:28:28 GMT
+      - Mon, 04 Mar 2024 17:15:34 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4835,7 +4703,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 032d54a9-1396-49f3-99b9-11ec2b01b734
+      - 6f894651-9f3a-49be-a25a-51e3e31a76a0
     status: 200 OK
     code: 200
     duration: ""
@@ -4844,23 +4712,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:28:33 GMT
+      - Mon, 04 Mar 2024 17:15:40 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4868,7 +4736,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b597d7cb-630f-47bb-a03f-4d238d11dcb4
+      - 2971dc05-05eb-4b06-bea9-bf8c33bbea70
     status: 200 OK
     code: 200
     duration: ""
@@ -4877,23 +4745,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:28:39 GMT
+      - Mon, 04 Mar 2024 17:15:45 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4901,7 +4769,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 10bd40f1-6df0-4469-9372-ba0115f4b497
+      - 5ffce6af-543d-4d80-b643-8e8e713bcf17
     status: 200 OK
     code: 200
     duration: ""
@@ -4910,23 +4778,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:28:44 GMT
+      - Mon, 04 Mar 2024 17:15:51 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4934,7 +4802,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - cc6fbf82-8d95-4df0-9be9-033c7591f803
+      - ccd11e91-cb82-49f4-a131-efc356d8a4e3
     status: 200 OK
     code: 200
     duration: ""
@@ -4943,23 +4811,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:28:49 GMT
+      - Mon, 04 Mar 2024 17:15:56 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -4967,7 +4835,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 14a8630d-0ad1-4ef4-be12-c5269deebf3b
+      - 866a4237-b13a-4175-bdeb-52369c1d65b7
     status: 200 OK
     code: 200
     duration: ""
@@ -4976,23 +4844,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:28:54 GMT
+      - Mon, 04 Mar 2024 17:16:01 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5000,7 +4868,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fe89ea6d-d529-4d5f-a26d-4b87249c4d90
+      - 15098a3c-3b58-419d-9913-62b94ccd066b
     status: 200 OK
     code: 200
     duration: ""
@@ -5009,23 +4877,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:28:59 GMT
+      - Mon, 04 Mar 2024 17:16:06 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5033,7 +4901,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ab2013fc-8f36-494c-ba04-427c0b4326ad
+      - 709b07d9-712f-4cac-95c2-bee0358d259f
     status: 200 OK
     code: 200
     duration: ""
@@ -5042,23 +4910,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:29:04 GMT
+      - Mon, 04 Mar 2024 17:16:11 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5066,7 +4934,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d537586e-6bbd-4b09-af75-6a9944ccb2fe
+      - c80dd537-65ce-4990-a579-36acd27c8605
     status: 200 OK
     code: 200
     duration: ""
@@ -5075,23 +4943,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:29:10 GMT
+      - Mon, 04 Mar 2024 17:16:16 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5099,7 +4967,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f1cf8f3a-4be7-4ef5-b7ed-867c3b977cef
+      - ca2481e8-aee2-4181-82a8-935e84f618f8
     status: 200 OK
     code: 200
     duration: ""
@@ -5108,23 +4976,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:29:15 GMT
+      - Mon, 04 Mar 2024 17:16:22 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5132,7 +5000,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 70cf4f0a-4b14-459c-9892-085f6c1635a7
+      - 93a0a5b6-64a9-4fcd-a088-c23e52363c38
     status: 200 OK
     code: 200
     duration: ""
@@ -5141,23 +5009,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:29:20 GMT
+      - Mon, 04 Mar 2024 17:16:27 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5165,7 +5033,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4deb702f-d09e-4557-a4f6-8bf9e891d368
+      - 15c05376-e569-40f9-a964-c1d3681117f7
     status: 200 OK
     code: 200
     duration: ""
@@ -5174,23 +5042,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:29:25 GMT
+      - Mon, 04 Mar 2024 17:16:32 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5198,7 +5066,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ad660b1c-6eda-4631-8824-6a0b8df292c0
+      - 861012c5-0506-4ec2-bd85-ca4dd81bbe42
     status: 200 OK
     code: 200
     duration: ""
@@ -5207,23 +5075,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:29:30 GMT
+      - Mon, 04 Mar 2024 17:16:37 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5231,7 +5099,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9318e5d8-4080-4bff-8f9e-824b3b289cb6
+      - 0dbd735d-f241-4768-b2f6-5af6afec1299
     status: 200 OK
     code: 200
     duration: ""
@@ -5240,23 +5108,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:29:35 GMT
+      - Mon, 04 Mar 2024 17:16:42 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5264,7 +5132,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c6fe5e6d-55cb-4acb-b41e-9d5b1333d335
+      - b25357d5-1a9c-4ce3-bb75-ffa6676bfc80
     status: 200 OK
     code: 200
     duration: ""
@@ -5273,23 +5141,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:29:40 GMT
+      - Mon, 04 Mar 2024 17:16:47 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5297,7 +5165,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 18e3b74f-3f8c-4731-99cc-4cf3f6c6a9e6
+      - cc5deced-05d7-4435-87d4-4fb3af6aa860
     status: 200 OK
     code: 200
     duration: ""
@@ -5306,23 +5174,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:29:46 GMT
+      - Mon, 04 Mar 2024 17:16:53 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5330,7 +5198,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4abb6b55-6b14-4e92-9712-8a4f0267d9e6
+      - a7a2970a-3ad3-45be-8902-56b7cf545012
     status: 200 OK
     code: 200
     duration: ""
@@ -5339,23 +5207,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:29:51 GMT
+      - Mon, 04 Mar 2024 17:16:58 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5363,7 +5231,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5ab27097-1ce2-4e72-bd05-f51bc4894a64
+      - 1121b63a-7c06-41e5-8073-2f2a4738c1a7
     status: 200 OK
     code: 200
     duration: ""
@@ -5372,23 +5240,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:29:56 GMT
+      - Mon, 04 Mar 2024 17:17:03 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5396,7 +5264,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 43eead05-2c79-4422-87d8-92ef54980fc7
+      - ccd71781-f938-465b-8cc0-d60d737da4c4
     status: 200 OK
     code: 200
     duration: ""
@@ -5405,23 +5273,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:01 GMT
+      - Mon, 04 Mar 2024 17:17:08 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5429,7 +5297,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - eb083556-bf6a-41a6-8dcc-b6a9b957ffe7
+      - 9b919fd4-a4a0-4795-9ef7-1f449f093e4e
     status: 200 OK
     code: 200
     duration: ""
@@ -5438,23 +5306,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:06 GMT
+      - Mon, 04 Mar 2024 17:17:13 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5462,7 +5330,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44a0e2f8-21f9-4586-b521-55316e42efcc
+      - 63cd95c1-35d1-40c6-af4f-53a12ade72a6
     status: 200 OK
     code: 200
     duration: ""
@@ -5471,23 +5339,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:11 GMT
+      - Mon, 04 Mar 2024 17:17:18 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5495,7 +5363,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2ea29207-30f7-452d-b3c2-ef94b8eec496
+      - 0aed8b6c-52e8-4a8e-bac1-306a4be884af
     status: 200 OK
     code: 200
     duration: ""
@@ -5504,23 +5372,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:25:34.867770Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "853"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:17 GMT
+      - Mon, 04 Mar 2024 17:17:23 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5528,7 +5396,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 235fc795-807d-4386-be7a-9e417e2cb682
+      - 4b97d931-7629-4d57-a56d-ec56f88891a9
     status: 200 OK
     code: 200
     duration: ""
@@ -5537,23 +5405,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:21.338937Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "846"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:22 GMT
+      - Mon, 04 Mar 2024 17:17:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5561,7 +5429,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4ced4702-1c14-4876-b352-a548611ee6f8
+      - 2a268699-c709-45a4-800e-5aea2901af8c
     status: 200 OK
     code: 200
     duration: ""
@@ -5570,23 +5438,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:21.338937Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"initializing","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:12:38.155650Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "846"
+      - "823"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:22 GMT
+      - Mon, 04 Mar 2024 17:17:34 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5594,7 +5462,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fefffc8e-1157-41ee-83ef-a475de586aa8
+      - 318bf8bf-287c-4ee3-a789-eb1db87da2c1
     status: 200 OK
     code: 200
     duration: ""
@@ -5603,23 +5471,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:21.338937Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:37.825663Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "846"
+      - "816"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:22 GMT
+      - Mon, 04 Mar 2024 17:17:39 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5627,7 +5495,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 48443bc4-c1f3-451e-bf17-f6f5f56662f7
+      - ba520a37-73ca-4b90-87d8-4e8ae47e938d
     status: 200 OK
     code: 200
     duration: ""
@@ -5636,23 +5504,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01/certificate
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLakNDQWhLZ0F3SUJBZ0lSQUtyZXYwNDFmNHYzdEVCM2EzU2pKWm93RFFZSktvWklodmNOQVFFTEJRQXcKTVRFV01CUUdBMVVFQ2hNTlUyTmhiR1YzWVhsU1pXUnBjekVYTUJVR0ExVUVBeE1PTVRZekxqRTNNaTR4TkRRdQpOREl3SGhjTk1qUXdNakl5TVRneU1USTBXaGNOTXpRd01qRTVNVGd5TVRJMFdqQXhNUll3RkFZRFZRUUtFdzFUClkyRnNaWGRoZVZKbFpHbHpNUmN3RlFZRFZRUURFdzR4TmpNdU1UY3lMakUwTkM0ME1qQ0NBU0l3RFFZSktvWkkKaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPWGp2cXJsZ05mV3dmVzNqRm9FNGtwSlBmeUllb3gwSVdBWQp2djFKUStBUWoyVHF0a043MW53WXh5c3U0bWNaUXk0dlFYNmNTazNWT0FRN3l4ODlZRUlXS0hqQ3diRFNHcjBDCnhtMGx3WUk3NEx2SmZrQXUrd0RsaHJLc1ZZRnBYVTNYZUV2VTU3YWJBaHV6dUt2TEc1dlJqRnQ4NmUrV2htN2YKL0wyNWQrQXNqS3BVTWxPWVhGU01hSkFZajRJN05UMWV5RGRVdHJoUjd0U1pCYS8xdlBpbWxZTTc1bC9nQnRnegpLUFVNMGN4cCtZQy9vQTdNZG1NUUloL3VoanphNzBBMEpFZ3J4T1d5WDZCcjdYTkZmbGxKNWxKak9xSGpBbHhTClJaTHZGc1pKVGk2QkkzZzFNeUxmRFF6WFNFQ1N3MUhTelRuTThtaGt1SjFURU02ak5EY0NBd0VBQWFNOU1Ec3cKRGdZRFZSMFBBUUgvQkFRREFnV2dNQXdHQTFVZEV3RUIvd1FDTUFBd0d3WURWUjBSQkJRd0VvY0V3S2hqQVljRQp3S2hqQW9jRXdLaGpBekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBY25GOFRqUmlpSWFic0JCYWZCbzQ0TjBiCmJkeVVZYXhSajZrUnAvMVh1UVlNS1JlUEVpazJ0a3JmcElIM25lalZhbGNKN1ZmNUdVVCsyRlJaRVJLQ0MxWDkKbGFIV2phZDdYaGlxMitha21QL2R6Q3JIWlNiVmNlYWJ6U2tSYU1aVHhlMzlWVjgvOFNuRXV1THc4SVZzbVZwQQpiV3JSbi8xZHBKRzlNMmlrOGVLeWtCZnUzV1VZTkNqaExsU3BxbU1EcHhjYk1GM25mRWIvOXVLdE93NWdEV3MvCkpYNEpKT2l0RmFUTENxL250SUhpRFpWYkt6Mk1ydnNQSXErd0k2a3U0MkxSWmVOSjdMRnJhUExhMks4YnZ1eG4KQWxOQmFvaFpzaEliV0MzYnBubzFQY2ZYQVFvMHRhSGRZQmgvOG04cER3Smc4UTNCRk9WNGg0VWNYZUdjNWc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:37.825663Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "1629"
+      - "816"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:22 GMT
+      - Mon, 04 Mar 2024 17:17:39 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5660,7 +5528,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 793ff34a-ab2b-4dcb-baf0-d23d5c99c8b5
+      - 0edf8809-6ce6-47cf-9df9-82d01c5c6c34
     status: 200 OK
     code: 200
     duration: ""
@@ -5669,23 +5537,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:21.338937Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:37.825663Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "846"
+      - "816"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:22 GMT
+      - Mon, 04 Mar 2024 17:17:39 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5693,7 +5561,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 88bc9d8a-065b-410a-a0a0-90d1cbf9e6b9
+      - b258b170-6780-4717-add3-cc22186a081c
     status: 200 OK
     code: 200
     duration: ""
@@ -5702,23 +5570,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/34761e5b-cf85-4777-aef9-07c8fe068eb9
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b/certificate
     method: GET
   response:
-    body: '{"created_at":"2024-02-22T18:18:37.481183Z","dhcp_enabled":true,"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","name":"tf-pn-determined-williamson","organization_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","region":"fr-par","subnets":[{"created_at":"2024-02-22T18:18:37.481183Z","id":"4c052d2b-b5ae-4e1f-96ec-b61d2fd35b5a","subnet":"192.168.99.0/24","updated_at":"2024-02-22T18:18:37.481183Z"},{"created_at":"2024-02-22T18:18:37.481183Z","id":"abcdee36-300e-46b2-94a7-978ed5330c6e","subnet":"fd63:256c:45f7:444b::/64","updated_at":"2024-02-22T18:18:37.481183Z"}],"tags":[],"updated_at":"2024-02-22T18:18:37.481183Z","vpc_id":"1ec1ecb6-8f58-4f7c-92cc-53c2a5ae519c"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLakNDQWhLZ0F3SUJBZ0lSQUxLekVEcjZaMUZndlpRODhzQW12emt3RFFZSktvWklodmNOQVFFTEJRQXcKTVRFV01CUUdBMVVFQ2hNTlUyTmhiR1YzWVhsU1pXUnBjekVYTUJVR0ExVUVBeE1PTWpFeUxqUTNMakkwT0M0eApNamN3SGhjTk1qUXdNekEwTVRjd09ESTRXaGNOTXpRd016QXlNVGN3T0RJNFdqQXhNUll3RkFZRFZRUUtFdzFUClkyRnNaWGRoZVZKbFpHbHpNUmN3RlFZRFZRUURFdzR5TVRJdU5EY3VNalE0TGpFeU56Q0NBU0l3RFFZSktvWkkKaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPWVVBakl6TlpzVE02MlNYcUdUQURTOUMwMlBHV1RiTDQxSAo2a3RjQmVXb2ZGQ0N1NlFpa3E2OUVaVjViT0VoQXNYM2w0NmpucGNxRGF0SGwrUDZDQUl4L2FWbEw4YXdwY2NjClBXRnNwbFAzM2xoSnRBcDFteHhwbmQ1Z3BkSTIrSUtUanBaTUE5Y2wrSTV4NXlLYVQyS3U4ZGR5T1psNSt1VkQKM0E1NHZ4bkVMZnZkTVNtclVYejVHQVlZR21temVZenovamMxVHk5YXE2cm9FS0JLa2w0dVhtQ1ErY3RiNW8zWAprNVhkUjF4eUkxdDhDQWN3MXpPWlNsMDZpdzdHVUZYMk9CTnBsbXlVRWhLQ2RnZjlzUGNhU2NJVFZka3ZaT01GCjE3TlRGV1k0M2U3dVFKWlhVa2k2aE5ZZU1lWVQvSE1VOW1PMWNKWHpZY2ZWT0t0VGJ3TUNBd0VBQWFNOU1Ec3cKRGdZRFZSMFBBUUgvQkFRREFnV2dNQXdHQTFVZEV3RUIvd1FDTUFBd0d3WURWUjBSQkJRd0VvY0V3S2hqQVljRQp3S2hqQW9jRXdLaGpBekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBM0hxLytrcENJZzM3Y0gwN0VVQzNJdWF3CnlJYlRUUWphNGhmeWhwSzEwamJrNzNSRFNmL3NPWFIvaTk4cFJYNC9Xdmh4Y0QzWHhhcUdRcXFKWE5YNitIYk8Kb1NqR0NhY1I3WS9ud0dWQjlzaDhYeU5FNUFqYThmcjJRaUd5UHNFcEEzUkpyZTRuV3ZXYVNCZEJ5OWVKa3VzdwpXeXpGSkt6cXlwQUQrK1doMEZOOW1nV0hKRU1mN2NyWWNHWnVxV0EzNkZMWEJ1N0J1TUNBZ3hkWFE1YzkwS0IvCmtNdyt3eFNWbFZhOU1ZNjY1V0JheWJJWEoyRWNtMkxjL1lEUWwwZllIT0xSK1F4OG1NOFpnZ1JXWDJaNmNNRDgKMkRDRmFqOTI3WDM4SFAvdEU2YXQvK3ZqTWNYa0Q2SXY5cjlIV215RTJ4NEhlc3FBdUtkYUt5MmI0c2pFTlE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "729"
+      - "1627"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:23 GMT
+      - Mon, 04 Mar 2024 17:17:39 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5726,7 +5594,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8bb478cb-a647-422a-a08b-a25c8d35278b
+      - 78cf71bc-f9c7-475f-ba0f-9d77aad78c4f
     status: 200 OK
     code: 200
     duration: ""
@@ -5735,23 +5603,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:21.338937Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:37.825663Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "846"
+      - "816"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:23 GMT
+      - Mon, 04 Mar 2024 17:17:39 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5759,7 +5627,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 55a70d8a-29c3-473e-9eec-ae42819c4163
+      - 1cfdc888-5a14-40b0-8b3b-382650fb840a
     status: 200 OK
     code: 200
     duration: ""
@@ -5768,23 +5636,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01/certificate
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/627871f8-e5ae-4206-a73c-fee60507c1af
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLakNDQWhLZ0F3SUJBZ0lSQUtyZXYwNDFmNHYzdEVCM2EzU2pKWm93RFFZSktvWklodmNOQVFFTEJRQXcKTVRFV01CUUdBMVVFQ2hNTlUyTmhiR1YzWVhsU1pXUnBjekVYTUJVR0ExVUVBeE1PTVRZekxqRTNNaTR4TkRRdQpOREl3SGhjTk1qUXdNakl5TVRneU1USTBXaGNOTXpRd01qRTVNVGd5TVRJMFdqQXhNUll3RkFZRFZRUUtFdzFUClkyRnNaWGRoZVZKbFpHbHpNUmN3RlFZRFZRUURFdzR4TmpNdU1UY3lMakUwTkM0ME1qQ0NBU0l3RFFZSktvWkkKaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPWGp2cXJsZ05mV3dmVzNqRm9FNGtwSlBmeUllb3gwSVdBWQp2djFKUStBUWoyVHF0a043MW53WXh5c3U0bWNaUXk0dlFYNmNTazNWT0FRN3l4ODlZRUlXS0hqQ3diRFNHcjBDCnhtMGx3WUk3NEx2SmZrQXUrd0RsaHJLc1ZZRnBYVTNYZUV2VTU3YWJBaHV6dUt2TEc1dlJqRnQ4NmUrV2htN2YKL0wyNWQrQXNqS3BVTWxPWVhGU01hSkFZajRJN05UMWV5RGRVdHJoUjd0U1pCYS8xdlBpbWxZTTc1bC9nQnRnegpLUFVNMGN4cCtZQy9vQTdNZG1NUUloL3VoanphNzBBMEpFZ3J4T1d5WDZCcjdYTkZmbGxKNWxKak9xSGpBbHhTClJaTHZGc1pKVGk2QkkzZzFNeUxmRFF6WFNFQ1N3MUhTelRuTThtaGt1SjFURU02ak5EY0NBd0VBQWFNOU1Ec3cKRGdZRFZSMFBBUUgvQkFRREFnV2dNQXdHQTFVZEV3RUIvd1FDTUFBd0d3WURWUjBSQkJRd0VvY0V3S2hqQVljRQp3S2hqQW9jRXdLaGpBekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBY25GOFRqUmlpSWFic0JCYWZCbzQ0TjBiCmJkeVVZYXhSajZrUnAvMVh1UVlNS1JlUEVpazJ0a3JmcElIM25lalZhbGNKN1ZmNUdVVCsyRlJaRVJLQ0MxWDkKbGFIV2phZDdYaGlxMitha21QL2R6Q3JIWlNiVmNlYWJ6U2tSYU1aVHhlMzlWVjgvOFNuRXV1THc4SVZzbVZwQQpiV3JSbi8xZHBKRzlNMmlrOGVLeWtCZnUzV1VZTkNqaExsU3BxbU1EcHhjYk1GM25mRWIvOXVLdE93NWdEV3MvCkpYNEpKT2l0RmFUTENxL250SUhpRFpWYkt6Mk1ydnNQSXErd0k2a3U0MkxSWmVOSjdMRnJhUExhMks4YnZ1eG4KQWxOQmFvaFpzaEliV0MzYnBubzFQY2ZYQVFvMHRhSGRZQmgvOG04cER3Smc4UTNCRk9WNGg0VWNYZUdjNWc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"created_at":"2024-03-04T17:06:01.017456Z","dhcp_enabled":true,"id":"627871f8-e5ae-4206-a73c-fee60507c1af","name":"tf-pn-magical-mirzakhani","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-03-04T17:06:01.017456Z","id":"cb58c7b5-c3c9-4dd4-a2b6-9a6f77bba55e","subnet":"172.16.28.0/22","updated_at":"2024-03-04T17:06:01.017456Z"},{"created_at":"2024-03-04T17:06:01.017456Z","id":"73935ea7-d676-4ec4-86f7-14d000f580a9","subnet":"fd5f:519c:6d46:2830::/64","updated_at":"2024-03-04T17:06:01.017456Z"}],"tags":[],"updated_at":"2024-03-04T17:06:01.017456Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
     headers:
       Content-Length:
-      - "1629"
+      - "708"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:23 GMT
+      - Mon, 04 Mar 2024 17:17:40 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5792,7 +5660,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 93228080-e71a-4ae8-be72-76995d42e0f9
+      - 546f4186-5bbf-44e0-b638-55c956ee9fdc
     status: 200 OK
     code: 200
     duration: ""
@@ -5801,23 +5669,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:21.338937Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:37.825663Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "846"
+      - "816"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:23 GMT
+      - Mon, 04 Mar 2024 17:17:40 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5825,7 +5693,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 7bb2d8f5-6f24-4940-ac7d-9ec23c5768c4
+      - f93dbb7c-5188-4e2a-a970-11fe06826302
     status: 200 OK
     code: 200
     duration: ""
@@ -5834,23 +5702,89 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURLakNDQWhLZ0F3SUJBZ0lSQUxLekVEcjZaMUZndlpRODhzQW12emt3RFFZSktvWklodmNOQVFFTEJRQXcKTVRFV01CUUdBMVVFQ2hNTlUyTmhiR1YzWVhsU1pXUnBjekVYTUJVR0ExVUVBeE1PTWpFeUxqUTNMakkwT0M0eApNamN3SGhjTk1qUXdNekEwTVRjd09ESTRXaGNOTXpRd016QXlNVGN3T0RJNFdqQXhNUll3RkFZRFZRUUtFdzFUClkyRnNaWGRoZVZKbFpHbHpNUmN3RlFZRFZRUURFdzR5TVRJdU5EY3VNalE0TGpFeU56Q0NBU0l3RFFZSktvWkkKaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFPWVVBakl6TlpzVE02MlNYcUdUQURTOUMwMlBHV1RiTDQxSAo2a3RjQmVXb2ZGQ0N1NlFpa3E2OUVaVjViT0VoQXNYM2w0NmpucGNxRGF0SGwrUDZDQUl4L2FWbEw4YXdwY2NjClBXRnNwbFAzM2xoSnRBcDFteHhwbmQ1Z3BkSTIrSUtUanBaTUE5Y2wrSTV4NXlLYVQyS3U4ZGR5T1psNSt1VkQKM0E1NHZ4bkVMZnZkTVNtclVYejVHQVlZR21temVZenovamMxVHk5YXE2cm9FS0JLa2w0dVhtQ1ErY3RiNW8zWAprNVhkUjF4eUkxdDhDQWN3MXpPWlNsMDZpdzdHVUZYMk9CTnBsbXlVRWhLQ2RnZjlzUGNhU2NJVFZka3ZaT01GCjE3TlRGV1k0M2U3dVFKWlhVa2k2aE5ZZU1lWVQvSE1VOW1PMWNKWHpZY2ZWT0t0VGJ3TUNBd0VBQWFNOU1Ec3cKRGdZRFZSMFBBUUgvQkFRREFnV2dNQXdHQTFVZEV3RUIvd1FDTUFBd0d3WURWUjBSQkJRd0VvY0V3S2hqQVljRQp3S2hqQW9jRXdLaGpBekFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBM0hxLytrcENJZzM3Y0gwN0VVQzNJdWF3CnlJYlRUUWphNGhmeWhwSzEwamJrNzNSRFNmL3NPWFIvaTk4cFJYNC9Xdmh4Y0QzWHhhcUdRcXFKWE5YNitIYk8Kb1NqR0NhY1I3WS9ud0dWQjlzaDhYeU5FNUFqYThmcjJRaUd5UHNFcEEzUkpyZTRuV3ZXYVNCZEJ5OWVKa3VzdwpXeXpGSkt6cXlwQUQrK1doMEZOOW1nV0hKRU1mN2NyWWNHWnVxV0EzNkZMWEJ1N0J1TUNBZ3hkWFE1YzkwS0IvCmtNdyt3eFNWbFZhOU1ZNjY1V0JheWJJWEoyRWNtMkxjL1lEUWwwZllIT0xSK1F4OG1NOFpnZ1JXWDJaNmNNRDgKMkRDRmFqOTI3WDM4SFAvdEU2YXQvK3ZqTWNYa0Q2SXY5cjlIV215RTJ4NEhlc3FBdUtkYUt5MmI0c2pFTlE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "1627"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 04 Mar 2024 17:17:40 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d2309cbf-a13b-481a-80c4-cb40dcff2b1c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
+    method: GET
+  response:
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"ready","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:37.825663Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    headers:
+      Content-Length:
+      - "816"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 04 Mar 2024 17:17:41 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-2;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 71e7d198-09cd-46f6-b06a-0029e9043d0c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: DELETE
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:23.678466Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:41.453136Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "849"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:25 GMT
+      - Mon, 04 Mar 2024 17:17:43 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5858,7 +5792,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f8339a8-025d-4367-949c-029be97f03c6
+      - 80ed9861-3864-438b-ae0b-8ff7e1293775
     status: 200 OK
     code: 200
     duration: ""
@@ -5867,23 +5801,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:23.678466Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:41.453136Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "849"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:25 GMT
+      - Mon, 04 Mar 2024 17:17:43 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5891,7 +5825,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 82141450-4240-4776-8e42-02bce373fea1
+      - 9854a605-c178-47a6-a09c-379f92749da3
     status: 200 OK
     code: 200
     duration: ""
@@ -5900,23 +5834,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:23.678466Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:41.453136Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "849"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:31 GMT
+      - Mon, 04 Mar 2024 17:17:48 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5924,7 +5858,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e1eede1b-064f-4f55-9efc-36b92251c2dc
+      - 414b799e-5805-4203-a896-e5385bf032fc
     status: 200 OK
     code: 200
     duration: ""
@@ -5933,23 +5867,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:23.678466Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:41.453136Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "849"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:36 GMT
+      - Mon, 04 Mar 2024 17:17:53 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5957,7 +5891,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4f1baa28-97e0-4efb-bd64-3e5e6bde4873
+      - ec1693a4-c8b6-4eb3-ad33-3234c37345c0
     status: 200 OK
     code: 200
     duration: ""
@@ -5966,23 +5900,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:23.678466Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:41.453136Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "849"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:41 GMT
+      - Mon, 04 Mar 2024 17:17:58 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -5990,7 +5924,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 6746f1a7-ca35-46b9-8209-6cd3c7013373
+      - 5a47761a-18d1-4248-b5e0-7e7e19316169
     status: 200 OK
     code: 200
     duration: ""
@@ -5999,23 +5933,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:23.678466Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:41.453136Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "849"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:46 GMT
+      - Mon, 04 Mar 2024 17:18:04 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6023,7 +5957,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 028e646f-bb76-4c72-bc98-61015a3fe3cd
+      - 49946275-c1b7-44db-8327-ce26f0267d5f
     status: 200 OK
     code: 200
     duration: ""
@@ -6032,23 +5966,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:23.678466Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:41.453136Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "849"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:51 GMT
+      - Mon, 04 Mar 2024 17:18:09 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6056,7 +5990,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 44cb005e-ff80-4bfe-acef-48fb24105b78
+      - 0b867cce-a90b-4bc6-8716-2fdbd9353b86
     status: 200 OK
     code: 200
     duration: ""
@@ -6065,23 +5999,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:23.678466Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:41.453136Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "849"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:30:56 GMT
+      - Mon, 04 Mar 2024 17:18:14 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6089,7 +6023,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4c3e8378-3a34-4721-bfd7-58a3aecf212f
+      - 21c0bffd-46f3-4e8e-be6b-2909b3c3475e
     status: 200 OK
     code: 200
     duration: ""
@@ -6098,23 +6032,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:23.678466Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:41.453136Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "849"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:31:01 GMT
+      - Mon, 04 Mar 2024 17:18:19 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6122,7 +6056,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c63311bc-eb67-4ce1-b000-d524036046c1
+      - 2e1f0cd1-342d-4651-9537-a4ab05fa14fa
     status: 200 OK
     code: 200
     duration: ""
@@ -6131,23 +6065,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:23.678466Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:41.453136Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "849"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:31:06 GMT
+      - Mon, 04 Mar 2024 17:18:24 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6155,7 +6089,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ae94b8c3-da9c-46f2-97a9-e4ddcb9ffc66
+      - 06984536-0961-40d6-a019-f78f3cc5d41d
     status: 200 OK
     code: 200
     duration: ""
@@ -6164,23 +6098,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:23.678466Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:41.453136Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "849"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:31:12 GMT
+      - Mon, 04 Mar 2024 17:18:29 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6188,7 +6122,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 39368b51-5c72-4d38-b754-300151f1d210
+      - 8849cfb8-cba7-4e56-9b16-bb6e9dff7681
     status: 200 OK
     code: 200
     duration: ""
@@ -6197,23 +6131,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-02-22T18:21:12.493516Z","endpoints":[{"id":"696c2905-fafc-4e56-8dc7-a56c64807676","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"34761e5b-cf85-4777-aef9-07c8fe068eb9","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"386c0428-f6d1-4314-8263-cf2c8d787c01","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"fa1e3217-dc80-42ac-85c3-3f034b78b552","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-02-22T18:30:23.678466Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
+    body: '{"acl_rules":[],"cluster_settings":[],"cluster_size":5,"created_at":"2024-03-04T17:08:15.742992Z","endpoints":[{"id":"4dc667c9-8f20-4642-9a00-9943d8c8a8c1","ips":["192.168.99.1","192.168.99.2","192.168.99.3","192.168.99.4","192.168.99.5"],"port":6379,"private_network":{"id":"627871f8-e5ae-4206-a73c-fee60507c1af","provisioning_mode":"static","service_ips":["192.168.99.1/24","192.168.99.2/24","192.168.99.3/24","192.168.99.4/24","192.168.99.5/24"],"zone":"fr-par-1"}}],"id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","name":"test_redis_migrate_cluster_size_static","node_type":"RED1-XS","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","status":"deleting","tags":[],"tls_enabled":true,"updated_at":"2024-03-04T17:17:41.453136Z","upgradable_versions":[],"user_name":"my_initial_user","version":"7.0.5","zone":"fr-par-1"}'
     headers:
       Content-Length:
-      - "849"
+      - "819"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:31:17 GMT
+      - Mon, 04 Mar 2024 17:18:35 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6221,7 +6155,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 35469ef1-1f01-4828-b8c6-c3ada6b1a73b
+      - f087916c-1c2c-4d4f-be9b-c49fc7f9d4b9
     status: 200 OK
     code: 200
     duration: ""
@@ -6230,12 +6164,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"386c0428-f6d1-4314-8263-cf2c8d787c01","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -6244,9 +6178,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:31:22 GMT
+      - Mon, 04 Mar 2024 17:18:40 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6254,7 +6188,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 68a5cad2-57fb-453b-8daa-436ea3e5ab88
+      - 0f31bccb-f884-4a9c-b8fb-f49aee5c5c01
     status: 404 Not Found
     code: 404
     duration: ""
@@ -6263,9 +6197,9 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/34761e5b-cf85-4777-aef9-07c8fe068eb9
+    url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/627871f8-e5ae-4206-a73c-fee60507c1af
     method: DELETE
   response:
     body: ""
@@ -6275,9 +6209,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:31:23 GMT
+      - Mon, 04 Mar 2024 17:18:41 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6285,7 +6219,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 469b9a38-6b0b-4bc0-943b-abc026db87cf
+      - 8921a844-cffb-45cb-b9e8-fe6ae1913b58
     status: 204 No Content
     code: 204
     duration: ""
@@ -6294,12 +6228,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.21.6; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/386c0428-f6d1-4314-8263-cf2c8d787c01
+    url: https://api.scaleway.com/redis/v1/zones/fr-par-1/clusters/613f50ed-abb3-4f1c-96d2-9d337b1e5c4b
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"cluster","resource_id":"386c0428-f6d1-4314-8263-cf2c8d787c01","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"cluster","resource_id":"613f50ed-abb3-4f1c-96d2-9d337b1e5c4b","type":"not_found"}'
     headers:
       Content-Length:
       - "128"
@@ -6308,9 +6242,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 22 Feb 2024 18:31:23 GMT
+      - Mon, 04 Mar 2024 17:18:41 GMT
       Server:
-      - Scaleway API Gateway (fr-par-1;edge02)
+      - Scaleway API Gateway (fr-par-2;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -6318,7 +6252,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 941927b1-e9cf-4ae2-a260-34f68675977e
+      - bcec7ec2-d87b-448d-818a-43332d4a69a3
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
The Redis nightly tests failed because of an error during the creation of the private network (`subnets is invalid for unexpected reason, subnet_overlaps_in_vpc: {}`), removing said subnet from the configuration may resolve the issue as it is not mandatory.