### PR TITLE
fix(logger): set provider logger as sdk-go logger

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -7,6 +7,10 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/logger"
 )
 
+func init() {
+	logger.SetLogger(L)
+}
+
 // Logger is the implementation of the SDK Logger interface for this terraform plugin.
 //
 // cf. https://godoc.org/github.com/scaleway/scaleway-sdk-go/logger#Logger


### PR DESCRIPTION
This fix the need of `SCW_DEBUG=1` to get requests logs. Only `TF_LOG=DEBUG` is needed with this change.
This logger was made to replace the sdk logger as specified in logger.Logger docstring.