### PR TITLE
fix(instance): server private_network with deleted pnic

### DIFF
--- a/internal/services/instance/helpers_instance.go
+++ b/internal/services/instance/helpers_instance.go
@@ -448,6 +448,7 @@ func (ph *privateNICsHandler) get(key string) (interface{}, error) {
 		"mac_address": pn.MacAddress,
 		"status":      pn.State.String(),
 		"zone":        loc,
+		"pnic_id":     pn.ID,
 	}, nil
 }
 

--- a/internal/services/instance/helpers_instance.go
+++ b/internal/services/instance/helpers_instance.go
@@ -427,7 +427,7 @@ func (ph *privateNICsHandler) set(d *schema.ResourceData) error {
 		keyValue := d.Get(pnKey)
 		keyRaw, err := ph.get(keyValue.(string))
 		if err != nil {
-			return err
+			continue
 		}
 		privateNetworks = append(privateNetworks, keyRaw.(map[string]interface{}))
 	}

--- a/internal/services/instance/server.go
+++ b/internal/services/instance/server.go
@@ -302,6 +302,11 @@ func ResourceServer() *schema.Resource {
 							Computed:    true,
 							Description: "The private NIC state",
 						},
+						"pnic_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The ID of the NIC",
+						},
 						"zone": zonal.Schema(),
 					},
 				},

--- a/internal/services/instance/server_test.go
+++ b/internal/services/instance/server_test.go
@@ -2080,7 +2080,32 @@ func TestAccServer_PrivateNetworkMissingPNIC(t *testing.T) {
 							pn_id = scaleway_vpc_private_network.pn.id
 						}
 					}
