### PR TITLE
fix(rdb): allow updates from bssd to lssd if new node type has enough space

### DIFF
--- a/scaleway/resource_rdb_instance.go
+++ b/scaleway/resource_rdb_instance.go
@@ -593,7 +593,7 @@ func resourceScalewayRdbInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 
 	// If we are switching to local storage, we have to make sure that the node_type upgrade is done first
 	if d.HasChange("volume_type") {
-		_, wantedVolumeType := d.GetChange("volume_type")
+		wantedVolumeType := d.Get("volume_type")
 		if wantedVolumeType == rdb.VolumeTypeLssd.String() {
 			for i, req := range upgradeInstanceRequests {
 				if req.NodeType != nil && i != 0 {

--- a/scaleway/resource_rdb_instance.go
+++ b/scaleway/resource_rdb_instance.go
@@ -591,6 +591,18 @@ func resourceScalewayRdbInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 			})
 	}
 
+	// If we are switching to local storage, we have to make sure that the node_type upgrade is done first
+	if d.HasChange("volume_type") {
+		_, wantedVolumeType := d.GetChange("volume_type")
+		if wantedVolumeType == rdb.VolumeTypeLssd.String() {
+			for i, req := range upgradeInstanceRequests {
+				if req.NodeType != nil && i != 0 {
+					upgradeInstanceRequests[0], upgradeInstanceRequests[i] = upgradeInstanceRequests[i], upgradeInstanceRequests[0]
+				}
+			}
+		}
+	}
+
 	// Carry out the upgrades
 	for i := range upgradeInstanceRequests {
 		_, err = waitForRDBInstance(ctx, rdbAPI, region, ID, d.Timeout(schema.TimeoutUpdate))

--- a/scaleway/resource_rdb_instance_test.go
+++ b/scaleway/resource_rdb_instance_test.go
@@ -880,6 +880,25 @@ func TestAccScalewayRdbInstance_Volume(t *testing.T) {
 					resource.TestCheckResourceAttr("scaleway_rdb_instance.main", "volume_size_in_gb", "10"),
 				),
 			},
+			{
+				Config: fmt.Sprintf(`
+					resource scaleway_rdb_instance main {
+						name = "test-rdb-instance-volume"
+						node_type = "db-dev-m"
+						engine = %q
+						is_ha_cluster = false
+						disable_backup = true
+						user_name = "my_initial_user"
+						password = "thiZ_is_v&ry_s3cret"
+						region= "nl-ams"
+						tags = [ "terraform-test", "scaleway_rdb_instance", "volume" ]
+					}
+				`, latestEngineVersion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayRdbExists(tt, "scaleway_rdb_instance.main"),
+					resource.TestCheckResourceAttr("scaleway_rdb_instance.main", "volume_type", "lssd"),
+				),
+			},
 		},
 	})
 }

--- a/scaleway/testdata/rdb-instance-volume.cassette.yaml
+++ b/scaleway/testdata/rdb-instance-volume.cassette.yaml
@@ -6,7 +6,7 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/fr-par/database-engines
     method: GET
