### PR TITLE
fix(instance_server): ignore enable_ipv6 with routed_ip disabled

### DIFF
--- a/docs/resources/instance_server.md
+++ b/docs/resources/instance_server.md
@@ -210,7 +210,7 @@ attached to the server. Updates to this field will trigger a stop/start of the s
 
 ~> **Important:** If this field contains local volumes, you have to first detach them, in one apply, and then delete the volume in another apply.
 
-- `enable_ipv6` - (Defaults to `false`) Determines if IPv6 is enabled for the server.
+- `enable_ipv6` - (Defaults to `false`) Determines if IPv6 is enabled for the server. Useful only with `routed_ip_enabled` as false, otherwise ipv6 is always supported.
 
 - `ip_id` - (Optional) The ID of the reserved IP that is attached to the server.
 
@@ -220,7 +220,7 @@ attached to the server. Updates to this field will trigger a stop/start of the s
 
 - `enable_dynamic_ip` - (Defaults to `false`) If true a dynamic IP will be attached to the server.
 
-- `routed_ip_enabled` - (Defaults to `false`) If true, the server will support routed ips only. Changing it to true will migrate the server and its IP to routed type.
+- `routed_ip_enabled` - (Defaults to `true`) If true, the server will support routed ips only. Changing it to true will migrate the server and its IP to routed type.
 
 ~> **Important:** Enabling routed ip will restart the server
 

--- a/internal/services/instance/server.go
+++ b/internal/services/instance/server.go
@@ -171,7 +171,7 @@ func ResourceServer() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 				Description: "Determines if IPv6 is enabled for the server",
-				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
 					// routed_ip enabled servers already support enable_ipv6. Let's ignore this argument if it is.
 					routedIPEnabled := types.GetBool(d, "routed_ip_enabled")
 					if routedIPEnabled == nil || routedIPEnabled.(bool) {

--- a/internal/services/instance/server.go
+++ b/internal/services/instance/server.go
@@ -171,6 +171,15 @@ func ResourceServer() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 				Description: "Determines if IPv6 is enabled for the server",
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					// routed_ip enabled servers already support enable_ipv6. Let's ignore this argument if it is.
+					routedIPEnabled := types.GetBool(d, "routed_ip_enabled")
+					if routedIPEnabled == nil || routedIPEnabled.(bool) {
+						return true
+					}
+
+					return false
+				},
 			},
 			"private_ip": {
 				Type:        schema.TypeString,

--- a/internal/services/instance/server_test.go
+++ b/internal/services/instance/server_test.go
@@ -716,6 +716,7 @@ func TestAccServer_Ipv6(t *testing.T) {
 						image = "ubuntu_focal"
 		  				type  = "DEV1-S"
 		  				enable_ipv6 = true
+						routed_ip_enabled = false
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
@@ -731,6 +732,7 @@ func TestAccServer_Ipv6(t *testing.T) {
 						image = "ubuntu_focal"
 		  				type  = "DEV1-S"
 		  				enable_ipv6 = false
+						routed_ip_enabled = false
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(


### PR DESCRIPTION
`enable_ipv6` will always be disabled without routed_ip enabled