-`,
+				`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scaleway_instance_server.main", "type", "PLAY2-PICO"),
+					resource.TestCheckResourceAttr("scaleway_instance_server.main", "private_network.#", "1"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.pn_id"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.mac_address"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.status"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.zone"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.pnic_id"),
+					resource.TestCheckResourceAttrPair("scaleway_instance_server.main", "private_network.0.pn_id",
+						"scaleway_vpc_private_network.pn", "id"),
+				),
+				ExpectNonEmptyPlan: true, // pnic get deleted and the plan is not empty after the apply as private_network is now missing
+			},
+			{
+				Config: `
+					resource scaleway_vpc_private_network pn {}
+
+					resource "scaleway_instance_server" "main" {
+						image = "ubuntu_jammy"
+						type  = "PLAY2-PICO"
+						private_network {
+							pn_id = scaleway_vpc_private_network.pn.id
+						}
+					}
+				`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("scaleway_instance_server.main", "type", "PLAY2-PICO"),
 					resource.TestCheckResourceAttr("scaleway_instance_server.main", "private_network.#", "1"),

--- a/internal/services/instance/server_test.go
+++ b/internal/services/instance/server_test.go
@@ -14,6 +14,7 @@ import (
 	instanceSDK "github.com/scaleway/scaleway-sdk-go/api/instance/v1"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/acctest"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality"
+	"github.com/scaleway/terraform-provider-scaleway/v2/internal/locality/zonal"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/meta"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/provider"
 	"github.com/scaleway/terraform-provider-scaleway/v2/internal/services/instance"
@@ -1952,6 +1953,144 @@ func TestAccServer_BlockExternal(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("scaleway_instance_server.main", "type", "PLAY2-PICO"),
 					resource.TestCheckResourceAttr("scaleway_instance_server.main", "additional_volume_ids.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServer_PrivateNetworkMissingPNIC(t *testing.T) {
+	tt := acctest.NewTestTools(t)
+	defer tt.Cleanup()
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: tt.ProviderFactories,
+		CheckDestroy:      instancechecks.IsServerDestroyed(tt),
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource scaleway_vpc_private_network pn {}
+
+					resource "scaleway_instance_server" "main" {
+						image = "ubuntu_jammy"
+						type  = "PLAY2-PICO"
+						private_network {
+							pn_id = scaleway_vpc_private_network.pn.id
+						}
+					}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scaleway_instance_server.main", "type", "PLAY2-PICO"),
+					resource.TestCheckResourceAttr("scaleway_instance_server.main", "private_network.#", "1"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.pn_id"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.mac_address"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.status"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.zone"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.pnic_id"),
+					resource.TestCheckResourceAttrPair("scaleway_instance_server.main", "private_network.0.pn_id",
+						"scaleway_vpc_private_network.pn", "id"),
+				),
+			},
+			{
+				Config: `
+					resource scaleway_vpc_private_network pn {}
+
+					resource "scaleway_instance_server" "main" {
+						image = "ubuntu_jammy"
+						type  = "PLAY2-PICO"
+						private_network {
+							pn_id = scaleway_vpc_private_network.pn.id
+						}
+					}
+
+					resource scaleway_instance_private_nic pnic {
+						private_network_id = scaleway_vpc_private_network.pn.id
+						server_id = scaleway_instance_server.main.id
+					}
+`,
+				ResourceName: "scaleway_instance_private_nic.pnic",
+				ImportState:  true,
+				ImportStateIdFunc: func(state *terraform.State) (string, error) {
+					serverID := state.RootModule().Resources["scaleway_instance_server.main"].Primary.ID
+					pnicID, exists := state.RootModule().Resources["scaleway_instance_server.main"].Primary.Attributes["private_network.0.pnic_id"]
+					if !exists {
+						return "", errors.New("private_network.0.pnic_id not found")
+					}
+
+					id := serverID + "/" + pnicID
+
+					return id, nil
+				},
+				ImportStatePersist: true,
+			},
+			{ // We import private nic as a separate resource to trigger its deletion.
+				Config: `
+					resource scaleway_vpc_private_network pn {}
+
+					resource "scaleway_instance_server" "main" {
+						image = "ubuntu_jammy"
+						type  = "PLAY2-PICO"
+						private_network {
+							pn_id = scaleway_vpc_private_network.pn.id
+						}
+					}
+
+					resource scaleway_instance_private_nic pnic {
+						private_network_id = scaleway_vpc_private_network.pn.id
+						server_id = scaleway_instance_server.main.id
+					}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scaleway_instance_server.main", "type", "PLAY2-PICO"),
+					resource.TestCheckResourceAttr("scaleway_instance_server.main", "private_network.#", "1"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.pn_id"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.mac_address"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.status"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.zone"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.pnic_id"),
+					resource.TestCheckResourceAttrPair("scaleway_instance_server.main", "private_network.0.pn_id",
+						"scaleway_vpc_private_network.pn", "id"),
+					func(state *terraform.State) error {
+						serverPNICID, exists := state.RootModule().Resources["scaleway_instance_server.main"].Primary.Attributes["private_network.0.pnic_id"]
+						if !exists {
+							return errors.New("private_network.0.pnic_id not found")
+						}
+						localizedPNICID := state.RootModule().Resources["scaleway_instance_private_nic.pnic"].Primary.ID
+						_, pnicID, _, err := zonal.ParseNestedID(localizedPNICID)
+						if err != nil {
+							return err
+						}
+
+						if serverPNICID != pnicID {
+							return fmt.Errorf("expected server pnic (%s) to equal standalone pnic id (%s)", serverPNICID, pnicID)
+						}
+
+						return nil
+					},
+				),
+			},
+			{
+				Config: `
+					resource scaleway_vpc_private_network pn {}
+
+					resource "scaleway_instance_server" "main" {
+						image = "ubuntu_jammy"
+						type  = "PLAY2-PICO"
+						private_network {
+							pn_id = scaleway_vpc_private_network.pn.id
+						}
+					}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("scaleway_instance_server.main", "type", "PLAY2-PICO"),
+					resource.TestCheckResourceAttr("scaleway_instance_server.main", "private_network.#", "1"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.pn_id"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.mac_address"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.status"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.zone"),
+					resource.TestCheckResourceAttrSet("scaleway_instance_server.main", "private_network.0.pnic_id"),
+					resource.TestCheckResourceAttrPair("scaleway_instance_server.main", "private_network.0.pn_id",
+						"scaleway_vpc_private_network.pn", "id"),
 				),
 			},
 		},

--- a/internal/services/instance/testdata/server-private-network-missing-pnic.cassette.yaml
+++ b/internal/services/instance/testdata/server-private-network-missing-pnic.cassette.yaml
@@ -1,0 +1,4375 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 116
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-pn-compassionate-williams","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","tags":[],"subnets":null}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 729
+        uncompressed: false
+        body: '{"created_at":"2024-04-24T14:19:52.169225Z","dhcp_enabled":true,"id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","name":"tf-pn-compassionate-williams","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-04-24T14:19:52.169225Z","id":"80c3f381-6c62-406e-9bab-3ca28658291d","subnet":"172.17.24.0/22","updated_at":"2024-04-24T14:19:52.169225Z"},{"created_at":"2024-04-24T14:19:52.169225Z","id":"97f690fa-ad26-4096-91fd-00274a838d93","subnet":"fd5f:519c:6d46:7e71::/64","updated_at":"2024-04-24T14:19:52.169225Z"}],"tags":[],"updated_at":"2024-04-24T14:19:52.169225Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "729"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:19:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e936ad58-6484-493b-a39a-07910e456e3e
+        status: 200 OK
+        code: 200
+        duration: 792.046627ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bcdea822-d7eb-49e7-b230-f1c61acb618d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 729
+        uncompressed: false
+        body: '{"created_at":"2024-04-24T14:19:52.169225Z","dhcp_enabled":true,"id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","name":"tf-pn-compassionate-williams","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-04-24T14:19:52.169225Z","id":"80c3f381-6c62-406e-9bab-3ca28658291d","subnet":"172.17.24.0/22","updated_at":"2024-04-24T14:19:52.169225Z"},{"created_at":"2024-04-24T14:19:52.169225Z","id":"97f690fa-ad26-4096-91fd-00274a838d93","subnet":"fd5f:519c:6d46:7e71::/64","updated_at":"2024-04-24T14:19:52.169225Z"}],"tags":[],"updated_at":"2024-04-24T14:19:52.169225Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "729"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:19:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 86d0602d-3bbe-45ab-a128-d3fe9843b225
+        status: 200 OK
+        code: 200
+        duration: 27.770673ms
+    - id: 2
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/marketplace/v2/local-images?image_label=ubuntu_jammy&order_by=created_at_asc&type=instance_local&zone=fr-par-1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 1260
+        uncompressed: false
+        body: '{"local_images":[{"arch":"x86_64","compatible_commercial_types":["DEV1-L","DEV1-M","DEV1-S","DEV1-XL","GP1-L","GP1-M","GP1-S","GP1-XL","GP1-XS","START1-L","START1-M","START1-S","START1-XS","VC1L","VC1M","VC1S","X64-120GB","X64-15GB","X64-30GB","X64-60GB","ENT1-XXS","ENT1-XS","ENT1-S","ENT1-M","ENT1-L","ENT1-XL","ENT1-2XL","PRO2-XXS","PRO2-XS","PRO2-S","PRO2-M","PRO2-L","STARDUST1-S","PLAY2-MICRO","PLAY2-NANO","PLAY2-PICO","POP2-2C-8G","POP2-4C-16G","POP2-8C-32G","POP2-16C-64G","POP2-32C-128G","POP2-64C-256G","POP2-HM-2C-16G","POP2-HM-4C-32G","POP2-HM-8C-64G","POP2-HM-16C-128G","POP2-HM-32C-256G","POP2-HM-64C-512G","POP2-HC-2C-4G","POP2-HC-4C-8G","POP2-HC-8C-16G","POP2-HC-16C-32G","POP2-HC-32C-64G","POP2-HC-64C-128G"],"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"},{"arch":"arm64","compatible_commercial_types":["AMP2-C1","AMP2-C2","AMP2-C4","AMP2-C8","AMP2-C12","AMP2-C24","AMP2-C48","AMP2-C60","COPARM1-2C-8G","COPARM1-4C-16G","COPARM1-8C-32G","COPARM1-16C-64G","COPARM1-32C-128G"],"id":"b5ab68b0-7798-4dee-b678-e5de52054d68","label":"ubuntu_jammy","type":"instance_local","zone":"fr-par-1"}],"total_count":2}'
+        headers:
+            Content-Length:
+                - "1260"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:19:52 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4b3bedd8-6770-4072-907f-b6c485cb8583
+        status: 200 OK
+        code: 200
+        duration: 79.855343ms
+    - id: 3
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=1
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 38029
+        uncompressed: false
+        body: '{"servers":{"COPARM1-16C-64G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.3454,"mig_profile":null,"monthly_price":252.14,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-2C-8G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0426,"mig_profile":null,"monthly_price":31.1,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-32C-128G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.6935,"mig_profile":null,"monthly_price":506.26,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-4C-16G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0857,"mig_profile":null,"monthly_price":62.56,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"COPARM1-8C-32G":{"alt_names":[],"arch":"arm64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1724,"mig_profile":null,"monthly_price":125.85,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"DEV1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.04952,"mig_profile":null,"monthly_price":36.1496,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":80000000000,"min_size":0}},"DEV1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02556,"mig_profile":null,"monthly_price":18.6588,"ncpus":3,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":40000000000,"min_size":0}},"DEV1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01368,"mig_profile":null,"monthly_price":9.9864,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":20000000000,"min_size":0}},"DEV1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.07308,"mig_profile":null,"monthly_price":53.3484,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":12884901888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":120000000000,"min_size":0}},"ENT1-2XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.53,"mig_profile":null,"monthly_price":2576.9,"ncpus":96,"network":{"interfaces":[{"internal_bandwidth":20000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":20000000000}],"ipv6_support":true,"sum_internal_bandwidth":20000000000,"sum_internet_bandwidth":20000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":412316860416,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"ENT1-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.655,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"GP1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.7894,"mig_profile":null,"monthly_price":576.262,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":5000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":5000000000}],"ipv6_support":true,"sum_internal_bandwidth":5000000000,"sum_internet_bandwidth":5000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4064,"mig_profile":null,"monthly_price":296.672,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2042,"mig_profile":null,"monthly_price":149.066,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-VIZ":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1,"mig_profile":null,"monthly_price":72,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":300000000000,"min_size":0}},"GP1-XL":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.6714,"mig_profile":null,"monthly_price":1220.122,"ncpus":48,"network":{"interfaces":[{"internal_bandwidth":10000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":10000000000}],"ipv6_support":true,"sum_internal_bandwidth":10000000000,"sum_internet_bandwidth":10000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":600000000000,"min_size":0}},"GP1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1016,"mig_profile":null,"monthly_price":74.168,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":150000000000,"min_size":0}},"PLAY2-MICRO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.054,"mig_profile":null,"monthly_price":39.42,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-NANO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.027,"mig_profile":null,"monthly_price":19.71,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PLAY2-PICO":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.014,"mig_profile":null,"monthly_price":10.22,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-16C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.59,"mig_profile":null,"monthly_price":430.7,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-2C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0735,"mig_profile":null,"monthly_price":53.66,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-32C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.18,"mig_profile":null,"monthly_price":861.4,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-4C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.147,"mig_profile":null,"monthly_price":107.31,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-64C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":2.35,"mig_profile":null,"monthly_price":1715.5,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-8C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.29,"mig_profile":null,"monthly_price":211.7,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-16C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.4256,"mig_profile":null,"monthly_price":310.69,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-2C-4G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0532,"mig_profile":null,"monthly_price":38.84,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-32C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.8512,"mig_profile":null,"monthly_price":621.38,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-4C-8G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.1064,"mig_profile":null,"monthly_price":77.67,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-64C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.7024,"mig_profile":null,"monthly_price":1242.75,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HC-8C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.2128,"mig_profile":null,"monthly_price":155.34,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-16C-128G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.824,"mig_profile":null,"monthly_price":601.52,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3200000000}],"ipv6_support":true,"sum_internal_bandwidth":3200000000,"sum_internet_bandwidth":3200000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-2C-16G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.103,"mig_profile":null,"monthly_price":75.19,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-32C-256G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":1.648,"mig_profile":null,"monthly_price":1203.04,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6400000000}],"ipv6_support":true,"sum_internal_bandwidth":6400000000,"sum_internet_bandwidth":6400000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":274877906944,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-4C-32G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.206,"mig_profile":null,"monthly_price":150.38,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":800000000}],"ipv6_support":true,"sum_internal_bandwidth":800000000,"sum_internet_bandwidth":800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-64C-512G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":3.296,"mig_profile":null,"monthly_price":2406.08,"ncpus":64,"network":{"interfaces":[{"internal_bandwidth":12800000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":12800000000}],"ipv6_support":true,"sum_internal_bandwidth":12800000000,"sum_internet_bandwidth":12800000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":549755813888,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"POP2-HM-8C-64G":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.412,"mig_profile":null,"monthly_price":300.76,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1600000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1600000000}],"ipv6_support":true,"sum_internal_bandwidth":1600000000,"sum_internet_bandwidth":1600000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.877,"mig_profile":null,"monthly_price":640.21,"ncpus":32,"network":{"interfaces":[{"internal_bandwidth":6000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":6000000000}],"ipv6_support":true,"sum_internal_bandwidth":6000000000,"sum_internet_bandwidth":6000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":137438953472,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.438,"mig_profile":null,"monthly_price":319.74,"ncpus":16,"network":{"interfaces":[{"internal_bandwidth":3000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":3000000000}],"ipv6_support":true,"sum_internal_bandwidth":3000000000,"sum_internet_bandwidth":3000000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":68719476736,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.219,"mig_profile":null,"monthly_price":159.87,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":1500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1500000000}],"ipv6_support":true,"sum_internal_bandwidth":1500000000,"sum_internet_bandwidth":1500000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":34359738368,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11,"mig_profile":null,"monthly_price":80.3,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":700000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":700000000}],"ipv6_support":true,"sum_internal_bandwidth":700000000,"sum_internet_bandwidth":700000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":17179869184,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"PRO2-XXS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":false,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.055,"mig_profile":null,"monthly_price":40.15,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":350000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":350000000}],"ipv6_support":true,"sum_internal_bandwidth":350000000,"sum_internet_bandwidth":350000000},"per_volume_constraint":{"l_ssd":{"max_size":0,"min_size":0}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":0,"min_size":0}},"RENDER-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":1,"hourly_price":1.2426,"mig_profile":null,"monthly_price":907.098,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":45097156608,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":0}},"STARDUST1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00459,"mig_profile":null,"monthly_price":3.3507,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":800000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":10000000000,"min_size":0}}}}'
+        headers:
+            Content-Length:
+                - "38029"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:19:52 GMT
+            Link:
+                - </products/servers?page=2&per_page=50&>; rel="next",</products/servers?page=2&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7a26f509-10fe-4066-bce0-e3d710355230
+            X-Total-Count:
+                - "61"
+        status: 200 OK
+        code: 200
+        duration: 53.685398ms
+    - id: 4
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/products/servers?page=2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 8728
+        uncompressed: false
+        body: '{"servers":{"START1-L":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0368,"mig_profile":null,"monthly_price":26.864,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":400000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":400000000}],"ipv6_support":true,"sum_internal_bandwidth":400000000,"sum_internet_bandwidth":400000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"START1-M":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0194,"mig_profile":null,"monthly_price":14.162,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":300000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":300000000}],"ipv6_support":true,"sum_internal_bandwidth":300000000,"sum_internet_bandwidth":300000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"START1-S":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0106,"mig_profile":null,"monthly_price":7.738,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"START1-XS":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.0062,"mig_profile":null,"monthly_price":4.526,"ncpus":1,"network":{"interfaces":[{"internal_bandwidth":100000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":100000000}],"ipv6_support":true,"sum_internal_bandwidth":100000000,"sum_internet_bandwidth":100000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":1073741824,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":25000000000,"min_size":25000000000}},"VC1L":{"alt_names":["X64-8GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.02468,"mig_profile":null,"monthly_price":18.0164,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":8589934592,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"VC1M":{"alt_names":["X64-4GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.01555,"mig_profile":null,"monthly_price":11.3515,"ncpus":4,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":4294967296,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":100000000000,"min_size":100000000000}},"VC1S":{"alt_names":["X64-2GB"],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.00862,"mig_profile":null,"monthly_price":6.2926,"ncpus":2,"network":{"interfaces":[{"internal_bandwidth":200000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":200000000}],"ipv6_support":true,"sum_internal_bandwidth":200000000,"sum_internet_bandwidth":200000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":2147483648,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":50000000000,"min_size":50000000000}},"X64-120GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.42574,"mig_profile":null,"monthly_price":310.7902,"ncpus":12,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":128849018880,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":1000000000000,"min_size":500000000000}},"X64-15GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.06032,"mig_profile":null,"monthly_price":44.0336,"ncpus":6,"network":{"interfaces":[{"internal_bandwidth":250000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":250000000}],"ipv6_support":true,"sum_internal_bandwidth":250000000,"sum_internet_bandwidth":250000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":16106127360,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":200000000000,"min_size":200000000000}},"X64-30GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.11906,"mig_profile":null,"monthly_price":86.9138,"ncpus":8,"network":{"interfaces":[{"internal_bandwidth":500000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":500000000}],"ipv6_support":true,"sum_internal_bandwidth":500000000,"sum_internet_bandwidth":500000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":32212254720,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":400000000000,"min_size":300000000000}},"X64-60GB":{"alt_names":[],"arch":"x86_64","baremetal":false,"capabilities":{"block_storage":true,"boot_types":["local","rescue"],"hot_snapshots_local_volume":true,"placement_groups":true,"private_network":8},"gpu":0,"hourly_price":0.213,"mig_profile":null,"monthly_price":155.49,"ncpus":10,"network":{"interfaces":[{"internal_bandwidth":1000000000,"internet_bandwidth":null},{"internal_bandwidth":null,"internet_bandwidth":1000000000}],"ipv6_support":true,"sum_internal_bandwidth":1000000000,"sum_internet_bandwidth":1000000000},"per_volume_constraint":{"l_ssd":{"max_size":200000000000,"min_size":1000000000}},"ram":64424509440,"scratch_storage_max_size":null,"volumes_constraint":{"max_size":700000000000,"min_size":400000000000}}}}'
+        headers:
+            Content-Length:
+                - "8728"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:19:53 GMT
+            Link:
+                - </products/servers?page=1&per_page=50&>; rel="first",</products/servers?page=1&per_page=50&>; rel="previous",</products/servers?page=2&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 22c7a25d-504e-4541-9d57-ee2fa08f01e9
+            X-Total-Count:
+                - "61"
+        status: 200 OK
+        code: 200
+        duration: 234.465241ms
+    - id: 5
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 261
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"name":"tf-srv-quirky-williams","dynamic_ip_required":false,"commercial_type":"PLAY2-PICO","image":"c0c92384-4eea-45b1-8fb7-de84bbda822c","volumes":{"0":{"boot":false,"volume_type":"b_ssd"}},"boot_type":"local","project":"105bdce1-64c0-48ab-899d-868455867ecf"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2643
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:19:53.712470+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2643"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:19:53 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 108de369-9f50-4567-9d49-9250cb2ef6ab
+        status: 201 Created
+        code: 201
+        duration: 816.955631ms
+    - id: 6
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2643
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:19:53.712470+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2643"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:19:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 04ec9929-e47e-48b1-9de0-c3923e7d4f69
+        status: 200 OK
+        code: 200
+        duration: 203.867702ms
+    - id: 7
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2643
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:19:53.712470+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2643"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:19:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7845311d-c2e0-409d-9ba1-17709262b8ae
+        status: 200 OK
+        code: 200
+        duration: 204.434588ms
+    - id: 8
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 20
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"action":"poweron"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/action
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 322
+        uncompressed: false
+        body: '{"task":{"description":"server_batch_poweron","href_from":"/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/action","href_result":"/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2","id":"1cd21dbb-6a3d-457d-a76b-d21e864061da","started_at":"2024-04-24T14:19:54.700287+00:00","status":"pending","terminated_at":null}}'
+        headers:
+            Content-Length:
+                - "322"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:19:54 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/1cd21dbb-6a3d-457d-a76b-d21e864061da
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2f037fb9-cc73-499e-8d95-5939d43a99b2
+        status: 202 Accepted
+        code: 202
+        duration: 510.138793ms
+    - id: 9
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2665
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:19:54.533301+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"allocating node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2665"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:19:54 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f91141eb-d675-422f-88c3-18946a19a973
+        status: 200 OK
+        code: 200
+        duration: 156.04202ms
+    - id: 10
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2763
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:19:54.533301+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"starting","state_detail":"provisioning node","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2763"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:00 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - edd3e14e-0d13-458f-aa60-6996535a5b81
+        status: 200 OK
+        code: 200
+        duration: 264.68096ms
+    - id: 11
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2794
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2794"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3dcfa0c8-ca46-4b86-a119-04c2d569862f
+        status: 200 OK
+        code: 200
+        duration: 135.622254ms
+    - id: 12
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bcdea822-d7eb-49e7-b230-f1c61acb618d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 729
+        uncompressed: false
+        body: '{"created_at":"2024-04-24T14:19:52.169225Z","dhcp_enabled":true,"id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","name":"tf-pn-compassionate-williams","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-04-24T14:19:52.169225Z","id":"80c3f381-6c62-406e-9bab-3ca28658291d","subnet":"172.17.24.0/22","updated_at":"2024-04-24T14:19:52.169225Z"},{"created_at":"2024-04-24T14:19:52.169225Z","id":"97f690fa-ad26-4096-91fd-00274a838d93","subnet":"fd5f:519c:6d46:7e71::/64","updated_at":"2024-04-24T14:19:52.169225Z"}],"tags":[],"updated_at":"2024-04-24T14:19:52.169225Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "729"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f69bea26-4cd4-40b9-bcc5-1159ce54f933
+        status: 200 OK
+        code: 200
+        duration: 37.361222ms
+    - id: 13
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2794
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2794"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6b62c4d2-49db-4d5e-b4ea-0891f1f3c374
+        status: 200 OK
+        code: 200
+        duration: 249.404092ms
+    - id: 14
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 61
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 376
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:05.946983+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "376"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:05 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f0f97981-5ea8-41c8-9540-41f078de9a27
+        status: 201 Created
+        code: 201
+        duration: 613.86016ms
+    - id: 15
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 376
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:06.301324+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "376"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:06 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fc3b88f4-98ca-46f8-8517-3302bb49983f
+        status: 200 OK
+        code: 200
+        duration: 72.535724ms
+    - id: 16
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 376
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:06.513086+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "376"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:11 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b8cfe94c-0eb1-40e2-bbcb-9c352079e360
+        status: 200 OK
+        code: 200
+        duration: 100.293834ms
+    - id: 17
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 376
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:06.513086+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "376"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:16 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - e6043763-8bb7-443f-9473-1baaf2b2508f
+        status: 200 OK
+        code: 200
+        duration: 67.56502ms
+    - id: 18
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 376
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:06.513086+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "376"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:21 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - db62786f-9d8d-4f9f-8e0b-298785468fc3
+        status: 200 OK
+        code: 200
+        duration: 82.931085ms
+    - id: 19
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 376
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:06.513086+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "376"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:26 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6fffe10c-7811-4bf2-ba4d-ce994cb8f0c8
+        status: 200 OK
+        code: 200
+        duration: 78.451094ms
+    - id: 20
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 376
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:06.513086+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "376"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:31 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - acc6cf0d-3d4e-4788-bb8e-951725a839c3
+        status: 200 OK
+        code: 200
+        duration: 86.273789ms
+    - id: 21
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 376
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:06.513086+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "376"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:36 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9d3cc86c-c3ff-47ed-8d0b-ed81395426f6
+        status: 200 OK
+        code: 200
+        duration: 61.635653ms
+    - id: 22
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 378
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "378"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3d1b13f3-9667-455e-8726-ffec717bdc58
+        status: 200 OK
+        code: 200
+        duration: 73.646612ms
+    - id: 23
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 378
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "378"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3e1fcfdb-840a-41ea-b425-04ff071dfcf6
+        status: 200 OK
+        code: 200
+        duration: 75.259914ms
+    - id: 24
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3155
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3155"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:41 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 69866900-9ab1-4d42-acd7-9e074f3b6c56
+        status: 200 OK
+        code: 200
+        duration: 212.030206ms
+    - id: 25
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:42 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ec92f9bf-936f-41c9-a0ac-a01e2714771e
+        status: 200 OK
+        code: 200
+        duration: 71.657873ms
+    - id: 26
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 381
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "381"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:42 GMT
+            Link:
+                - </servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7db26c9b-84d9-4102-876f-d6e2fe250cb2
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 75.109902ms
+    - id: 27
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bcdea822-d7eb-49e7-b230-f1c61acb618d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 729
+        uncompressed: false
+        body: '{"created_at":"2024-04-24T14:19:52.169225Z","dhcp_enabled":true,"id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","name":"tf-pn-compassionate-williams","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-04-24T14:19:52.169225Z","id":"80c3f381-6c62-406e-9bab-3ca28658291d","subnet":"172.17.24.0/22","updated_at":"2024-04-24T14:19:52.169225Z"},{"created_at":"2024-04-24T14:19:52.169225Z","id":"97f690fa-ad26-4096-91fd-00274a838d93","subnet":"fd5f:519c:6d46:7e71::/64","updated_at":"2024-04-24T14:19:52.169225Z"}],"tags":[],"updated_at":"2024-04-24T14:19:52.169225Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "729"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7eb450a1-0989-4934-9160-f04b6bc7bfd7
+        status: 200 OK
+        code: 200
+        duration: 30.201072ms
+    - id: 28
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3155
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3155"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f6b9afbb-6437-44c7-af99-03e56eeaa49b
+        status: 200 OK
+        code: 200
+        duration: 136.048986ms
+    - id: 29
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a40bb869-db4e-4b7d-a849-07581b3dff49
+        status: 200 OK
+        code: 200
+        duration: 73.771537ms
+    - id: 30
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 381
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "381"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:42 GMT
+            Link:
+                - </servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1200b730-da69-4fe6-be85-d41944ffa7e1
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 61.465493ms
+    - id: 31
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 378
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "378"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:43 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3198793d-a62e-4a61-b308-7347cc9e0ca1
+        status: 200 OK
+        code: 200
+        duration: 70.518802ms
+    - id: 32
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bcdea822-d7eb-49e7-b230-f1c61acb618d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 729
+        uncompressed: false
+        body: '{"created_at":"2024-04-24T14:19:52.169225Z","dhcp_enabled":true,"id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","name":"tf-pn-compassionate-williams","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-04-24T14:19:52.169225Z","id":"80c3f381-6c62-406e-9bab-3ca28658291d","subnet":"172.17.24.0/22","updated_at":"2024-04-24T14:19:52.169225Z"},{"created_at":"2024-04-24T14:19:52.169225Z","id":"97f690fa-ad26-4096-91fd-00274a838d93","subnet":"fd5f:519c:6d46:7e71::/64","updated_at":"2024-04-24T14:19:52.169225Z"}],"tags":[],"updated_at":"2024-04-24T14:19:52.169225Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "729"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - ecbf780b-862f-4ace-8181-620f98e9d0cb
+        status: 200 OK
+        code: 200
+        duration: 28.845664ms
+    - id: 33
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3155
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3155"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8ff8d166-9616-47c3-8722-4175f81baf46
+        status: 200 OK
+        code: 200
+        duration: 135.892251ms
+    - id: 34
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8073f757-150c-4ded-a289-65e317a75126
+        status: 200 OK
+        code: 200
+        duration: 77.367726ms
+    - id: 35
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 381
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "381"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:44 GMT
+            Link:
+                - </servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 30c841ac-d952-4663-aa9d-a472ad2e86e5
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 82.755394ms
+    - id: 36
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 378
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "378"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:44 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d780e2eb-0173-41f4-ac3a-6a7f2a5dddfd
+        status: 200 OK
+        code: 200
+        duration: 72.843372ms
+    - id: 37
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bcdea822-d7eb-49e7-b230-f1c61acb618d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 729
+        uncompressed: false
+        body: '{"created_at":"2024-04-24T14:19:52.169225Z","dhcp_enabled":true,"id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","name":"tf-pn-compassionate-williams","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-04-24T14:19:52.169225Z","id":"80c3f381-6c62-406e-9bab-3ca28658291d","subnet":"172.17.24.0/22","updated_at":"2024-04-24T14:19:52.169225Z"},{"created_at":"2024-04-24T14:19:52.169225Z","id":"97f690fa-ad26-4096-91fd-00274a838d93","subnet":"fd5f:519c:6d46:7e71::/64","updated_at":"2024-04-24T14:19:52.169225Z"}],"tags":[],"updated_at":"2024-04-24T14:19:52.169225Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "729"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 276be3db-1633-4aea-8c7d-4c581867add1
+        status: 200 OK
+        code: 200
+        duration: 25.440213ms
+    - id: 38
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3155
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3155"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 829b9e3d-ca39-4577-acfa-c3c8e1bb3b5c
+        status: 200 OK
+        code: 200
+        duration: 181.542085ms
+    - id: 39
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - fa5390e9-6d5f-4402-8ed1-f88de2c3ef9d
+        status: 200 OK
+        code: 200
+        duration: 72.939222ms
+    - id: 40
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 381
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "381"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:45 GMT
+            Link:
+                - </servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5179767d-6b1e-4787-913d-39fe7c44ddb9
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 72.826109ms
+    - id: 41
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 378
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "378"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7766c6f3-653f-452b-b7c4-ea2d40e438e0
+        status: 200 OK
+        code: 200
+        duration: 82.859781ms
+    - id: 42
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bcdea822-d7eb-49e7-b230-f1c61acb618d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 729
+        uncompressed: false
+        body: '{"created_at":"2024-04-24T14:19:52.169225Z","dhcp_enabled":true,"id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","name":"tf-pn-compassionate-williams","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-04-24T14:19:52.169225Z","id":"80c3f381-6c62-406e-9bab-3ca28658291d","subnet":"172.17.24.0/22","updated_at":"2024-04-24T14:19:52.169225Z"},{"created_at":"2024-04-24T14:19:52.169225Z","id":"97f690fa-ad26-4096-91fd-00274a838d93","subnet":"fd5f:519c:6d46:7e71::/64","updated_at":"2024-04-24T14:19:52.169225Z"}],"tags":[],"updated_at":"2024-04-24T14:19:52.169225Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "729"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9677e9ae-bc61-4a39-84b6-35813c6dee70
+        status: 200 OK
+        code: 200
+        duration: 30.432046ms
+    - id: 43
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 378
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "378"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:45 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9e82a707-ebfd-41b1-9c17-dedef22cb0f6
+        status: 200 OK
+        code: 200
+        duration: 83.767267ms
+    - id: 44
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3155
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3155"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a7366dc4-2c86-44a5-b8b9-a91b3bb39949
+        status: 200 OK
+        code: 200
+        duration: 145.027775ms
+    - id: 45
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f1d79d22-2d58-4b74-b2a2-5598e39433c3
+        status: 200 OK
+        code: 200
+        duration: 85.458756ms
+    - id: 46
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 381
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "381"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:46 GMT
+            Link:
+                - </servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 7f140ab3-fd1a-4e93-b089-0536174bbfdf
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 80.681356ms
+    - id: 47
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 378
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:05.946983+00:00","id":"8ed3250d-7e03-4361-9544-628696f30f3c","mac_address":"02:00:00:1a:1b:28","modification_date":"2024-04-24T14:20:37.481285+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "378"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:46 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 73ef2c5a-46dd-4eeb-ac01-506a31dedc92
+        status: 200 OK
+        code: 200
+        duration: 74.086008ms
+    - id: 48
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b226b75a-3f8a-4c1f-b4f1-44fb393ec379
+        status: 204 No Content
+        code: 204
+        duration: 331.38988ms
+    - id: 49
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/8ed3250d-7e03-4361-9544-628696f30f3c
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 148
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"8ed3250d-7e03-4361-9544-628696f30f3c","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "148"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:47 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a3cf4728-f2e1-46bc-ac28-6dc846b2826f
+        status: 404 Not Found
+        code: 404
+        duration: 67.160309ms
+    - id: 50
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bcdea822-d7eb-49e7-b230-f1c61acb618d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 729
+        uncompressed: false
+        body: '{"created_at":"2024-04-24T14:19:52.169225Z","dhcp_enabled":true,"id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","name":"tf-pn-compassionate-williams","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-04-24T14:19:52.169225Z","id":"80c3f381-6c62-406e-9bab-3ca28658291d","subnet":"172.17.24.0/22","updated_at":"2024-04-24T14:19:52.169225Z"},{"created_at":"2024-04-24T14:19:52.169225Z","id":"97f690fa-ad26-4096-91fd-00274a838d93","subnet":"fd5f:519c:6d46:7e71::/64","updated_at":"2024-04-24T14:19:52.169225Z"}],"tags":[],"updated_at":"2024-04-24T14:19:52.169225Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "729"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 00728886-7e18-47f9-bd5b-adbe33cd1f1c
+        status: 200 OK
+        code: 200
+        duration: 39.737289ms
+    - id: 51
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2794
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2794"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b84b6ec8-af3a-4526-9613-69ad0b474927
+        status: 200 OK
+        code: 200
+        duration: 147.444768ms
+    - id: 52
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1650fbea-a2f4-4cd2-8d47-cc393da271c4
+        status: 200 OK
+        code: 200
+        duration: 79.884056ms
+    - id: 53
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:48 GMT
+            Link:
+                - </servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 184f0945-1293-4afa-abf0-a07e9b57f4e9
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 67.363881ms
+    - id: 54
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bcdea822-d7eb-49e7-b230-f1c61acb618d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 729
+        uncompressed: false
+        body: '{"created_at":"2024-04-24T14:19:52.169225Z","dhcp_enabled":true,"id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","name":"tf-pn-compassionate-williams","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-04-24T14:19:52.169225Z","id":"80c3f381-6c62-406e-9bab-3ca28658291d","subnet":"172.17.24.0/22","updated_at":"2024-04-24T14:19:52.169225Z"},{"created_at":"2024-04-24T14:19:52.169225Z","id":"97f690fa-ad26-4096-91fd-00274a838d93","subnet":"fd5f:519c:6d46:7e71::/64","updated_at":"2024-04-24T14:19:52.169225Z"}],"tags":[],"updated_at":"2024-04-24T14:19:52.169225Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "729"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 19ce25fd-f475-46f1-9790-4cd4e83e5a1d
+        status: 200 OK
+        code: 200
+        duration: 28.202155ms
+    - id: 55
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2794
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2794"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:48 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 785b0b2d-9f62-4e9a-8d20-cf61f213c053
+        status: 200 OK
+        code: 200
+        duration: 200.726097ms
+    - id: 56
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 9a8c359c-9892-42f9-b19f-0efe7a37d4c2
+        status: 200 OK
+        code: 200
+        duration: 76.318034ms
+    - id: 57
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:49 GMT
+            Link:
+                - </servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 948ec077-c94f-4c1a-9f20-724e94716440
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 69.061352ms
+    - id: 58
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2794
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2794"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:49 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 15da0823-d562-4e28-88c8-97a90654a015
+        status: 200 OK
+        code: 200
+        duration: 168.823356ms
+    - id: 59
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 20
+        uncompressed: false
+        body: '{"private_nics":[]}'
+        headers:
+            Content-Length:
+                - "20"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:49 GMT
+            Link:
+                - </servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics?page=0&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8735b566-3139-40ca-9ce0-d01d64d6dadc
+            X-Total-Count:
+                - "0"
+        status: 200 OK
+        code: 200
+        duration: 68.003925ms
+    - id: 60
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2794
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2794"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 97ef704b-4215-4a46-998b-1820704d305e
+        status: 200 OK
+        code: 200
+        duration: 237.161989ms
+    - id: 61
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 61
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 376
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:50.339512+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "376"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1cce7954-bb9b-44eb-b8ba-f808ce239327
+        status: 201 Created
+        code: 201
+        duration: 511.674651ms
+    - id: 62
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/efcdb697-ae6a-41c2-b5fc-0643273f9aa3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 376
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:50.339512+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"syncing","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "376"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:50 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 531876ad-67dc-4ff3-a61b-1790f45c34a8
+        status: 200 OK
+        code: 200
+        duration: 67.841099ms
+    - id: 63
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/efcdb697-ae6a-41c2-b5fc-0643273f9aa3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 378
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:51.194522+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "378"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0ad6feda-d97a-4dbe-bf16-ea9ef254313a
+        status: 200 OK
+        code: 200
+        duration: 88.702243ms
+    - id: 64
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/efcdb697-ae6a-41c2-b5fc-0643273f9aa3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 378
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:51.194522+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "378"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 36b18867-82d2-4404-a8ad-119eb150b06d
+        status: 200 OK
+        code: 200
+        duration: 74.363479ms
+    - id: 65
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3155
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:51.194522+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3155"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:55 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8ba4a592-4e1c-40fc-894d-b00c6dc32b48
+        status: 200 OK
+        code: 200
+        duration: 190.570777ms
+    - id: 66
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3155
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:51.194522+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3155"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 6e857ddc-8391-4a7a-8cea-028a06fcac69
+        status: 200 OK
+        code: 200
+        duration: 204.002576ms
+    - id: 67
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:56 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 20dc01a0-e19d-4890-b4db-9635d5de155c
+        status: 200 OK
+        code: 200
+        duration: 97.543112ms
+    - id: 68
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 381
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:51.194522+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "381"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:56 GMT
+            Link:
+                - </servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - a5d99e9f-c824-4b2f-a204-62d028b1ad6d
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 80.832319ms
+    - id: 69
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bcdea822-d7eb-49e7-b230-f1c61acb618d
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 729
+        uncompressed: false
+        body: '{"created_at":"2024-04-24T14:19:52.169225Z","dhcp_enabled":true,"id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","name":"tf-pn-compassionate-williams","organization_id":"105bdce1-64c0-48ab-899d-868455867ecf","project_id":"105bdce1-64c0-48ab-899d-868455867ecf","region":"fr-par","subnets":[{"created_at":"2024-04-24T14:19:52.169225Z","id":"80c3f381-6c62-406e-9bab-3ca28658291d","subnet":"172.17.24.0/22","updated_at":"2024-04-24T14:19:52.169225Z"},{"created_at":"2024-04-24T14:19:52.169225Z","id":"97f690fa-ad26-4096-91fd-00274a838d93","subnet":"fd5f:519c:6d46:7e71::/64","updated_at":"2024-04-24T14:19:52.169225Z"}],"tags":[],"updated_at":"2024-04-24T14:19:52.169225Z","vpc_id":"8feba4f5-79f9-42cd-b5ce-3ed8c510569e"}'
+        headers:
+            Content-Length:
+                - "729"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 22890b3f-034f-42ee-9d8d-9c9d00ba1518
+        status: 200 OK
+        code: 200
+        duration: 34.098338ms
+    - id: 70
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3155
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:51.194522+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3155"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 72fff329-4338-4046-9214-d3743e8591a9
+        status: 200 OK
+        code: 200
+        duration: 124.993964ms
+    - id: 71
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/user_data
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 17
+        uncompressed: false
+        body: '{"user_data":[]}'
+        headers:
+            Content-Length:
+                - "17"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 2b5e5774-eb4b-4b64-a616-3a5d6087cf60
+        status: 200 OK
+        code: 200
+        duration: 76.080837ms
+    - id: 72
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 381
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:51.194522+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "381"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:56 GMT
+            Link:
+                - </servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 0e19407b-df35-44ba-a7dc-aef168c157be
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 85.957214ms
+    - id: 73
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3155
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweroff","terminate","reboot","stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:03.432008+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:51.194522+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"running","state_detail":"booting kernel","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3155"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:57 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 5d613a72-e982-4542-b884-cd4f0c2fb705
+        status: 200 OK
+        code: 200
+        duration: 152.923387ms
+    - id: 74
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 21
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: '{"action":"poweroff"}'
+        form: {}
+        headers:
+            Content-Type:
+                - application/json
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/action
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 317
+        uncompressed: false
+        body: '{"task":{"description":"server_poweroff","href_from":"/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/action","href_result":"/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2","id":"3eb12cc6-f3d9-4d50-a392-0a8a7bfb6e49","started_at":"2024-04-24T14:20:58.445781+00:00","status":"pending","terminated_at":null}}'
+        headers:
+            Content-Length:
+                - "317"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:58 GMT
+            Location:
+                - https://api.scaleway.com/instance/v1/zones/fr-par-1/tasks/3eb12cc6-f3d9-4d50-a392-0a8a7bfb6e49
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 4daf81c0-9490-482f-b286-0bfa4ef1f7d6
+        status: 202 Accepted
+        code: 202
+        duration: 583.504737ms
+    - id: 75
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3115
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:58.084642+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:51.194522+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3115"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:20:58 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - b4d22c91-af99-4b15-83bf-95b0562a65c1
+        status: 200 OK
+        code: 200
+        duration: 135.911929ms
+    - id: 76
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3115
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["stop_in_place","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":{"cluster_id":"7","hypervisor_id":"901","node_id":"26","platform_id":"14","zone_id":"par1"},"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:20:58.084642+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:51.194522+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopping","state_detail":"stopping","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3115"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:21:03 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - d762edaa-d0f6-47bf-8f4b-c85836f69acb
+        status: 200 OK
+        code: 200
+        duration: 258.966288ms
+    - id: 77
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 3004
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:21:05.444670+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:51.194522+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "3004"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:21:08 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 70e49a81-e399-49b9-a24a-dd647a5a42f6
+        status: 200 OK
+        code: 200
+        duration: 221.319168ms
+    - id: 78
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 381
+        uncompressed: false
+        body: '{"private_nics":[{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:51.194522+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}]}'
+        headers:
+            Content-Length:
+                - "381"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:21:08 GMT
+            Link:
+                - </servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics?page=1&per_page=50&>; rel="last"
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - c51ba8ab-51ee-481b-80b3-ca9fac6fe9a5
+            X-Total-Count:
+                - "1"
+        status: 200 OK
+        code: 200
+        duration: 93.512396ms
+    - id: 79
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/efcdb697-ae6a-41c2-b5fc-0643273f9aa3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 378
+        uncompressed: false
+        body: '{"private_nic":{"creation_date":"2024-04-24T14:20:50.339512+00:00","id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","mac_address":"02:00:00:1a:1b:29","modification_date":"2024-04-24T14:20:51.194522+00:00","private_network_id":"bcdea822-d7eb-49e7-b230-f1c61acb618d","server_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","state":"available","tags":[],"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "378"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:21:09 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 855c9aa8-c132-4313-b7fe-438c86bc9b68
+        status: 200 OK
+        code: 200
+        duration: 72.77854ms
+    - id: 80
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/efcdb697-ae6a-41c2-b5fc-0643273f9aa3
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:21:09 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 1d38544b-fe31-4564-889b-7e2577c3cb11
+        status: 204 No Content
+        code: 204
+        duration: 651.857518ms
+    - id: 81
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2/private_nics/efcdb697-ae6a-41c2-b5fc-0643273f9aa3
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 148
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_private_nic","resource_id":"efcdb697-ae6a-41c2-b5fc-0643273f9aa3","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "148"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:21:09 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 815a3de1-7eb8-4809-bd3a-70e60e7643eb
+        status: 404 Not Found
+        code: 404
+        duration: 71.33191ms
+    - id: 82
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 2643
+        uncompressed: false
+        body: '{"server":{"allowed_actions":["poweron","backup"],"arch":"x86_64","boot_type":"local","bootscript":{"architecture":"x86_64","bootcmdargs":"LINUX_COMMON scaleway boot=local nbd.max_part=16","default":true,"dtb":"","id":"fdfe150f-a870-4ce4-b432-9f56b5b995c1","initrd":"http://10.194.3.9/initrd/initrd-Linux-x86_64-v3.14.6.gz","kernel":"http://10.194.3.9/kernel/x86_64-mainline-lts-4.4-4.4.230-rev1/vmlinuz-4.4.230","organization":"11111111-1111-4111-8111-111111111111","project":"11111111-1111-4111-8111-111111111111","public":true,"title":"x86_64 mainline 4.4.230 rev1","zone":"fr-par-1"},"commercial_type":"PLAY2-PICO","creation_date":"2024-04-24T14:19:53.712470+00:00","dynamic_ip_required":false,"enable_ipv6":false,"extra_networks":[],"hostname":"tf-srv-quirky-williams","id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","image":{"arch":"x86_64","creation_date":"2024-04-22T11:58:44.240830+00:00","default_bootscript":null,"extra_volumes":{},"from_server":null,"id":"c0c92384-4eea-45b1-8fb7-de84bbda822c","modification_date":"2024-04-22T11:58:44.240830+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"51b656e3-4865-41e8-adbc-0c45bdd780db","project":"51b656e3-4865-41e8-adbc-0c45bdd780db","public":true,"root_volume":{"id":"65adff1c-cc93-409f-b9d4-fc5411b557fd","name":"Ubuntu 22.04 Jammy Jellyfish","size":10000000000,"volume_type":"unified"},"state":"available","tags":[],"zone":"fr-par-1"},"ipv6":null,"location":null,"mac_address":"de:00:00:4e:54:2d","maintenances":[],"modification_date":"2024-04-24T14:21:05.444670+00:00","name":"tf-srv-quirky-williams","organization":"105bdce1-64c0-48ab-899d-868455867ecf","placement_group":null,"private_ip":null,"private_nics":[],"project":"105bdce1-64c0-48ab-899d-868455867ecf","protected":false,"public_ip":null,"public_ips":[],"routed_ip_enabled":true,"security_group":{"id":"5881315f-2400-43a0-ac75-08adf6cb8c12","name":"Default security group"},"state":"stopped","state_detail":"","tags":[],"volumes":{"0":{"boot":false,"creation_date":"2024-04-24T14:19:53.712470+00:00","export_uri":null,"id":"d6bf9a7a-308c-4a24-ae84-c6d377acf488","modification_date":"2024-04-24T14:19:53.712470+00:00","name":"Ubuntu 22.04 Jammy Jellyfish","organization":"105bdce1-64c0-48ab-899d-868455867ecf","project":"105bdce1-64c0-48ab-899d-868455867ecf","server":{"id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","name":"tf-srv-quirky-williams"},"size":10000000000,"state":"available","tags":[],"volume_type":"b_ssd","zone":"fr-par-1"}},"zone":"fr-par-1"}}'
+        headers:
+            Content-Length:
+                - "2643"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:21:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bfb082c6-0716-4fc4-8d6a-613bda34743b
+        status: 200 OK
+        code: 200
+        duration: 234.229858ms
+    - id: 83
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:21:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 537c7a98-b751-4060-ac29-c9e184878949
+        status: 204 No Content
+        code: 204
+        duration: 311.768405ms
+    - id: 84
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:21:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - f42cb820-48c4-45b4-bc83-09a293ac590f
+        status: 404 Not Found
+        code: 404
+        duration: 94.767064ms
+    - id: 85
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/volumes/d6bf9a7a-308c-4a24-ae84-c6d377acf488
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:21:10 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 3e9ff11d-6f2d-4158-9521-f5c8cf516e59
+        status: 204 No Content
+        code: 204
+        duration: 210.843034ms
+    - id: 86
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/vpc/v2/regions/fr-par/private-networks/bcdea822-d7eb-49e7-b230-f1c61acb618d
+        method: DELETE
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 0
+        uncompressed: false
+        body: ""
+        headers:
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:21:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - 8dd868d6-3e47-4012-93b7-8452efac8740
+        status: 204 No Content
+        code: 204
+        duration: 1.222683272s
+    - id: 87
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.scaleway.com
+        remote_addr: ""
+        request_uri: ""
+        body: ""
+        form: {}
+        headers:
+            User-Agent:
+                - scaleway-sdk-go/v1.0.0-beta.7+dev (go1.22.2; linux; amd64) terraform-provider/develop terraform/terraform-tests
+        url: https://api.scaleway.com/instance/v1/zones/fr-par-1/servers/43133f29-f6bf-4021-8a7b-140b8b7308e2
+        method: GET
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: 143
+        uncompressed: false
+        body: '{"message":"resource is not found","resource":"instance_server","resource_id":"43133f29-f6bf-4021-8a7b-140b8b7308e2","type":"not_found"}'
+        headers:
+            Content-Length:
+                - "143"
+            Content-Security-Policy:
+                - default-src 'none'; frame-ancestors 'none'
+            Content-Type:
+                - application/json
+            Date:
+                - Wed, 24 Apr 2024 14:21:12 GMT
+            Server:
+                - Scaleway API Gateway (fr-par-2;edge01)
+            Strict-Transport-Security:
+                - max-age=63072000
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - DENY
+            X-Request-Id:
+                - bc789db5-58e3-4329-a772-3d15f2aab0fb
+        status: 404 Not Found
+        code: 404
+        duration: 319.963641ms


### PR DESCRIPTION
If a private nic is deleted while it was managed by terraform using `scaleway_instance_server.private_network`, it will make terraform get stuck on each refresh or apply.