@@ -66,7 +66,9 @@ interactions:
       the time to wait on a lock before checking for deadlock.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":60000,"int_min":100,"name":"deadlock_timeout","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"100","description":"Sets
       the default statistics target.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":10000,"int_min":1,"name":"default_statistics_target","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"off","description":"Sets
       the default deferrable status of new transactions.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"default_transaction_deferrable","property_type":"BOOLEAN","string_constraint":null,"unit":null},{"default_value":"4096","description":"Sets
-      the planner s assumption about the size of the data cache.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":1048576,"int_min":64,"name":"effective_cache_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"off","description":"Specifies
+      the planner s assumption about the size of the data cache.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":1048576,"int_min":64,"name":"effective_cache_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"1","description":"Sets
+      the number of concurrent disk I/O operations that PostgreSQL expects can be
+      executed simultaneously.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":32,"int_min":1,"name":"effective_io_concurrency","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"off","description":"Specifies
       whether or not a hot standby will send feedback to the primary or upstream standby
       about queries currently executing on the standby.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"hot_standby_feedback","property_type":"BOOLEAN","string_constraint":null,"unit":null},{"default_value":"3600000","description":"Sets
       the maximum allowed duration of any idling transaction. Value in ms","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":0,"name":"idle_in_transaction_session_timeout","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"0","description":"Sets
@@ -80,7 +82,10 @@ interactions:
       the maximum delay before canceling queries when a hot standby server is processing
       streamed WAL data.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":180000,"int_min":0,"name":"max_standby_streaming_delay","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"1024","description":"Maximum
       size to let the WAL grow during automatic checkpoints. Be careful adjusting
-      this setting will use disk space","float_max":null,"float_min":null,"hot_configurable":true,"int_max":10240,"int_min":256,"name":"max_wal_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"86400000","description":"Sets
+      this setting will use disk space","float_max":null,"float_min":null,"hot_configurable":true,"int_max":10240,"int_min":256,"name":"max_wal_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"none","description":"Specifies
+      which classes of statements will be logged by session audit logging","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"pgaudit.log","property_type":"STRING","string_constraint":"^none$|^ALL$|^(?:(READ|WRITE|FUNCTION|ROLE|DDL|MISC|MISC_SET)(?!.*\\1))(?:(,)(READ|WRITE|FUNCTION|ROLE|DDL|MISC|MISC_SET)(?!.*\\2\\3))*$","unit":null},{"default_value":"","description":"Specifies
+      the master role to use for object audit logging.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"pgaudit.role","property_type":"STRING","string_constraint":"^[a-zA-Z][a-zA-Z0-9_$-]{0,62}$","unit":null},{"default_value":"off","description":"Enable
+      pgaudit extension on the instance.","float_max":null,"float_min":null,"hot_configurable":false,"int_max":null,"int_min":null,"name":"rdb.enable_pgaudit","property_type":"BOOLEAN","string_constraint":null,"unit":null},{"default_value":"86400000","description":"Sets
       the maximum allowed duration of any statement. Value in ms","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":30000,"name":"statement_timeout","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"0","description":"Maximum
       number of TCP keepalive retransmits.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":0,"name":"tcp_keepalives_count","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"0","description":"Time
       between issuing TCP keepalives.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":0,"name":"tcp_keepalives_idle","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"0","description":"Time
@@ -104,7 +109,9 @@ interactions:
       the time to wait on a lock before checking for deadlock.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":60000,"int_min":100,"name":"deadlock_timeout","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"100","description":"Sets
       the default statistics target.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":10000,"int_min":1,"name":"default_statistics_target","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"off","description":"Sets
       the default deferrable status of new transactions.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"default_transaction_deferrable","property_type":"BOOLEAN","string_constraint":null,"unit":null},{"default_value":"4096","description":"Sets
-      the planner s assumption about the size of the data cache.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":1048576,"int_min":64,"name":"effective_cache_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"off","description":"Specifies
+      the planner s assumption about the size of the data cache.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":1048576,"int_min":64,"name":"effective_cache_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"1","description":"Sets
+      the number of concurrent disk I/O operations that PostgreSQL expects can be
+      executed simultaneously.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":32,"int_min":1,"name":"effective_io_concurrency","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"off","description":"Specifies
       whether or not a hot standby will send feedback to the primary or upstream standby
       about queries currently executing on the standby.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"hot_standby_feedback","property_type":"BOOLEAN","string_constraint":null,"unit":null},{"default_value":"3600000","description":"Sets
       the maximum allowed duration of any idling transaction. Value in ms","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":0,"name":"idle_in_transaction_session_timeout","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"0","description":"Sets
@@ -118,7 +125,10 @@ interactions:
       the maximum delay before canceling queries when a hot standby server is processing
       streamed WAL data.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":180000,"int_min":0,"name":"max_standby_streaming_delay","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"1024","description":"Maximum
       size to let the WAL grow during automatic checkpoints. Be careful adjusting
-      this setting will use disk space","float_max":null,"float_min":null,"hot_configurable":true,"int_max":10240,"int_min":256,"name":"max_wal_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"86400000","description":"Sets
+      this setting will use disk space","float_max":null,"float_min":null,"hot_configurable":true,"int_max":10240,"int_min":256,"name":"max_wal_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"none","description":"Specifies
+      which classes of statements will be logged by session audit logging","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"pgaudit.log","property_type":"STRING","string_constraint":"^none$|^ALL$|^(?:(READ|WRITE|FUNCTION|ROLE|DDL|MISC|MISC_SET)(?!.*\\1))(?:(,)(READ|WRITE|FUNCTION|ROLE|DDL|MISC|MISC_SET)(?!.*\\2\\3))*$","unit":null},{"default_value":"","description":"Specifies
+      the master role to use for object audit logging.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"pgaudit.role","property_type":"STRING","string_constraint":"^[a-zA-Z][a-zA-Z0-9_$-]{0,62}$","unit":null},{"default_value":"off","description":"Enable
+      pgaudit extension on the instance.","float_max":null,"float_min":null,"hot_configurable":false,"int_max":null,"int_min":null,"name":"rdb.enable_pgaudit","property_type":"BOOLEAN","string_constraint":null,"unit":null},{"default_value":"86400000","description":"Sets
       the maximum allowed duration of any statement. Value in ms","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":30000,"name":"statement_timeout","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"0","description":"Maximum
       number of TCP keepalive retransmits.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":0,"name":"tcp_keepalives_count","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"0","description":"Time
       between issuing TCP keepalives.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":0,"name":"tcp_keepalives_idle","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"0","description":"Time
@@ -142,7 +152,9 @@ interactions:
       the time to wait on a lock before checking for deadlock.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":60000,"int_min":100,"name":"deadlock_timeout","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"100","description":"Sets
       the default statistics target.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":10000,"int_min":1,"name":"default_statistics_target","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"off","description":"Sets
       the default deferrable status of new transactions.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"default_transaction_deferrable","property_type":"BOOLEAN","string_constraint":null,"unit":null},{"default_value":"4096","description":"Sets
-      the planner s assumption about the size of the data cache.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":1048576,"int_min":64,"name":"effective_cache_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"off","description":"Specifies
+      the planner s assumption about the size of the data cache.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":1048576,"int_min":64,"name":"effective_cache_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"1","description":"Sets
+      the number of concurrent disk I/O operations that PostgreSQL expects can be
+      executed simultaneously.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":32,"int_min":1,"name":"effective_io_concurrency","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"off","description":"Specifies
       whether or not a hot standby will send feedback to the primary or upstream standby
       about queries currently executing on the standby.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"hot_standby_feedback","property_type":"BOOLEAN","string_constraint":null,"unit":null},{"default_value":"3600000","description":"Sets
       the maximum allowed duration of any idling transaction. Value in ms","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":0,"name":"idle_in_transaction_session_timeout","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"0","description":"Sets
@@ -156,7 +168,10 @@ interactions:
       the maximum delay before canceling queries when a hot standby server is processing
       streamed WAL data.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":180000,"int_min":0,"name":"max_standby_streaming_delay","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"1024","description":"Maximum
       size to let the WAL grow during automatic checkpoints. Be careful adjusting
-      this setting will use disk space","float_max":null,"float_min":null,"hot_configurable":true,"int_max":10240,"int_min":256,"name":"max_wal_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"86400000","description":"Sets
+      this setting will use disk space","float_max":null,"float_min":null,"hot_configurable":true,"int_max":10240,"int_min":256,"name":"max_wal_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"none","description":"Specifies
+      which classes of statements will be logged by session audit logging","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"pgaudit.log","property_type":"STRING","string_constraint":"^none$|^ALL$|^(?:(READ|WRITE|FUNCTION|ROLE|DDL|MISC|MISC_SET)(?!.*\\1))(?:(,)(READ|WRITE|FUNCTION|ROLE|DDL|MISC|MISC_SET)(?!.*\\2\\3))*$","unit":null},{"default_value":"","description":"Specifies
+      the master role to use for object audit logging.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"pgaudit.role","property_type":"STRING","string_constraint":"^[a-zA-Z][a-zA-Z0-9_$-]{0,62}$","unit":null},{"default_value":"off","description":"Enable
+      pgaudit extension on the instance.","float_max":null,"float_min":null,"hot_configurable":false,"int_max":null,"int_min":null,"name":"rdb.enable_pgaudit","property_type":"BOOLEAN","string_constraint":null,"unit":null},{"default_value":"86400000","description":"Sets
       the maximum allowed duration of any statement. Value in ms","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":30000,"name":"statement_timeout","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"0","description":"Maximum
       number of TCP keepalive retransmits.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":0,"name":"tcp_keepalives_count","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"0","description":"Time
       between issuing TCP keepalives.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":0,"name":"tcp_keepalives_idle","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"0","description":"Time
@@ -180,7 +195,9 @@ interactions:
       the time to wait on a lock before checking for deadlock.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":60000,"int_min":100,"name":"deadlock_timeout","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"100","description":"Sets
       the default statistics target.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":10000,"int_min":1,"name":"default_statistics_target","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"off","description":"Sets
       the default deferrable status of new transactions.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"default_transaction_deferrable","property_type":"BOOLEAN","string_constraint":null,"unit":null},{"default_value":"4096","description":"Sets
-      the planner s assumption about the size of the data cache.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":1048576,"int_min":64,"name":"effective_cache_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"off","description":"Specifies
+      the planner s assumption about the size of the data cache.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":1048576,"int_min":64,"name":"effective_cache_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"1","description":"Sets
+      the number of concurrent disk I/O operations that PostgreSQL expects can be
+      executed simultaneously.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":32,"int_min":1,"name":"effective_io_concurrency","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"off","description":"Specifies
       whether or not a hot standby will send feedback to the primary or upstream standby
       about queries currently executing on the standby.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"hot_standby_feedback","property_type":"BOOLEAN","string_constraint":null,"unit":null},{"default_value":"3600000","description":"Sets
       the maximum allowed duration of any idling transaction. Value in ms","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":0,"name":"idle_in_transaction_session_timeout","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"0","description":"Sets
@@ -194,7 +211,10 @@ interactions:
       the maximum delay before canceling queries when a hot standby server is processing
       streamed WAL data.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":180000,"int_min":0,"name":"max_standby_streaming_delay","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"1024","description":"Maximum
       size to let the WAL grow during automatic checkpoints. Be careful adjusting
-      this setting will use disk space","float_max":null,"float_min":null,"hot_configurable":true,"int_max":10240,"int_min":256,"name":"max_wal_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"86400000","description":"Sets
+      this setting will use disk space","float_max":null,"float_min":null,"hot_configurable":true,"int_max":10240,"int_min":256,"name":"max_wal_size","property_type":"INT","string_constraint":null,"unit":"MB"},{"default_value":"none","description":"Specifies
+      which classes of statements will be logged by session audit logging","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"pgaudit.log","property_type":"STRING","string_constraint":"^none$|^ALL$|^(?:(READ|WRITE|FUNCTION|ROLE|DDL|MISC|MISC_SET)(?!.*\\1))(?:(,)(READ|WRITE|FUNCTION|ROLE|DDL|MISC|MISC_SET)(?!.*\\2\\3))*$","unit":null},{"default_value":"","description":"Specifies
+      the master role to use for object audit logging.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":null,"int_min":null,"name":"pgaudit.role","property_type":"STRING","string_constraint":"^[a-zA-Z][a-zA-Z0-9_$-]{0,62}$","unit":null},{"default_value":"off","description":"Enable
+      pgaudit extension on the instance.","float_max":null,"float_min":null,"hot_configurable":false,"int_max":null,"int_min":null,"name":"rdb.enable_pgaudit","property_type":"BOOLEAN","string_constraint":null,"unit":null},{"default_value":"86400000","description":"Sets
       the maximum allowed duration of any statement. Value in ms","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":30000,"name":"statement_timeout","property_type":"INT","string_constraint":null,"unit":"ms"},{"default_value":"0","description":"Maximum
       number of TCP keepalive retransmits.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":0,"name":"tcp_keepalives_count","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"0","description":"Time
       between issuing TCP keepalives.","float_max":null,"float_min":null,"hot_configurable":true,"int_max":2147483647,"int_min":0,"name":"tcp_keepalives_idle","property_type":"INT","string_constraint":null,"unit":null},{"default_value":"0","description":"Time
@@ -318,9 +338,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 12:57:05 GMT
+      - Tue, 19 Mar 2024 17:46:01 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -328,7 +348,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 96cf42f5-2767-4453-9304-130a87686566
+      - 611d16d0-b754-495d-8d8d-fc289bcfd298
     status: 200 OK
     code: 200
     duration: ""
@@ -339,23 +359,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
     url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "929"
+      - "763"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:42 GMT
+      - Tue, 19 Mar 2024 17:46:02 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -363,7 +383,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4eeee60d-f57f-49eb-86b5-6f6a5abaa838
+      - bb494609-e1bd-432e-9177-fa058617eccb
     status: 200 OK
     code: 200
     duration: ""
@@ -372,23 +392,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "929"
+      - "763"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:07:42 GMT
+      - Tue, 19 Mar 2024 17:46:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -396,7 +416,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4fb3a66c-1345-4463-bfe1-b415c0dc90c1
+      - 0c86582b-16af-4832-9546-68a37396728e
     status: 200 OK
     code: 200
     duration: ""
@@ -405,23 +425,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"provisioning","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "929"
+      - "763"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:08:13 GMT
+      - Tue, 19 Mar 2024 17:46:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -429,7 +449,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 5f8e2d2c-61db-44dc-90c6-15af0f56fab0
+      - a4108d47-333b-400f-8b20-a5d248a05bd9
     status: 200 OK
     code: 200
     duration: ""
@@ -438,23 +458,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "929"
+      - "763"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:08:43 GMT
+      - Tue, 19 Mar 2024 17:47:03 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -462,7 +482,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8d7e2083-1ceb-4203-a607-2550401cda3e
+      - 5f414040-ccf4-4979-8dd5-3213bed7a096
     status: 200 OK
     code: 200
     duration: ""
@@ -471,23 +491,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "929"
+      - "763"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:13 GMT
+      - Tue, 19 Mar 2024 17:47:33 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -495,7 +515,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - c4942237-02a3-4c74-882e-5fc05a90ac2a
+      - f09cc9ef-bc12-4ff4-8973-9baddfffbed1
     status: 200 OK
     code: 200
     duration: ""
@@ -504,23 +524,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "929"
+      - "763"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:09:43 GMT
+      - Tue, 19 Mar 2024 17:48:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -528,7 +548,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 1e32372a-e269-4348-a13f-a8d59176c081
+      - 4914790e-8b2c-4209-ada9-79950bd17f09
     status: 200 OK
     code: 200
     duration: ""
@@ -537,23 +557,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "929"
+      - "763"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:14 GMT
+      - Tue, 19 Mar 2024 17:48:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -561,7 +581,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - baa233bf-4650-4946-b47b-b7f185fca414
+      - 9f0f1825-3779-4d3a-b9e5-aab12c9b14ee
     status: 200 OK
     code: 200
     duration: ""
@@ -570,23 +590,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","load_balancer":{},"name":null,"port":0}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":null,"endpoints":[],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "929"
+      - "1027"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:10:45 GMT
+      - Tue, 19 Mar 2024 17:49:04 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -594,7 +614,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a592cd82-66f6-4374-86ba-fa74a05f818d
+      - e3a0772b-2985-4dd4-9869-56f3b3006a78
     status: 200 OK
     code: 200
     duration: ""
@@ -603,23 +623,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1236"
+      - "1238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:16 GMT
+      - Tue, 19 Mar 2024 17:49:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -627,7 +647,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b15d77e2-10f5-4681-9753-392d3514fb53
+      - 6769decf-d373-4383-9464-6ea32d560088
     status: 200 OK
     code: 200
     duration: ""
@@ -636,23 +656,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWnNVMERIOU1ZaFpGRXlpN0pSckJNeVlIczh3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR4TXpFdU1qZ3dIaGNOCk1qTXhNakU0TVRNeE1EVXhXaGNOTXpNeE1qRTFNVE14TURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqRXpNUzR5T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5uZ2RpMzhobXpQd0hNU1NadEY2QTBreDloS1BXbFdUWDMxamdRcVVIY2h6UU5IUUlHMkVZTysKNVFsNStSOWZhVUxBaGZMdUUyT2x6d2hFZVZ0R1pjanBXTndnWXZrcjJOQXh3amlIQVNrOE1tZ2ZlZkFPSVN3cwpaV3F5R2k3NDlpdHJrQk5hRXlIMWJ5TnhJN0haQ0FSMjVnOXRzUUozYmVaTzNEN2ROUlc2T0dBVis0NUFaa0FPCmRibVNmVXJ1c1NmUXU1MGdkM1dMdjhiZncwYXJWWkdEUHVhUXBIRUxuS0lYZDFUZzlpa3QzWmFEU2dMQm5mclIKMFhHTmFaVk5iMUk3alpTckZJaG9ORnJwK2IzTXFFS2lPWENWeWIrYXAzbFJFRy9WL0dicmF1NnordFRKRy9FdQplRTB4TUxqbzVORW5XY25aSzBUYk1vWkJIOFU5UHJjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU1UTXhMakk0Z2p4eWR5MHpOelF6WmpSa09TMDNZamM1TFRSallUUXRZV1F3WlMweU9ESXcKTkRJMU9HSXlaVGd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0eE16RXVNamlDUEhKMwpMVE0zTkRObU5HUTVMVGRpTnprdE5HTmhOQzFoWkRCbExUSTRNakEwTWpVNFlqSmxPQzV5WkdJdWJtd3RZVzF6CkxuTmpkeTVqYkc5MVpJY0VNdzlJeVljRU01NkRISWNFTTU2REhEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWVArVStUOTFhVWNENXk2OUVReXJuYm4vRVV6QUl4R1lJLytjaGFpUlZHQnZKZGJuUUZZYk9IQWxaK0cvd1N4Ywpxa1Y5NURrWmQwUVlVVk9RUktzc0VlL1J4WUdtMGltWVpTWXQ1YUN1czFDN056RFJyQ2R3cmV3QzdUWUZ2dFQ4CnVpeWMzd1RxaHVTWVdNSjFYanpsbUlTN1g0eWZsL2lCUVc1Y2FsK1dKYzlnQ1g0cmd5SGliclM2NUVudC9NL0MKU2N6VWRnRzNLOHphWFltNkZkUjREWWFDUHhBV1ErZ3RIWlNzSE00VnNtSnM0bGpDK3JTdGJVL1Ezc2krcU9OWgp0SkJxNTFhS0RTOUQ4M0NEWWdWeGZQeitiWkJPZVZ6Ymw1U21qOGxDZlJ6dFlWZnlST2o2c0phMjFPcmdjNjdXCnNNRWYySFhuaHFyMGdCdjMxVUxHUnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTVBpMzZrZnVyM3prdEZPTElDcEQ5OVZvK1g0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TWprdU1UZzRNQjRYCkRUSTBNRE14T1RFM05EZzFNbG9YRFRNME1ETXhOekUzTkRnMU1sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNamt1TVRnNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdwOExQZkkxN0lPSEhOT1NTS0E3cWZIcU5mNjYxU200TDVEcmV1eXFMamYzbStSOTM2d1IKU3hENmorTTVTS0lxdXFacWp0cXJmVnpTdnNoR3A0cWI3VUxGSTdGUTNRT2l5Z2loNHJtekc0TTUxcFZ5cVlEUAp1b0NzNXhXWmdWalM3UVFMREdzMXVvNEVVTWRBTk90U3g4VytjRE5BbmtrcUJpYWd3WE9TbCtyOFNTalF2dW1yClQzdEUzUFlmeEJvV3JtL1lQa2pHeWN1NU5wMTFQVHJKcWNZcjZmWXVoUmRVMElMWFFLMW8wMk8ybkhPRWtzNUYKa3pnTEM4UFZ1cTBKaEsvK0Y3ZUxTMWtINDN6eWdFV2ExZlBzb2tCUmdBcGhPYmk5NlJYRkdERjVBK0pmZXJPcwoxVVk4cW5vQ1ZjWERZNHZsdVlrdFJwTnZjMEg2MCtYWENRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9DNHhNamt1TVRnNGdqeHlkeTFoTjJFd016RXhPUzB5TURjeExUUTJNV1F0T0dKbE5DMHoKWkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzTFdGdGN5NXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9DNHhNamt1TVRnNApnanh5ZHkxaE4yRXdNekV4T1MweU1EY3hMVFEyTVdRdE9HSmxOQzB6WkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzCkxXRnRjeTV6WTNjdVkyeHZkV1NIQkRPZXBUMkhCRE9lZ2J5SEJET2VnYnd3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFEZFF2eHdtVTkzWjRXdFVFeTU2UEhidTlrN2NrY0ErWFI1OXlyUUJOc0JyQnhieFlhSm40dlVyRDkwNgpaVUFnN3Y2N0RqYWlUWWprcDl6SnZEY0ZQRUtyZXVieFJndlZud1BsSE9Pdm5saVp3d3VhV3BVWldlMmc0UEh1Ck9qam9PRzBvcFMyUGJVblB5b0pEb3ZsaFk2Vk1PRXpGaEhmS29EYTI3NEV2K0xZYXJPMzltN0F0WFYwMHNLdmUKdGk2ZXUvSEtzMWpJK05vbHJHSm9LQW93dXhSTUtDMXAzNnFqSVBHUmdNREoycEdzWmRDYkpqajZ0N09IRXhyTQorTjFqa0VqUGNkQ1N3aGc5dUgrczZkQXZaQW1XKzRtcTV3c2ZpMlBHb2pCSUtUNVh0NTE5OTNZQTJtNUlxM3N6Cnh6SExYVnczUjVKNHBzdUYwOGFLQWt4eG9OUT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2007"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:16 GMT
+      - Tue, 19 Mar 2024 17:49:34 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -660,7 +680,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 17421352-08c2-460f-9634-8fa779611ea0
+      - 6bb77671-4fd1-45c3-bde0-4561ad8b8826
     status: 200 OK
     code: 200
     duration: ""
@@ -669,23 +689,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3743f4d9-7b79-4ca4-ad0e-28204258b2e8&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "26"
+      - "1238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:16 GMT
+      - Tue, 19 Mar 2024 17:49:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -693,7 +713,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 13bef233-2122-43af-a4f1-84170a040b1f
+      - 1260143d-9457-4e24-b861-f95a120d3e3e
     status: 200 OK
     code: 200
     duration: ""
@@ -702,23 +722,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1236"
+      - "1238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:16 GMT
+      - Tue, 19 Mar 2024 17:49:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -726,7 +746,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f3a5a310-9c54-4cc9-aa77-f8185af07464
+      - d3667325-072e-47e5-955a-227ebb21e49c
     status: 200 OK
     code: 200
     duration: ""
@@ -735,23 +755,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTVBpMzZrZnVyM3prdEZPTElDcEQ5OVZvK1g0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TWprdU1UZzRNQjRYCkRUSTBNRE14T1RFM05EZzFNbG9YRFRNME1ETXhOekUzTkRnMU1sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNamt1TVRnNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdwOExQZkkxN0lPSEhOT1NTS0E3cWZIcU5mNjYxU200TDVEcmV1eXFMamYzbStSOTM2d1IKU3hENmorTTVTS0lxdXFacWp0cXJmVnpTdnNoR3A0cWI3VUxGSTdGUTNRT2l5Z2loNHJtekc0TTUxcFZ5cVlEUAp1b0NzNXhXWmdWalM3UVFMREdzMXVvNEVVTWRBTk90U3g4VytjRE5BbmtrcUJpYWd3WE9TbCtyOFNTalF2dW1yClQzdEUzUFlmeEJvV3JtL1lQa2pHeWN1NU5wMTFQVHJKcWNZcjZmWXVoUmRVMElMWFFLMW8wMk8ybkhPRWtzNUYKa3pnTEM4UFZ1cTBKaEsvK0Y3ZUxTMWtINDN6eWdFV2ExZlBzb2tCUmdBcGhPYmk5NlJYRkdERjVBK0pmZXJPcwoxVVk4cW5vQ1ZjWERZNHZsdVlrdFJwTnZjMEg2MCtYWENRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9DNHhNamt1TVRnNGdqeHlkeTFoTjJFd016RXhPUzB5TURjeExUUTJNV1F0T0dKbE5DMHoKWkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzTFdGdGN5NXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9DNHhNamt1TVRnNApnanh5ZHkxaE4yRXdNekV4T1MweU1EY3hMVFEyTVdRdE9HSmxOQzB6WkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzCkxXRnRjeTV6WTNjdVkyeHZkV1NIQkRPZXBUMkhCRE9lZ2J5SEJET2VnYnd3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFEZFF2eHdtVTkzWjRXdFVFeTU2UEhidTlrN2NrY0ErWFI1OXlyUUJOc0JyQnhieFlhSm40dlVyRDkwNgpaVUFnN3Y2N0RqYWlUWWprcDl6SnZEY0ZQRUtyZXVieFJndlZud1BsSE9Pdm5saVp3d3VhV3BVWldlMmc0UEh1Ck9qam9PRzBvcFMyUGJVblB5b0pEb3ZsaFk2Vk1PRXpGaEhmS29EYTI3NEV2K0xZYXJPMzltN0F0WFYwMHNLdmUKdGk2ZXUvSEtzMWpJK05vbHJHSm9LQW93dXhSTUtDMXAzNnFqSVBHUmdNREoycEdzWmRDYkpqajZ0N09IRXhyTQorTjFqa0VqUGNkQ1N3aGc5dUgrczZkQXZaQW1XKzRtcTV3c2ZpMlBHb2pCSUtUNVh0NTE5OTNZQTJtNUlxM3N6Cnh6SExYVnczUjVKNHBzdUYwOGFLQWt4eG9OUT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1236"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:16 GMT
+      - Tue, 19 Mar 2024 17:49:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -759,7 +779,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - fed3c434-f6ce-41bc-ad0a-6bfc4622e61b
+      - c1317cc4-0291-46fb-888c-dbd6254ff258
     status: 200 OK
     code: 200
     duration: ""
@@ -768,23 +788,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWnNVMERIOU1ZaFpGRXlpN0pSckJNeVlIczh3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR4TXpFdU1qZ3dIaGNOCk1qTXhNakU0TVRNeE1EVXhXaGNOTXpNeE1qRTFNVE14TURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqRXpNUzR5T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5uZ2RpMzhobXpQd0hNU1NadEY2QTBreDloS1BXbFdUWDMxamdRcVVIY2h6UU5IUUlHMkVZTysKNVFsNStSOWZhVUxBaGZMdUUyT2x6d2hFZVZ0R1pjanBXTndnWXZrcjJOQXh3amlIQVNrOE1tZ2ZlZkFPSVN3cwpaV3F5R2k3NDlpdHJrQk5hRXlIMWJ5TnhJN0haQ0FSMjVnOXRzUUozYmVaTzNEN2ROUlc2T0dBVis0NUFaa0FPCmRibVNmVXJ1c1NmUXU1MGdkM1dMdjhiZncwYXJWWkdEUHVhUXBIRUxuS0lYZDFUZzlpa3QzWmFEU2dMQm5mclIKMFhHTmFaVk5iMUk3alpTckZJaG9ORnJwK2IzTXFFS2lPWENWeWIrYXAzbFJFRy9WL0dicmF1NnordFRKRy9FdQplRTB4TUxqbzVORW5XY25aSzBUYk1vWkJIOFU5UHJjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU1UTXhMakk0Z2p4eWR5MHpOelF6WmpSa09TMDNZamM1TFRSallUUXRZV1F3WlMweU9ESXcKTkRJMU9HSXlaVGd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0eE16RXVNamlDUEhKMwpMVE0zTkRObU5HUTVMVGRpTnprdE5HTmhOQzFoWkRCbExUSTRNakEwTWpVNFlqSmxPQzV5WkdJdWJtd3RZVzF6CkxuTmpkeTVqYkc5MVpJY0VNdzlJeVljRU01NkRISWNFTTU2REhEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWVArVStUOTFhVWNENXk2OUVReXJuYm4vRVV6QUl4R1lJLytjaGFpUlZHQnZKZGJuUUZZYk9IQWxaK0cvd1N4Ywpxa1Y5NURrWmQwUVlVVk9RUktzc0VlL1J4WUdtMGltWVpTWXQ1YUN1czFDN056RFJyQ2R3cmV3QzdUWUZ2dFQ4CnVpeWMzd1RxaHVTWVdNSjFYanpsbUlTN1g0eWZsL2lCUVc1Y2FsK1dKYzlnQ1g0cmd5SGliclM2NUVudC9NL0MKU2N6VWRnRzNLOHphWFltNkZkUjREWWFDUHhBV1ErZ3RIWlNzSE00VnNtSnM0bGpDK3JTdGJVL1Ezc2krcU9OWgp0SkJxNTFhS0RTOUQ4M0NEWWdWeGZQeitiWkJPZVZ6Ymw1U21qOGxDZlJ6dFlWZnlST2o2c0phMjFPcmdjNjdXCnNNRWYySFhuaHFyMGdCdjMxVUxHUnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2007"
+      - "1238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:17 GMT
+      - Tue, 19 Mar 2024 17:49:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -792,7 +812,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 59143679-095f-4eef-b007-d0d89a466aa4
+      - 38c49f2d-b305-40e2-aaef-5aabfcf64fcd
     status: 200 OK
     code: 200
     duration: ""
@@ -801,23 +821,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3743f4d9-7b79-4ca4-ad0e-28204258b2e8&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25/certificate
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTVBpMzZrZnVyM3prdEZPTElDcEQ5OVZvK1g0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TWprdU1UZzRNQjRYCkRUSTBNRE14T1RFM05EZzFNbG9YRFRNME1ETXhOekUzTkRnMU1sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNamt1TVRnNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdwOExQZkkxN0lPSEhOT1NTS0E3cWZIcU5mNjYxU200TDVEcmV1eXFMamYzbStSOTM2d1IKU3hENmorTTVTS0lxdXFacWp0cXJmVnpTdnNoR3A0cWI3VUxGSTdGUTNRT2l5Z2loNHJtekc0TTUxcFZ5cVlEUAp1b0NzNXhXWmdWalM3UVFMREdzMXVvNEVVTWRBTk90U3g4VytjRE5BbmtrcUJpYWd3WE9TbCtyOFNTalF2dW1yClQzdEUzUFlmeEJvV3JtL1lQa2pHeWN1NU5wMTFQVHJKcWNZcjZmWXVoUmRVMElMWFFLMW8wMk8ybkhPRWtzNUYKa3pnTEM4UFZ1cTBKaEsvK0Y3ZUxTMWtINDN6eWdFV2ExZlBzb2tCUmdBcGhPYmk5NlJYRkdERjVBK0pmZXJPcwoxVVk4cW5vQ1ZjWERZNHZsdVlrdFJwTnZjMEg2MCtYWENRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9DNHhNamt1TVRnNGdqeHlkeTFoTjJFd016RXhPUzB5TURjeExUUTJNV1F0T0dKbE5DMHoKWkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzTFdGdGN5NXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9DNHhNamt1TVRnNApnanh5ZHkxaE4yRXdNekV4T1MweU1EY3hMVFEyTVdRdE9HSmxOQzB6WkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzCkxXRnRjeTV6WTNjdVkyeHZkV1NIQkRPZXBUMkhCRE9lZ2J5SEJET2VnYnd3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFEZFF2eHdtVTkzWjRXdFVFeTU2UEhidTlrN2NrY0ErWFI1OXlyUUJOc0JyQnhieFlhSm40dlVyRDkwNgpaVUFnN3Y2N0RqYWlUWWprcDl6SnZEY0ZQRUtyZXVieFJndlZud1BsSE9Pdm5saVp3d3VhV3BVWldlMmc0UEh1Ck9qam9PRzBvcFMyUGJVblB5b0pEb3ZsaFk2Vk1PRXpGaEhmS29EYTI3NEV2K0xZYXJPMzltN0F0WFYwMHNLdmUKdGk2ZXUvSEtzMWpJK05vbHJHSm9LQW93dXhSTUtDMXAzNnFqSVBHUmdNREoycEdzWmRDYkpqajZ0N09IRXhyTQorTjFqa0VqUGNkQ1N3aGc5dUgrczZkQXZaQW1XKzRtcTV3c2ZpMlBHb2pCSUtUNVh0NTE5OTNZQTJtNUlxM3N6Cnh6SExYVnczUjVKNHBzdUYwOGFLQWt4eG9OUT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "26"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:17 GMT
+      - Tue, 19 Mar 2024 17:49:35 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -825,7 +845,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f249e2bb-1004-4e6b-82d7-51fa777af733
+      - f6bb1dba-af7b-4550-951b-bfa124132442
     status: 200 OK
     code: 200
     duration: ""
@@ -834,23 +854,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1236"
+      - "1238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:17 GMT
+      - Tue, 19 Mar 2024 17:49:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -858,7 +878,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b4b0b2fc-c932-431e-8403-dcdda9f453d8
+      - e316fad7-f105-494a-9669-96ef7a84f8af
     status: 200 OK
     code: 200
     duration: ""
@@ -867,23 +887,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWnNVMERIOU1ZaFpGRXlpN0pSckJNeVlIczh3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR4TXpFdU1qZ3dIaGNOCk1qTXhNakU0TVRNeE1EVXhXaGNOTXpNeE1qRTFNVE14TURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqRXpNUzR5T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5uZ2RpMzhobXpQd0hNU1NadEY2QTBreDloS1BXbFdUWDMxamdRcVVIY2h6UU5IUUlHMkVZTysKNVFsNStSOWZhVUxBaGZMdUUyT2x6d2hFZVZ0R1pjanBXTndnWXZrcjJOQXh3amlIQVNrOE1tZ2ZlZkFPSVN3cwpaV3F5R2k3NDlpdHJrQk5hRXlIMWJ5TnhJN0haQ0FSMjVnOXRzUUozYmVaTzNEN2ROUlc2T0dBVis0NUFaa0FPCmRibVNmVXJ1c1NmUXU1MGdkM1dMdjhiZncwYXJWWkdEUHVhUXBIRUxuS0lYZDFUZzlpa3QzWmFEU2dMQm5mclIKMFhHTmFaVk5iMUk3alpTckZJaG9ORnJwK2IzTXFFS2lPWENWeWIrYXAzbFJFRy9WL0dicmF1NnordFRKRy9FdQplRTB4TUxqbzVORW5XY25aSzBUYk1vWkJIOFU5UHJjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU1UTXhMakk0Z2p4eWR5MHpOelF6WmpSa09TMDNZamM1TFRSallUUXRZV1F3WlMweU9ESXcKTkRJMU9HSXlaVGd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0eE16RXVNamlDUEhKMwpMVE0zTkRObU5HUTVMVGRpTnprdE5HTmhOQzFoWkRCbExUSTRNakEwTWpVNFlqSmxPQzV5WkdJdWJtd3RZVzF6CkxuTmpkeTVqYkc5MVpJY0VNdzlJeVljRU01NkRISWNFTTU2REhEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWVArVStUOTFhVWNENXk2OUVReXJuYm4vRVV6QUl4R1lJLytjaGFpUlZHQnZKZGJuUUZZYk9IQWxaK0cvd1N4Ywpxa1Y5NURrWmQwUVlVVk9RUktzc0VlL1J4WUdtMGltWVpTWXQ1YUN1czFDN056RFJyQ2R3cmV3QzdUWUZ2dFQ4CnVpeWMzd1RxaHVTWVdNSjFYanpsbUlTN1g0eWZsL2lCUVc1Y2FsK1dKYzlnQ1g0cmd5SGliclM2NUVudC9NL0MKU2N6VWRnRzNLOHphWFltNkZkUjREWWFDUHhBV1ErZ3RIWlNzSE00VnNtSnM0bGpDK3JTdGJVL1Ezc2krcU9OWgp0SkJxNTFhS0RTOUQ4M0NEWWdWeGZQeitiWkJPZVZ6Ymw1U21qOGxDZlJ6dFlWZnlST2o2c0phMjFPcmdjNjdXCnNNRWYySFhuaHFyMGdCdjMxVUxHUnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "2007"
+      - "1238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:17 GMT
+      - Tue, 19 Mar 2024 17:49:36 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -891,106 +911,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 201f76b7-efe3-4922-a208-ac479a6be7b5
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3743f4d9-7b79-4ca4-ad0e-28204258b2e8&resource_type=rdb_instance
-    method: GET
-  response:
-    body: '{"ips":[],"total_count":0}'
-    headers:
-      Content-Length:
-      - "26"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:11:17 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - ca53afc7-1c67-4c90-acb8-6a13d885e066
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1236"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:11:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - b824373c-c4f1-4753-8541-4b09e94c1a80
-    status: 200 OK
-    code: 200
-    duration: ""
-- request:
-    body: ""
-    form: {}
-    headers:
-      User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
-        terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
-    method: GET
-  response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":5000000000,"type":"lssd"}}'
-    headers:
-      Content-Length:
-      - "1236"
-      Content-Security-Policy:
-      - default-src 'none'; frame-ancestors 'none'
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 18 Dec 2023 13:11:18 GMT
-      Server:
-      - Scaleway API-Gateway
-      Strict-Transport-Security:
-      - max-age=63072000
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Request-Id:
-      - 4c7cd4b6-a72b-4368-9530-61801667aab6
+      - 07ec67f7-33ca-43ce-a76e-ff83071c52ff
     status: 200 OK
     code: 200
     duration: ""
@@ -1001,23 +922,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8/upgrade
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25/upgrade
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:18 GMT
+      - Tue, 19 Mar 2024 17:49:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1025,7 +946,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f77528f1-66c8-4db9-89b8-551482e5e83e
+      - 4bf987e0-d003-4ba7-98e3-b7f3a1d89f84
     status: 200 OK
     code: 200
     duration: ""
@@ -1034,23 +955,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:19 GMT
+      - Tue, 19 Mar 2024 17:49:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1058,7 +979,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0835afc4-7c08-4d8d-ae35-095c52393779
+      - e0386ad8-4a15-4030-837c-47b9b9e176f6
     status: 200 OK
     code: 200
     duration: ""
@@ -1067,23 +988,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:11:49 GMT
+      - Tue, 19 Mar 2024 17:50:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1091,7 +1012,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f6f1b0ca-bef3-4e8c-b410-5b9fbe318f06
+      - 8b31f67a-5f5b-4bf2-bebf-57f022fab5f6
     status: 200 OK
     code: 200
     duration: ""
@@ -1100,23 +1021,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:19 GMT
+      - Tue, 19 Mar 2024 17:50:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1124,7 +1045,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e30f5b7e-f0a2-4090-8800-c80ffbf9dbad
+      - 8d28b0a9-92af-482c-a74d-2dcc9cd36633
     status: 200 OK
     code: 200
     duration: ""
@@ -1133,23 +1054,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:12:49 GMT
+      - Tue, 19 Mar 2024 17:51:07 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1157,7 +1078,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 65a954eb-f86f-40ab-8462-b0c1e8a24f35
+      - 282b694e-3f0f-4d3d-8f9e-425103116d16
     status: 200 OK
     code: 200
     duration: ""
@@ -1166,23 +1087,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:19 GMT
+      - Tue, 19 Mar 2024 17:51:37 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1190,7 +1111,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - bcb828cf-a714-4b51-a321-4def68d3a892
+      - d99040fd-e52a-4248-bded-bf2426ce0a18
     status: 200 OK
     code: 200
     duration: ""
@@ -1199,23 +1120,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:13:50 GMT
+      - Tue, 19 Mar 2024 17:52:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1223,7 +1144,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 600e397c-e7ed-447b-a946-e3a460b66ecf
+      - d523b7fa-4421-4df4-bece-261ffb1333d7
     status: 200 OK
     code: 200
     duration: ""
@@ -1232,23 +1153,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:20 GMT
+      - Tue, 19 Mar 2024 17:52:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1256,7 +1177,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8a250d83-267d-475f-9382-34fde113e3c3
+      - 8bf8f82f-f23c-48c2-a18f-36fa1456f8b0
     status: 200 OK
     code: 200
     duration: ""
@@ -1265,23 +1186,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:14:50 GMT
+      - Tue, 19 Mar 2024 17:53:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1289,7 +1210,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e1794de-3014-48db-8696-f8c61154e30d
+      - f5dadb99-371f-4e40-acb2-b04b727ae521
     status: 200 OK
     code: 200
     duration: ""
@@ -1298,23 +1219,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:21 GMT
+      - Tue, 19 Mar 2024 17:53:38 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1322,7 +1243,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 3ce9267c-93c7-4df8-bd09-d6bfd4b8e495
+      - 6a41d441-1681-41f1-891c-396a145020c9
     status: 200 OK
     code: 200
     duration: ""
@@ -1331,23 +1252,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:15:51 GMT
+      - Tue, 19 Mar 2024 17:54:08 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1355,7 +1276,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b48926e7-fe45-466d-a5cc-288394a243b7
+      - 32f1fb23-547c-4928-a201-709dacda4d1d
     status: 200 OK
     code: 200
     duration: ""
@@ -1364,23 +1285,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:21 GMT
+      - Tue, 19 Mar 2024 17:54:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1388,7 +1309,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 98845914-e1e3-4d32-ada8-8175cd95b418
+      - 74778d87-6244-469a-9018-279d48226fb1
     status: 200 OK
     code: 200
     duration: ""
@@ -1397,23 +1318,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:16:51 GMT
+      - Tue, 19 Mar 2024 17:55:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1421,7 +1342,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16a7072a-3c7f-4d38-b8ce-dbc3d2fc993f
+      - e69c75bf-8d00-44ba-b40e-89ddccce3769
     status: 200 OK
     code: 200
     duration: ""
@@ -1430,23 +1351,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:22 GMT
+      - Tue, 19 Mar 2024 17:55:39 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1454,7 +1375,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - f7f16671-4684-4c0d-a9d5-475a7764fa73
+      - e361b17c-40c3-46d5-bec0-8c6fa943a2ac
     status: 200 OK
     code: 200
     duration: ""
@@ -1463,23 +1384,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1243"
+      - "1245"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:17:52 GMT
+      - Tue, 19 Mar 2024 17:56:09 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1487,7 +1408,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 16ea614c-92eb-4f06-8546-f7495acb01ab
+      - 2c1528f0-386b-4e7d-85a4-7a445e482ebb
     status: 200 OK
     code: 200
     duration: ""
@@ -1496,23 +1417,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1236"
+      - "1238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:22 GMT
+      - Tue, 19 Mar 2024 17:56:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1520,7 +1441,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 568d592d-156a-41c1-91f1-d3f4448fc07a
+      - 6d98eb13-2717-4c74-ba27-70f1b2cda051
     status: 200 OK
     code: 200
     duration: ""
@@ -1529,23 +1450,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":5000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1236"
+      - "1238"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:22 GMT
+      - Tue, 19 Mar 2024 17:56:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1553,7 +1474,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 07591093-b42f-44ba-afba-858cf4671858
+      - 7680e11c-179d-4719-9161-1f2b4799b365
     status: 200 OK
     code: 200
     duration: ""
@@ -1564,23 +1485,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8/upgrade
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25/upgrade
     method: POST
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1244"
+      - "1246"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:22 GMT
+      - Tue, 19 Mar 2024 17:56:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1588,7 +1509,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 695eb817-4c40-4207-891c-29af97d914a1
+      - 5c7317d5-dea0-43a7-9895-2d7ab69a95e4
     status: 200 OK
     code: 200
     duration: ""
@@ -1597,23 +1518,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1244"
+      - "1246"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:23 GMT
+      - Tue, 19 Mar 2024 17:56:40 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1621,7 +1542,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 4a6494c1-fa43-4a59-b54f-1e3d81f9080a
+      - 571f2db3-5db9-44e8-8b40-a66f5555fdb1
     status: 200 OK
     code: 200
     duration: ""
@@ -1630,23 +1551,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1237"
+      - "1239"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:53 GMT
+      - Tue, 19 Mar 2024 17:57:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1654,7 +1575,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d2bc148f-0263-4684-8f36-9d6248bffcb7
+      - 4a196739-e6dc-408e-913c-d8087094d341
     status: 200 OK
     code: 200
     duration: ""
@@ -1663,23 +1584,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1237"
+      - "1239"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:53 GMT
+      - Tue, 19 Mar 2024 17:57:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1687,7 +1608,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 2d36e88e-a0e1-4021-92d9-a3cb9f892a59
+      - a1cdaab0-2911-47ca-aef9-d9ae1711c151
     status: 200 OK
     code: 200
     duration: ""
@@ -1698,23 +1619,23 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: PATCH
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1237"
+      - "1239"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:54 GMT
+      - Tue, 19 Mar 2024 17:57:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1722,7 +1643,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8cbc4584-14e5-4d09-8aba-c3b5996317ed
+      - 0174166a-5c49-4e1c-ba6d-5018032b49a7
     status: 200 OK
     code: 200
     duration: ""
@@ -1731,23 +1652,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1237"
+      - "1239"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:54 GMT
+      - Tue, 19 Mar 2024 17:57:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1755,7 +1676,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ee48114f-e165-4966-9a1b-8dec6ba2a9ba
+      - c85386ec-1d0f-4e3b-aeec-b3081529a6a1
     status: 200 OK
     code: 200
     duration: ""
@@ -1764,23 +1685,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25/certificate
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWnNVMERIOU1ZaFpGRXlpN0pSckJNeVlIczh3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR4TXpFdU1qZ3dIaGNOCk1qTXhNakU0TVRNeE1EVXhXaGNOTXpNeE1qRTFNVE14TURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqRXpNUzR5T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5uZ2RpMzhobXpQd0hNU1NadEY2QTBreDloS1BXbFdUWDMxamdRcVVIY2h6UU5IUUlHMkVZTysKNVFsNStSOWZhVUxBaGZMdUUyT2x6d2hFZVZ0R1pjanBXTndnWXZrcjJOQXh3amlIQVNrOE1tZ2ZlZkFPSVN3cwpaV3F5R2k3NDlpdHJrQk5hRXlIMWJ5TnhJN0haQ0FSMjVnOXRzUUozYmVaTzNEN2ROUlc2T0dBVis0NUFaa0FPCmRibVNmVXJ1c1NmUXU1MGdkM1dMdjhiZncwYXJWWkdEUHVhUXBIRUxuS0lYZDFUZzlpa3QzWmFEU2dMQm5mclIKMFhHTmFaVk5iMUk3alpTckZJaG9ORnJwK2IzTXFFS2lPWENWeWIrYXAzbFJFRy9WL0dicmF1NnordFRKRy9FdQplRTB4TUxqbzVORW5XY25aSzBUYk1vWkJIOFU5UHJjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU1UTXhMakk0Z2p4eWR5MHpOelF6WmpSa09TMDNZamM1TFRSallUUXRZV1F3WlMweU9ESXcKTkRJMU9HSXlaVGd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0eE16RXVNamlDUEhKMwpMVE0zTkRObU5HUTVMVGRpTnprdE5HTmhOQzFoWkRCbExUSTRNakEwTWpVNFlqSmxPQzV5WkdJdWJtd3RZVzF6CkxuTmpkeTVqYkc5MVpJY0VNdzlJeVljRU01NkRISWNFTTU2REhEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWVArVStUOTFhVWNENXk2OUVReXJuYm4vRVV6QUl4R1lJLytjaGFpUlZHQnZKZGJuUUZZYk9IQWxaK0cvd1N4Ywpxa1Y5NURrWmQwUVlVVk9RUktzc0VlL1J4WUdtMGltWVpTWXQ1YUN1czFDN056RFJyQ2R3cmV3QzdUWUZ2dFQ4CnVpeWMzd1RxaHVTWVdNSjFYanpsbUlTN1g0eWZsL2lCUVc1Y2FsK1dKYzlnQ1g0cmd5SGliclM2NUVudC9NL0MKU2N6VWRnRzNLOHphWFltNkZkUjREWWFDUHhBV1ErZ3RIWlNzSE00VnNtSnM0bGpDK3JTdGJVL1Ezc2krcU9OWgp0SkJxNTFhS0RTOUQ4M0NEWWdWeGZQeitiWkJPZVZ6Ymw1U21qOGxDZlJ6dFlWZnlST2o2c0phMjFPcmdjNjdXCnNNRWYySFhuaHFyMGdCdjMxVUxHUnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTVBpMzZrZnVyM3prdEZPTElDcEQ5OVZvK1g0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TWprdU1UZzRNQjRYCkRUSTBNRE14T1RFM05EZzFNbG9YRFRNME1ETXhOekUzTkRnMU1sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNamt1TVRnNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdwOExQZkkxN0lPSEhOT1NTS0E3cWZIcU5mNjYxU200TDVEcmV1eXFMamYzbStSOTM2d1IKU3hENmorTTVTS0lxdXFacWp0cXJmVnpTdnNoR3A0cWI3VUxGSTdGUTNRT2l5Z2loNHJtekc0TTUxcFZ5cVlEUAp1b0NzNXhXWmdWalM3UVFMREdzMXVvNEVVTWRBTk90U3g4VytjRE5BbmtrcUJpYWd3WE9TbCtyOFNTalF2dW1yClQzdEUzUFlmeEJvV3JtL1lQa2pHeWN1NU5wMTFQVHJKcWNZcjZmWXVoUmRVMElMWFFLMW8wMk8ybkhPRWtzNUYKa3pnTEM4UFZ1cTBKaEsvK0Y3ZUxTMWtINDN6eWdFV2ExZlBzb2tCUmdBcGhPYmk5NlJYRkdERjVBK0pmZXJPcwoxVVk4cW5vQ1ZjWERZNHZsdVlrdFJwTnZjMEg2MCtYWENRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9DNHhNamt1TVRnNGdqeHlkeTFoTjJFd016RXhPUzB5TURjeExUUTJNV1F0T0dKbE5DMHoKWkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzTFdGdGN5NXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9DNHhNamt1TVRnNApnanh5ZHkxaE4yRXdNekV4T1MweU1EY3hMVFEyTVdRdE9HSmxOQzB6WkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzCkxXRnRjeTV6WTNjdVkyeHZkV1NIQkRPZXBUMkhCRE9lZ2J5SEJET2VnYnd3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFEZFF2eHdtVTkzWjRXdFVFeTU2UEhidTlrN2NrY0ErWFI1OXlyUUJOc0JyQnhieFlhSm40dlVyRDkwNgpaVUFnN3Y2N0RqYWlUWWprcDl6SnZEY0ZQRUtyZXVieFJndlZud1BsSE9Pdm5saVp3d3VhV3BVWldlMmc0UEh1Ck9qam9PRzBvcFMyUGJVblB5b0pEb3ZsaFk2Vk1PRXpGaEhmS29EYTI3NEV2K0xZYXJPMzltN0F0WFYwMHNLdmUKdGk2ZXUvSEtzMWpJK05vbHJHSm9LQW93dXhSTUtDMXAzNnFqSVBHUmdNREoycEdzWmRDYkpqajZ0N09IRXhyTQorTjFqa0VqUGNkQ1N3aGc5dUgrczZkQXZaQW1XKzRtcTV3c2ZpMlBHb2pCSUtUNVh0NTE5OTNZQTJtNUlxM3N6Cnh6SExYVnczUjVKNHBzdUYwOGFLQWt4eG9OUT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "2007"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:54 GMT
+      - Tue, 19 Mar 2024 17:57:11 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1788,7 +1709,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - a3e91dd6-5b50-4fe2-b91f-a9782f8bf8ed
+      - b5b35916-a5c8-4533-ad18-b74b3e2cace0
     status: 200 OK
     code: 200
     duration: ""
@@ -1797,23 +1718,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3743f4d9-7b79-4ca4-ad0e-28204258b2e8&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "26"
+      - "1239"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:54 GMT
+      - Tue, 19 Mar 2024 17:57:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1821,7 +1742,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e07d91b7-cab7-4699-9eb9-0761a91c2611
+      - c3ac6b46-974a-40ef-85ef-762e7f249cf2
     status: 200 OK
     code: 200
     duration: ""
@@ -1830,23 +1751,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1237"
+      - "1239"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:54 GMT
+      - Tue, 19 Mar 2024 17:57:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1854,7 +1775,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - da53372f-d874-4d1a-9f5b-be29ec18d952
+      - 3bc8b445-94f5-40ae-adf0-b300e11a9617
     status: 200 OK
     code: 200
     duration: ""
@@ -1863,23 +1784,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25/certificate
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTVBpMzZrZnVyM3prdEZPTElDcEQ5OVZvK1g0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TWprdU1UZzRNQjRYCkRUSTBNRE14T1RFM05EZzFNbG9YRFRNME1ETXhOekUzTkRnMU1sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNamt1TVRnNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdwOExQZkkxN0lPSEhOT1NTS0E3cWZIcU5mNjYxU200TDVEcmV1eXFMamYzbStSOTM2d1IKU3hENmorTTVTS0lxdXFacWp0cXJmVnpTdnNoR3A0cWI3VUxGSTdGUTNRT2l5Z2loNHJtekc0TTUxcFZ5cVlEUAp1b0NzNXhXWmdWalM3UVFMREdzMXVvNEVVTWRBTk90U3g4VytjRE5BbmtrcUJpYWd3WE9TbCtyOFNTalF2dW1yClQzdEUzUFlmeEJvV3JtL1lQa2pHeWN1NU5wMTFQVHJKcWNZcjZmWXVoUmRVMElMWFFLMW8wMk8ybkhPRWtzNUYKa3pnTEM4UFZ1cTBKaEsvK0Y3ZUxTMWtINDN6eWdFV2ExZlBzb2tCUmdBcGhPYmk5NlJYRkdERjVBK0pmZXJPcwoxVVk4cW5vQ1ZjWERZNHZsdVlrdFJwTnZjMEg2MCtYWENRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9DNHhNamt1TVRnNGdqeHlkeTFoTjJFd016RXhPUzB5TURjeExUUTJNV1F0T0dKbE5DMHoKWkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzTFdGdGN5NXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9DNHhNamt1TVRnNApnanh5ZHkxaE4yRXdNekV4T1MweU1EY3hMVFEyTVdRdE9HSmxOQzB6WkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzCkxXRnRjeTV6WTNjdVkyeHZkV1NIQkRPZXBUMkhCRE9lZ2J5SEJET2VnYnd3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFEZFF2eHdtVTkzWjRXdFVFeTU2UEhidTlrN2NrY0ErWFI1OXlyUUJOc0JyQnhieFlhSm40dlVyRDkwNgpaVUFnN3Y2N0RqYWlUWWprcDl6SnZEY0ZQRUtyZXVieFJndlZud1BsSE9Pdm5saVp3d3VhV3BVWldlMmc0UEh1Ck9qam9PRzBvcFMyUGJVblB5b0pEb3ZsaFk2Vk1PRXpGaEhmS29EYTI3NEV2K0xZYXJPMzltN0F0WFYwMHNLdmUKdGk2ZXUvSEtzMWpJK05vbHJHSm9LQW93dXhSTUtDMXAzNnFqSVBHUmdNREoycEdzWmRDYkpqajZ0N09IRXhyTQorTjFqa0VqUGNkQ1N3aGc5dUgrczZkQXZaQW1XKzRtcTV3c2ZpMlBHb2pCSUtUNVh0NTE5OTNZQTJtNUlxM3N6Cnh6SExYVnczUjVKNHBzdUYwOGFLQWt4eG9OUT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "1237"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:55 GMT
+      - Tue, 19 Mar 2024 17:57:12 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1887,7 +1808,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 8da930cb-3a50-45b7-a34e-8ad0ee89e325
+      - c3524299-b32a-4a11-b1cd-d43dafa4bb53
     status: 200 OK
     code: 200
     duration: ""
@@ -1896,23 +1817,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8/certificate
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQvRENDQXVTZ0F3SUJBZ0lVWnNVMERIOU1ZaFpGRXlpN0pSckJNeVlIczh3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dERUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RmpBVUJnTlZCQU1NRFRVeExqRTFPQzR4TXpFdU1qZ3dIaGNOCk1qTXhNakU0TVRNeE1EVXhXaGNOTXpNeE1qRTFNVE14TURVeFdqQllNUXN3Q1FZRFZRUUdFd0pHVWpFT01Bd0cKQTFVRUNBd0ZVR0Z5YVhNeERqQU1CZ05WQkFjTUJWQmhjbWx6TVJFd0R3WURWUVFLREFoVFkyRnNaWGRoZVRFVwpNQlFHQTFVRUF3d05OVEV1TVRVNExqRXpNUzR5T0RDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDCkFRb0NnZ0VCQU5uZ2RpMzhobXpQd0hNU1NadEY2QTBreDloS1BXbFdUWDMxamdRcVVIY2h6UU5IUUlHMkVZTysKNVFsNStSOWZhVUxBaGZMdUUyT2x6d2hFZVZ0R1pjanBXTndnWXZrcjJOQXh3amlIQVNrOE1tZ2ZlZkFPSVN3cwpaV3F5R2k3NDlpdHJrQk5hRXlIMWJ5TnhJN0haQ0FSMjVnOXRzUUozYmVaTzNEN2ROUlc2T0dBVis0NUFaa0FPCmRibVNmVXJ1c1NmUXU1MGdkM1dMdjhiZncwYXJWWkdEUHVhUXBIRUxuS0lYZDFUZzlpa3QzWmFEU2dMQm5mclIKMFhHTmFaVk5iMUk3alpTckZJaG9ORnJwK2IzTXFFS2lPWENWeWIrYXAzbFJFRy9WL0dicmF1NnordFRKRy9FdQplRTB4TUxqbzVORW5XY25aSzBUYk1vWkJIOFU5UHJjQ0F3RUFBYU9CdlRDQnVqQ0J0d1lEVlIwUkJJR3ZNSUdzCmdnMDFNUzR4TlRndU1UTXhMakk0Z2p4eWR5MHpOelF6WmpSa09TMDNZamM1TFRSallUUXRZV1F3WlMweU9ESXcKTkRJMU9HSXlaVGd1Y21SaUxtNXNMV0Z0Y3k1elkzY3VZMnh2ZFdTQ0RUVXhMakUxT0M0eE16RXVNamlDUEhKMwpMVE0zTkRObU5HUTVMVGRpTnprdE5HTmhOQzFoWkRCbExUSTRNakEwTWpVNFlqSmxPQzV5WkdJdWJtd3RZVzF6CkxuTmpkeTVqYkc5MVpJY0VNdzlJeVljRU01NkRISWNFTTU2REhEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUEKWVArVStUOTFhVWNENXk2OUVReXJuYm4vRVV6QUl4R1lJLytjaGFpUlZHQnZKZGJuUUZZYk9IQWxaK0cvd1N4Ywpxa1Y5NURrWmQwUVlVVk9RUktzc0VlL1J4WUdtMGltWVpTWXQ1YUN1czFDN056RFJyQ2R3cmV3QzdUWUZ2dFQ4CnVpeWMzd1RxaHVTWVdNSjFYanpsbUlTN1g0eWZsL2lCUVc1Y2FsK1dKYzlnQ1g0cmd5SGliclM2NUVudC9NL0MKU2N6VWRnRzNLOHphWFltNkZkUjREWWFDUHhBV1ErZ3RIWlNzSE00VnNtSnM0bGpDK3JTdGJVL1Ezc2krcU9OWgp0SkJxNTFhS0RTOUQ4M0NEWWdWeGZQeitiWkJPZVZ6Ymw1U21qOGxDZlJ6dFlWZnlST2o2c0phMjFPcmdjNjdXCnNNRWYySFhuaHFyMGdCdjMxVUxHUnc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "2007"
+      - "1239"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:55 GMT
+      - Tue, 19 Mar 2024 17:57:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1920,7 +1841,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 0eb981ef-46e4-4065-acbf-2ad28108b245
+      - a8d3a4ad-cc14-4060-8be1-03b117c402fc
     status: 200 OK
     code: 200
     duration: ""
@@ -1929,23 +1850,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/ipam/v1/regions/nl-ams/ips?is_ipv6=false&order_by=created_at_desc&page=1&resource_id=3743f4d9-7b79-4ca4-ad0e-28204258b2e8&resource_type=rdb_instance
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25/certificate
     method: GET
   response:
-    body: '{"ips":[],"total_count":0}'
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTVBpMzZrZnVyM3prdEZPTElDcEQ5OVZvK1g0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TWprdU1UZzRNQjRYCkRUSTBNRE14T1RFM05EZzFNbG9YRFRNME1ETXhOekUzTkRnMU1sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNamt1TVRnNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdwOExQZkkxN0lPSEhOT1NTS0E3cWZIcU5mNjYxU200TDVEcmV1eXFMamYzbStSOTM2d1IKU3hENmorTTVTS0lxdXFacWp0cXJmVnpTdnNoR3A0cWI3VUxGSTdGUTNRT2l5Z2loNHJtekc0TTUxcFZ5cVlEUAp1b0NzNXhXWmdWalM3UVFMREdzMXVvNEVVTWRBTk90U3g4VytjRE5BbmtrcUJpYWd3WE9TbCtyOFNTalF2dW1yClQzdEUzUFlmeEJvV3JtL1lQa2pHeWN1NU5wMTFQVHJKcWNZcjZmWXVoUmRVMElMWFFLMW8wMk8ybkhPRWtzNUYKa3pnTEM4UFZ1cTBKaEsvK0Y3ZUxTMWtINDN6eWdFV2ExZlBzb2tCUmdBcGhPYmk5NlJYRkdERjVBK0pmZXJPcwoxVVk4cW5vQ1ZjWERZNHZsdVlrdFJwTnZjMEg2MCtYWENRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9DNHhNamt1TVRnNGdqeHlkeTFoTjJFd016RXhPUzB5TURjeExUUTJNV1F0T0dKbE5DMHoKWkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzTFdGdGN5NXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9DNHhNamt1TVRnNApnanh5ZHkxaE4yRXdNekV4T1MweU1EY3hMVFEyTVdRdE9HSmxOQzB6WkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzCkxXRnRjeTV6WTNjdVkyeHZkV1NIQkRPZXBUMkhCRE9lZ2J5SEJET2VnYnd3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFEZFF2eHdtVTkzWjRXdFVFeTU2UEhidTlrN2NrY0ErWFI1OXlyUUJOc0JyQnhieFlhSm40dlVyRDkwNgpaVUFnN3Y2N0RqYWlUWWprcDl6SnZEY0ZQRUtyZXVieFJndlZud1BsSE9Pdm5saVp3d3VhV3BVWldlMmc0UEh1Ck9qam9PRzBvcFMyUGJVblB5b0pEb3ZsaFk2Vk1PRXpGaEhmS29EYTI3NEV2K0xZYXJPMzltN0F0WFYwMHNLdmUKdGk2ZXUvSEtzMWpJK05vbHJHSm9LQW93dXhSTUtDMXAzNnFqSVBHUmdNREoycEdzWmRDYkpqajZ0N09IRXhyTQorTjFqa0VqUGNkQ1N3aGc5dUgrczZkQXZaQW1XKzRtcTV3c2ZpMlBHb2pCSUtUNVh0NTE5OTNZQTJtNUlxM3N6Cnh6SExYVnczUjVKNHBzdUYwOGFLQWt4eG9OUT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
     headers:
       Content-Length:
-      - "26"
+      - "2011"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:55 GMT
+      - Tue, 19 Mar 2024 17:57:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1953,7 +1874,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 9e5220c1-a4ee-4224-a516-47d30563484d
+      - a70f8de2-432e-4685-9a18-a2c97d05c548
     status: 200 OK
     code: 200
     duration: ""
@@ -1962,23 +1883,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
     headers:
       Content-Length:
-      - "1237"
+      - "1239"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:55 GMT
+      - Tue, 19 Mar 2024 17:57:13 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -1986,7 +1907,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - 77e250aa-bbe5-4e1a-85aa-b42b7497fd76
+      - c249f58d-7111-479a-8e67-55b7895d6965
     status: 200 OK
     code: 200
     duration: ""
@@ -1995,23 +1916,1382 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1239"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 17:57:13 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 346a04d8-b930-4dae-b50d-17be6efc121f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"node_type":"db-dev-m"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25/upgrade
+    method: POST
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 17:57:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - cba8368a-dc3b-4e89-b1f3-840f22296901
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 17:57:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 8f00db6b-65ae-47d3-aff2-f425920b7d75
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 17:57:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d3beb6f7-0520-4d62-a9de-5cfd6d68bc2f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 17:58:14 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - ad11fc4c-a753-442f-88a3-8f940c058c3f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 17:58:44 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - da4017d8-0466-43d5-aba7-887c29ba27e7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 17:59:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 485a5141-aa0a-427d-b6e9-94c2cc82870f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 17:59:45 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 45c3e32b-3bab-4a22-98a0-40e9b4e52703
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:00:15 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 36a96e7c-6888-456d-8bd0-078d692c9896
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:00:46 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 62ae0054-4a40-48a8-a8b6-a47fb8ba82a4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:01:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7df15a06-8496-4b38-82bd-d9442efbf53d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:01:46 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 28f6109d-e006-4f63-a5bf-7fa453e6eea6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:02:16 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - be4b9aa3-6b13-497a-bc97-2a91f9403de9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:02:46 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 058f42df-8f81-472c-b68a-0278441911cc
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:03:17 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 22dd0ef0-4ed2-4fd5-929e-e4fca2586aa2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1239"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:03:47 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c945dac5-9416-4395-8ca5-c13e1ae72173
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    headers:
+      Content-Length:
+      - "1239"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:03:47 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - eb18696e-4d29-4fd6-9837-304b616950a8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"volume_type":"lssd"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25/upgrade
+    method: POST
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:03:48 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c09f48fb-5ff6-4f0c-8fb9-c005fcdd4c4f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:03:48 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e1382956-6642-49f1-b480-5a31cba8bfc0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:04:18 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d0579797-3632-4e0e-9e51-e8af6506fd76
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:04:48 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d5230722-5fbd-432b-9783-84f1790dc3a8
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:05:18 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 23f15a6d-db6f-41a5-af85-4a320245013a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:05:49 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4650d31a-230b-4a72-8017-f2c768ed8a5c
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:06:19 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 07b93ce8-1bfa-4d48-86b2-330ea7606649
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:06:49 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 5937dd03-70f6-4f9a-b406-a6342d5b46c0
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:07:19 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 09160fb5-d753-4eeb-8949-ce1c116ad7b4
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:07:49 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 12e8f99b-f6f4-4b91-b4a1-dfe16b8bbf7d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:08:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 47c7019a-ece4-4583-b43d-b1f445d0f1d2
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:08:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - e9294db5-71f9-4fb4-9414-657273aff0e6
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:09:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge02)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 4b5885f8-219c-43f2-979f-f9b9ae5d07d7
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:09:50 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fb33e707-afe9-420c-b401-94c428cd1b59
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"initializing","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1246"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:10:20 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 369a5353-16fc-48a8-b433-beb7cccea34a
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1239"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:10:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - c3ebb92b-802f-47e9-8b3e-a4e76a379f6e
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1239"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:10:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - b0cab6a3-e335-4be1-b83f-0f8b01310713
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: PATCH
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1239"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:10:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7a082ddb-4865-477b-8781-47305fd23384
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1239"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:10:51 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 7bc4327b-7484-44ac-9668-9290caddf08f
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTVBpMzZrZnVyM3prdEZPTElDcEQ5OVZvK1g0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TWprdU1UZzRNQjRYCkRUSTBNRE14T1RFM05EZzFNbG9YRFRNME1ETXhOekUzTkRnMU1sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNamt1TVRnNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdwOExQZkkxN0lPSEhOT1NTS0E3cWZIcU5mNjYxU200TDVEcmV1eXFMamYzbStSOTM2d1IKU3hENmorTTVTS0lxdXFacWp0cXJmVnpTdnNoR3A0cWI3VUxGSTdGUTNRT2l5Z2loNHJtekc0TTUxcFZ5cVlEUAp1b0NzNXhXWmdWalM3UVFMREdzMXVvNEVVTWRBTk90U3g4VytjRE5BbmtrcUJpYWd3WE9TbCtyOFNTalF2dW1yClQzdEUzUFlmeEJvV3JtL1lQa2pHeWN1NU5wMTFQVHJKcWNZcjZmWXVoUmRVMElMWFFLMW8wMk8ybkhPRWtzNUYKa3pnTEM4UFZ1cTBKaEsvK0Y3ZUxTMWtINDN6eWdFV2ExZlBzb2tCUmdBcGhPYmk5NlJYRkdERjVBK0pmZXJPcwoxVVk4cW5vQ1ZjWERZNHZsdVlrdFJwTnZjMEg2MCtYWENRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9DNHhNamt1TVRnNGdqeHlkeTFoTjJFd016RXhPUzB5TURjeExUUTJNV1F0T0dKbE5DMHoKWkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzTFdGdGN5NXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9DNHhNamt1TVRnNApnanh5ZHkxaE4yRXdNekV4T1MweU1EY3hMVFEyTVdRdE9HSmxOQzB6WkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzCkxXRnRjeTV6WTNjdVkyeHZkV1NIQkRPZXBUMkhCRE9lZ2J5SEJET2VnYnd3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFEZFF2eHdtVTkzWjRXdFVFeTU2UEhidTlrN2NrY0ErWFI1OXlyUUJOc0JyQnhieFlhSm40dlVyRDkwNgpaVUFnN3Y2N0RqYWlUWWprcDl6SnZEY0ZQRUtyZXVieFJndlZud1BsSE9Pdm5saVp3d3VhV3BVWldlMmc0UEh1Ck9qam9PRzBvcFMyUGJVblB5b0pEb3ZsaFk2Vk1PRXpGaEhmS29EYTI3NEV2K0xZYXJPMzltN0F0WFYwMHNLdmUKdGk2ZXUvSEtzMWpJK05vbHJHSm9LQW93dXhSTUtDMXAzNnFqSVBHUmdNREoycEdzWmRDYkpqajZ0N09IRXhyTQorTjFqa0VqUGNkQ1N3aGc5dUgrczZkQXZaQW1XKzRtcTV3c2ZpMlBHb2pCSUtUNVh0NTE5OTNZQTJtNUlxM3N6Cnh6SExYVnczUjVKNHBzdUYwOGFLQWt4eG9OUT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:10:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - fcb6d88a-0ef9-47d4-a2a9-30ebaefd6a6d
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1239"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:10:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - a860d966-44e9-448b-b873-45201d5614c9
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1239"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:10:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - 0600827b-e961-434a-aade-f4be0e857be3
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25/certificate
+    method: GET
+  response:
+    body: '{"content":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVBRENDQXVpZ0F3SUJBZ0lVTVBpMzZrZnVyM3prdEZPTElDcEQ5OVZvK1g0d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1dURUxNQWtHQTFVRUJoTUNSbEl4RGpBTUJnTlZCQWdNQlZCaGNtbHpNUTR3REFZRFZRUUhEQVZRWVhKcApjekVSTUE4R0ExVUVDZ3dJVTJOaGJHVjNZWGt4RnpBVkJnTlZCQU1NRGpVeExqRTFPQzR4TWprdU1UZzRNQjRYCkRUSTBNRE14T1RFM05EZzFNbG9YRFRNME1ETXhOekUzTkRnMU1sb3dXVEVMTUFrR0ExVUVCaE1DUmxJeERqQU0KQmdOVkJBZ01CVkJoY21sek1RNHdEQVlEVlFRSERBVlFZWEpwY3pFUk1BOEdBMVVFQ2d3SVUyTmhiR1YzWVhreApGekFWQmdOVkJBTU1EalV4TGpFMU9DNHhNamt1TVRnNE1JSUJJakFOQmdrcWhraUc5dzBCQVFFRkFBT0NBUThBCk1JSUJDZ0tDQVFFQXdwOExQZkkxN0lPSEhOT1NTS0E3cWZIcU5mNjYxU200TDVEcmV1eXFMamYzbStSOTM2d1IKU3hENmorTTVTS0lxdXFacWp0cXJmVnpTdnNoR3A0cWI3VUxGSTdGUTNRT2l5Z2loNHJtekc0TTUxcFZ5cVlEUAp1b0NzNXhXWmdWalM3UVFMREdzMXVvNEVVTWRBTk90U3g4VytjRE5BbmtrcUJpYWd3WE9TbCtyOFNTalF2dW1yClQzdEUzUFlmeEJvV3JtL1lQa2pHeWN1NU5wMTFQVHJKcWNZcjZmWXVoUmRVMElMWFFLMW8wMk8ybkhPRWtzNUYKa3pnTEM4UFZ1cTBKaEsvK0Y3ZUxTMWtINDN6eWdFV2ExZlBzb2tCUmdBcGhPYmk5NlJYRkdERjVBK0pmZXJPcwoxVVk4cW5vQ1ZjWERZNHZsdVlrdFJwTnZjMEg2MCtYWENRSURBUUFCbzRHL01JRzhNSUc1QmdOVkhSRUVnYkV3CmdhNkNEalV4TGpFMU9DNHhNamt1TVRnNGdqeHlkeTFoTjJFd016RXhPUzB5TURjeExUUTJNV1F0T0dKbE5DMHoKWkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzTFdGdGN5NXpZM2N1WTJ4dmRXU0NEalV4TGpFMU9DNHhNamt1TVRnNApnanh5ZHkxaE4yRXdNekV4T1MweU1EY3hMVFEyTVdRdE9HSmxOQzB6WkRFNU5tSmhaVEZqTWpVdWNtUmlMbTVzCkxXRnRjeTV6WTNjdVkyeHZkV1NIQkRPZXBUMkhCRE9lZ2J5SEJET2VnYnd3RFFZSktvWklodmNOQVFFTEJRQUQKZ2dFQkFEZFF2eHdtVTkzWjRXdFVFeTU2UEhidTlrN2NrY0ErWFI1OXlyUUJOc0JyQnhieFlhSm40dlVyRDkwNgpaVUFnN3Y2N0RqYWlUWWprcDl6SnZEY0ZQRUtyZXVieFJndlZud1BsSE9Pdm5saVp3d3VhV3BVWldlMmc0UEh1Ck9qam9PRzBvcFMyUGJVblB5b0pEb3ZsaFk2Vk1PRXpGaEhmS29EYTI3NEV2K0xZYXJPMzltN0F0WFYwMHNLdmUKdGk2ZXUvSEtzMWpJK05vbHJHSm9LQW93dXhSTUtDMXAzNnFqSVBHUmdNREoycEdzWmRDYkpqajZ0N09IRXhyTQorTjFqa0VqUGNkQ1N3aGc5dUgrczZkQXZaQW1XKzRtcTV3c2ZpMlBHb2pCSUtUNVh0NTE5OTNZQTJtNUlxM3N6Cnh6SExYVnczUjVKNHBzdUYwOGFLQWt4eG9OUT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=","content_type":"application/x-pem-file","name":"ssl_certificate"}'
+    headers:
+      Content-Length:
+      - "2011"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:10:52 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - d2ab9c68-576d-41d7-8ad4-5b33c4dbb403
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
+    method: GET
+  response:
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"ready","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
+    headers:
+      Content-Length:
+      - "1239"
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 19 Mar 2024 18:10:53 GMT
+      Server:
+      - Scaleway API Gateway (fr-par-3;edge01)
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Request-Id:
+      - de051fd4-340c-4fc3-a797-a77e9ccc96ec
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      User-Agent:
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
+        terraform/terraform-tests
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: DELETE
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1240"
+      - "1242"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:55 GMT
+      - Tue, 19 Mar 2024 18:10:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2019,7 +3299,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - b96a3780-1024-4fcd-b2e3-d12ca496f6cf
+      - 40fbda47-88da-44ad-9f0d-5a5e3f368cca
     status: 200 OK
     code: 200
     duration: ""
@@ -2028,23 +3308,23 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2023-12-18T13:07:42.575150Z","endpoint":{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765},"endpoints":[{"id":"1fd5518c-44da-4346-a36d-c70022d129fa","ip":"51.158.131.28","load_balancer":{},"name":null,"port":20765}],"engine":"PostgreSQL-15","id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-s","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"bssd","size":10000000000,"type":"bssd"}}'
+    body: '{"backup_same_region":false,"backup_schedule":{"disabled":true,"frequency":24,"next_run_at":null,"retention":7},"created_at":"2024-03-19T17:46:02.620509Z","endpoint":{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378},"endpoints":[{"id":"bb95d546-6c92-4d57-a0f4-5e61722b197a","ip":"51.158.129.188","load_balancer":{},"name":null,"port":26378}],"engine":"PostgreSQL-15","id":"a7a03119-2071-461d-8be4-3d196bae1c25","init_settings":[],"is_ha_cluster":false,"logs_policy":{"max_age_retention":30,"total_disk_retention":null},"maintenances":[],"name":"test-rdb-instance-volume","node_type":"db-dev-m","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","read_replicas":[],"region":"nl-ams","settings":[{"name":"effective_cache_size","value":"1300"},{"name":"maintenance_work_mem","value":"150"},{"name":"max_connections","value":"100"},{"name":"max_parallel_workers","value":"0"},{"name":"max_parallel_workers_per_gather","value":"0"},{"name":"work_mem","value":"4"}],"status":"deleting","tags":["terraform-test","scaleway_rdb_instance","volume"],"upgradable_version":[],"volume":{"class":"lssd","size":25000000000,"type":"lssd"}}'
     headers:
       Content-Length:
-      - "1240"
+      - "1242"
       Content-Security-Policy:
       - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:18:56 GMT
+      - Tue, 19 Mar 2024 18:10:53 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2052,7 +3332,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - e6f643d0-299d-40d4-a4cc-f16657e3104d
+      - ecb63908-5b47-4e3c-8d58-9c883e35cf1c
     status: 200 OK
     code: 200
     duration: ""
@@ -2061,12 +3341,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"a7a03119-2071-461d-8be4-3d196bae1c25","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2075,9 +3355,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:26 GMT
+      - Tue, 19 Mar 2024 18:11:24 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge01)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2085,7 +3365,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - ea8154d4-efea-41b2-a62b-452bd0d35760
+      - ac75042c-4787-4c76-befc-8d3f7c4158c6
     status: 404 Not Found
     code: 404
     duration: ""
@@ -2094,12 +3374,12 @@ interactions:
     form: {}
     headers:
       User-Agent:
-      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.20.4; linux; amd64) terraform-provider/develop
+      - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.0; linux; amd64) terraform-provider/develop
         terraform/terraform-tests
-    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/3743f4d9-7b79-4ca4-ad0e-28204258b2e8
+    url: https://api.scaleway.com/rdb/v1/regions/nl-ams/instances/a7a03119-2071-461d-8be4-3d196bae1c25
     method: GET
   response:
-    body: '{"message":"resource is not found","resource":"instance","resource_id":"3743f4d9-7b79-4ca4-ad0e-28204258b2e8","type":"not_found"}'
+    body: '{"message":"resource is not found","resource":"instance","resource_id":"a7a03119-2071-461d-8be4-3d196bae1c25","type":"not_found"}'
     headers:
       Content-Length:
       - "129"
@@ -2108,9 +3388,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Mon, 18 Dec 2023 13:19:26 GMT
+      - Tue, 19 Mar 2024 18:11:24 GMT
       Server:
-      - Scaleway API-Gateway
+      - Scaleway API Gateway (fr-par-3;edge02)
       Strict-Transport-Security:
       - max-age=63072000
       X-Content-Type-Options:
@@ -2118,7 +3398,7 @@ interactions:
       X-Frame-Options:
       - DENY
       X-Request-Id:
-      - d77cb766-fb5c-45c1-a934-79d8ff552fed
+      - d7e6d72f-517c-4104-afb3-6d67904907b6
     status: 404 Not Found
     code: 404
     duration: ""


### PR DESCRIPTION
I noticed a case that did not occur in the tests but there was a bug when changing the volume type from `bssd` to `lssd` as the `volume_size_in_gb` attribute goes from the given value to 0 (the volume size depends on the node type). And since we carry out the upgrades starting from the volume and ending with the node type, that resulted in the API rejecting the update of the `volume_type` because the `node_type` should be updated first.

To fix the issue, this PR adds the comparing of the actual and the wanted storage capacities to see if the node_type has to be updated first.