### PR TITLE
fix(mnq): doc review of terraform mnq doc

### DIFF
--- a/docs/resources/mnq_nats_account.md
+++ b/docs/resources/mnq_nats_account.md
@@ -5,10 +5,10 @@ page_title: "Scaleway: scaleway_mnq_nats_account"
 
 # Resource: scaleway_mnq_nats_account
 
-Creates and manages Scaleway Messaging and queuing Nats Accounts.
-For further information please check
-our [documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/nats-overview/)
-To use Scaleway's provider with official nats jetstream provider, check out the [corresponding guide](../guides/mnq_with_nats_terraform_provider.md)
+Creates and manages Scaleway Messaging and Queuing NATS accounts.
+For further information, see
+our [main documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/nats-overview/)
+To use the Scaleway provider with the official NATS JetStream provider, check out the [corresponding guide](../guides/mnq_with_nats_terraform_provider.md).
 
 ## Example Usage
 
@@ -24,12 +24,12 @@ resource "scaleway_mnq_nats_account" "main" {
 
 The following arguments are supported:
 
-- `name` - (Optional) The unique name of the nats account.
+- `name` - (Optional) The unique name of the NATS account.
 
-- `region` - (Defaults to [provider](../index.md#region) `region`). The [region](../guides/regions_and_zones.md#regions)
+- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
   in which the account should be created.
 
-- `project_id` - (Defaults to [provider](../index.md#project_id) `project_id`) The ID of the project the
+- `project_id` - (Defaults to [provider](../index.md#arguments-reference) `project_id`) The ID of the Project the
   account is associated with.
 
 ## Attributes Reference
@@ -38,13 +38,13 @@ In addition to all arguments above, the following attributes are exported:
 
 - `id` - The ID of the account
 
-~> **Important:** Messaging and Queueing nats accounts' IDs are [regional](../guides/regions_and_zones.md#resource-ids), which means they are of the form `{region}/{id}`, e.g. `fr-par/11111111-1111-1111-1111-111111111111`
+~> **Important:** Messaging and Queueing NATS account IDs are [regional](../guides/regions_and_zones.md#resource-ids), which means they are of the form `{region}/{id}`, e.g. `fr-par/11111111-1111-1111-1111-111111111111`
 
 - `endpoint` - The endpoint of the NATS service for this account.
 
 ## Import
 
-Namespaces can be imported using the `{region}/{id}`, e.g.
+Namespaces can be imported using `{region}/{id}`, e.g.
 
 ```bash
 $ terraform import scaleway_mnq_nats_account.main fr-par/11111111111111111111111111111111

--- a/docs/resources/mnq_nats_account.md
+++ b/docs/resources/mnq_nats_account.md
@@ -26,7 +26,7 @@ The following arguments are supported:
 
 - `name` - (Optional) The unique name of the NATS account.
 
-- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
+- `region` - (Defaults to [provider](../index.md#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
   in which the account should be created.
 
 - `project_id` - (Defaults to [provider](../index.md#arguments-reference) `project_id`) The ID of the Project the

--- a/docs/resources/mnq_nats_credentials.md
+++ b/docs/resources/mnq_nats_credentials.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 - `name` - (Optional) The unique name of the NATS credentials.
 
-- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
+- `region` - (Defaults to [provider](../index.md#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
   in which the account exists.
 
 ## Attributes Reference

--- a/docs/resources/mnq_nats_credentials.md
+++ b/docs/resources/mnq_nats_credentials.md
@@ -5,9 +5,9 @@ page_title: "Scaleway: scaleway_mnq_nats_credentials"
 
 # Resource: scaleway_mnq_nats_credentials
 
-Creates and manages Scaleway Messaging and queuing Nats Credentials.
-For further information please check
-our [documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/nats-overview/)
+Creates and manages Scaleway Messaging and Queuing NATS credentials.
+For further information, see
+our [main documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/nats-overview/).
 
 ## Example Usage
 
@@ -27,11 +27,11 @@ resource "scaleway_mnq_nats_credentials" "main" {
 
 The following arguments are supported:
 
-- `account_id` - (Required) The ID of the nats account the credentials are generated from
+- `account_id` - (Required) The ID of the NATS account the credentials are generated from
 
-- `name` - (Optional) The unique name of the nats credentials.
+- `name` - (Optional) The unique name of the NATS credentials.
 
-- `region` - (Defaults to [provider](../index.md#region) `region`). The [region](../guides/regions_and_zones.md#regions)
+- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
   in which the account exists.
 
 ## Attributes Reference
@@ -40,13 +40,13 @@ In addition to all arguments above, the following attributes are exported:
 
 - `id` - The ID of the credentials
 
-~> **Important:** Messaging and Queueing nats credentials' IDs are [regional](../guides/regions_and_zones.md#resource-ids), which means they are of the form `{region}/{id}`, e.g. `fr-par/11111111-1111-1111-1111-111111111111`
+~> **Important:** Messaging and Queueing NATS credentials' IDs are [regional](../guides/regions_and_zones.md#resource-ids), which means they are of the form `{region}/{id}`, e.g. `fr-par/11111111-1111-1111-1111-111111111111`
 
 - `file` - The content of the credentials file.
 
 ## Import
 
-Namespaces can be imported using the `{region}/{id}`, e.g.
+Namespaces can be imported using `{region}/{id}`, e.g.
 
 ```bash
 $ terraform import scaleway_mnq_nats_credentials.main fr-par/11111111111111111111111111111111

--- a/docs/resources/mnq_sns.md
+++ b/docs/resources/mnq_sns.md
@@ -5,28 +5,28 @@ page_title: "Scaleway: scaleway_mnq_sns"
 
 # Resource: scaleway_mnq_sns
 
-Activate Scaleway Messaging and queuing SNS for a project.
-For further information please check
-our [documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/sns-overview/)
+Activates Scaleway Messaging and Queuing SNS in a Project.
+For further information, see
+our [main documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/sns-overview/).
 
 ## Example Usage
 
 ### Basic
 
-Activate SNS for default project
+Activate SNS in the default Project
 
 ```terraform
 resource scaleway_mnq_sns "main" {}
 ```
 
-Activate SNS for a specific project
+Activate SNS in a specific Project
 
 ```terraform
 data scaleway_account_project project {
   name = "default"
 }
 
-// For specific project in default region
+// For specific Project in default region
 resource scaleway_mnq_sns "for_project" {
   project_id = data.scaleway_account_project.project.id
 }
@@ -37,25 +37,25 @@ resource scaleway_mnq_sns "for_project" {
 The following arguments are supported:
 
 
-- `region` - (Defaults to [provider](../index.md#region) `region`). The [region](../guides/regions_and_zones.md#regions)
-  in which sns will be enabled.
+- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
+  in which SNS will be enabled.
 
-- `project_id` - (Defaults to [provider](../index.md#project_id) `project_id`) The ID of the project the sns will be enabled for.
+- `project_id` - (Defaults to [provider](../index.mds#arguments-reference) `project_id`) The ID of the project in which SNS will be enabled.
 
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-- `id` - The ID of the project
+- `id` - The ID of the Project
 
-~> **Important:** Messaging and Queueing sns' IDs are [regional](../guides/regions_and_zones.md#resource-ids), which means they are of the form `{region}/{id}`, e.g. `fr-par/11111111-1111-1111-1111-111111111111`
+~> **Important:** Messaging and Queueing SN' IDs are [regional](../guides/regions_and_zones.md#resource-ids), which means they are of the form `{region}/{id}`, e.g. `fr-par/11111111-1111-1111-1111-111111111111`
 
-- `endpoint` - The endpoint of the SNS service for this project.
+- `endpoint` - The endpoint of the SNS service for this Project.
 
 ## Import
 
-SNS status can be imported using the `{region}/{project_id}`, e.g.
+SNS status can be imported using `{region}/{project_id}`, e.g.
 
 ```bash
 $ terraform import scaleway_mnq_sns.main fr-par/11111111111111111111111111111111

--- a/docs/resources/mnq_sns.md
+++ b/docs/resources/mnq_sns.md
@@ -37,10 +37,10 @@ resource scaleway_mnq_sns "for_project" {
 The following arguments are supported:
 
 
-- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
+- `region` - (Defaults to [provider](../index.md#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
   in which SNS will be enabled.
 
-- `project_id` - (Defaults to [provider](../index.mds#arguments-reference) `project_id`) The ID of the project in which SNS will be enabled.
+- `project_id` - (Defaults to [provider](../index.md#arguments-reference) `project_id`) The ID of the project in which SNS will be enabled.
 
 
 ## Attributes Reference

--- a/docs/resources/mnq_sns_credentials.md
+++ b/docs/resources/mnq_sns_credentials.md
@@ -40,9 +40,9 @@ The following arguments are supported:
     - `can_manage` - (Optional). Defines whether the user can manage the associated resource(s).
 
 
-- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions) in which SNS is enabled.
+- `region` - (Defaults to [provider](../index.md#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions) in which SNS is enabled.
 
-- `project_id` - (Defaults to [provider](../index.mds#arguments-reference) `project_id`) The ID of the Project in which SNS is enabled.
+- `project_id` - (Defaults to [provider](../index.md#arguments-reference) `project_id`) The ID of the Project in which SNS is enabled.
 
 
 ## Attributes Reference

--- a/docs/resources/mnq_sns_credentials.md
+++ b/docs/resources/mnq_sns_credentials.md
@@ -5,9 +5,9 @@ page_title: "Scaleway: scaleway_mnq_sns_credentials"
 
 # Resource: scaleway_mnq_sns_credentials
 
-Creates and manages Scaleway Messaging and queuing SNS Credentials.
-For further information please check
-our [documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/sns-overview/)
+Creates and manages Scaleway Messaging and Queuing SNS credentials.
+For further information, see
+our [main documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/sns-overview/)
 
 ## Example Usage
 
@@ -32,17 +32,17 @@ resource scaleway_mnq_sns_credentials main {
 
 The following arguments are supported:
 
-- `name` - (Optional) The unique name of the sns credentials.
+- `name` - (Optional) The unique name of the SNS credentials.
 
-- `permissions` - (Optional). List of permissions associated to these credentials. Only one of permissions may be set.
-    - `can_publish` - (Optional). Defines if user can publish messages to the service.
-    - `can_receive` - (Optional). Defines if user can receive messages from the service.
-    - `can_manage` - (Optional). Defines if user can manage the associated resource(s).
+- `permissions` - (Optional). List of permissions associated with these credentials. Only one of the following permissions may be set:
+    - `can_publish` - (Optional). Defines whether the user can publish messages to the service.
+    - `can_receive` - (Optional). Defines whether the user can receive messages from the service.
+    - `can_manage` - (Optional). Defines whether the user can manage the associated resource(s).
 
 
-- `region` - (Defaults to [provider](../index.md#region) `region`). The [region](../guides/regions_and_zones.md#regions) in which sns is enabled.
+- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions) in which SNS is enabled.
 
-- `project_id` - (Defaults to [provider](../index.md#project_id) `project_id`) The ID of the project the sns is enabled for.
+- `project_id` - (Defaults to [provider](../index.mds#arguments-reference) `project_id`) The ID of the Project in which SNS is enabled.
 
 
 ## Attributes Reference
@@ -51,14 +51,14 @@ In addition to all arguments above, the following attributes are exported:
 
 - `id` - The ID of the credentials
 
-~> **Important:** Messaging and Queueing sns credentials' IDs are [regional](../guides/regions_and_zones.md#resource-ids), which means they are of the form `{region}/{id}`, e.g. `fr-par/11111111-1111-1111-1111-111111111111`
+~> **Important:** Messaging and Queueing SNS credential IDs are [regional](../guides/regions_and_zones.md#resource-ids), which means they are of the form `{region}/{id}`, e.g. `fr-par/11111111-1111-1111-1111-111111111111`
 
 - `access_key` - The ID of the key.
 - `secret_key` - The secret value of the key.
 
 ## Import
 
-SNS credentials can be imported using the `{region}/{id}`, e.g.
+SNS credentials can be imported using `{region}/{id}`, e.g.
 
 ```bash
 $ terraform import scaleway_mnq_sns_credentials.main fr-par/11111111111111111111111111111111

--- a/docs/resources/mnq_sns_topic.md
+++ b/docs/resources/mnq_sns_topic.md
@@ -50,10 +50,10 @@ The following arguments are supported:
 
 - `sns_endpoint` - (Optional) The endpoint of the SNS service. Can contain a {region} placeholder. Defaults to `https://sns.mnq.{region}.scaleway.com`.
 
-- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
+- `region` - (Defaults to [provider](../index.md#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
   in which SNS is enabled.
 
-- `project_id` - (Defaults to [provider](../index.mds#arguments-reference) `project_id`) The ID of the Project in which SNS is enabled.
+- `project_id` - (Defaults to [provider](../index.md#arguments-reference) `project_id`) The ID of the Project in which SNS is enabled.
 
 ## Attributes Reference
 

--- a/docs/resources/mnq_sns_topic.md
+++ b/docs/resources/mnq_sns_topic.md
@@ -5,9 +5,9 @@ page_title: "Scaleway: scaleway_mnq_sns_topic"
 
 # Resource: scaleway_mnq_sns_topic
 
-Manage Scaleway Messaging and queuing SNS Topics.
-For further information please check
-our [documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/sns-overview/)
+Manage Scaleway Messaging and queuing SNS topics.
+For further information, see
+our [main documentation](https://www.scaleway.com/en/docs/serverless/messaging/how-to/create-manage-topics/).
 
 ## Example Usage
 
@@ -36,7 +36,7 @@ resource "scaleway_mnq_sns_topic" "topic" {
 The following arguments are supported:
 
 
-- `name` - (Optional) The unique name of the sns topic. Either `name` or `name_prefix` is required. Conflicts with `name_prefix`.
+- `name` - (Optional) The unique name of the SNS topic. Either `name` or `name_prefix` is required. Conflicts with `name_prefix`.
 
 - `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 
@@ -46,14 +46,14 @@ The following arguments are supported:
 
 - `content_based_deduplication` - (Optional) Specifies whether to enable content-based deduplication.
 
-- `fifo_topic` - (Optional) Whether the topic is a FIFO. If true, the topic name must end with .fifo.
+- `fifo_topic` - (Optional) Whether the topic is a FIFO topic. If true, the topic name must end with .fifo.
 
 - `sns_endpoint` - (Optional) The endpoint of the SNS service. Can contain a {region} placeholder. Defaults to `https://sns.mnq.{region}.scaleway.com`.
 
-- `region` - (Defaults to [provider](../index.md#region) `region`). The [region](../guides/regions_and_zones.md#regions)
-  in which sns is enabled.
+- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
+  in which SNS is enabled.
 
-- `project_id` - (Defaults to [provider](../index.md#project_id) `project_id`) The ID of the project the sns is enabled for.
+- `project_id` - (Defaults to [provider](../index.mds#arguments-reference) `project_id`) The ID of the Project in which SNS is enabled.
 
 ## Attributes Reference
 
@@ -65,7 +65,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-SNS topic can be imported using the `{region}/{project-id}/{topic-name}`, e.g.
+SNS topics can be imported using `{region}/{project-id}/{topic-name}`, e.g.
 
 ```bash
 $ terraform import scaleway_mnq_sns_topic.main fr-par/11111111111111111111111111111111/my-topic

--- a/docs/resources/mnq_sns_topic_subscription.md
+++ b/docs/resources/mnq_sns_topic_subscription.md
@@ -5,9 +5,9 @@ page_title: "Scaleway: scaleway_mnq_sns_topic_subscription"
 
 # Resource: scaleway_mnq_sns_topic_subscription
 
-Manage Scaleway Messaging and queuing SNS Topic Subscriptions.
-For further information please check
-our [documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/sns-overview/)
+Manages Scaleway Messaging and Queuing SNS topic subscriptions.
+For further information, see
+our [main documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/sns-overview/).
 
 ## Example Usage
 
@@ -48,7 +48,7 @@ resource scaleway_mnq_sns_topic_subscription main {
 The following arguments are supported:
 
 
-- `protocol` - (Required) Protocol of the SNS Topic Subscription.
+- `protocol` - (Required) Protocol of the SNS topic subscription.
 
 - `topic_id` - (Optional) The ID of the topic. Either `topic_id` or `topic_arn` is required. Conflicts with `topic_arn`.
 
@@ -58,14 +58,14 @@ The following arguments are supported:
 
 - `secret_key` - (Optional) The secret key of the SNS credentials.
 
-- `redrive_policy` - (Optional) Activate JSON Redrive Policy.
+- `redrive_policy` - (Optional) Activate JSON redrive policy.
 
 - `sns_endpoint` - (Optional) The endpoint of the SNS service. Can contain a {region} placeholder. Defaults to `https://sns.mnq.{region}.scaleway.com`.
 
-- `region` - (Defaults to [provider](../index.md#region) `region`). The [region](../guides/regions_and_zones.md#regions)
-  in which sns is enabled.
+- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
+  in which SNS is enabled.
 
-- `project_id` - (Defaults to [provider](../index.md#project_id) `project_id`) The ID of the project the sns is enabled for.
+- `project_id` - (Defaults to [provider](../index.mds#arguments-reference) `project_id`) The ID of the Project in which SNS is enabled.
 
 ## Attributes Reference
 
@@ -77,7 +77,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-SNS topic subscriptions can be imported using the `{region}/{project-id}/{topic-name}/{subscription-id}`, e.g.
+SNS topic subscriptions can be imported using `{region}/{project-id}/{topic-name}/{subscription-id}`, e.g.
 
 ```bash
 $ terraform import scaleway_mnq_sns_topic_subscription.main fr-par/11111111111111111111111111111111/my-topic/11111111111111111111111111111111

--- a/docs/resources/mnq_sns_topic_subscription.md
+++ b/docs/resources/mnq_sns_topic_subscription.md
@@ -62,10 +62,10 @@ The following arguments are supported:
 
 - `sns_endpoint` - (Optional) The endpoint of the SNS service. Can contain a {region} placeholder. Defaults to `https://sns.mnq.{region}.scaleway.com`.
 
-- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
+- `region` - (Defaults to [provider](../index.md#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
   in which SNS is enabled.
 
-- `project_id` - (Defaults to [provider](../index.mds#arguments-reference) `project_id`) The ID of the Project in which SNS is enabled.
+- `project_id` - (Defaults to [provider](../index.md#arguments-reference) `project_id`) The ID of the Project in which SNS is enabled.
 
 ## Attributes Reference
 

--- a/docs/resources/mnq_sqs.md
+++ b/docs/resources/mnq_sqs.md
@@ -5,15 +5,15 @@ page_title: "Scaleway: scaleway_mnq_sqs"
 
 # Resource: scaleway_mnq_sqs
 
-Activate Scaleway Messaging and queuing SQS for a project.
-For further information please check
-our [documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/sqs-overview/)
+Activate Scaleway Messaging and Queuing SQS in a Project.
+For further information, see
+our [main documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/sqs-overview/).
 
 ## Example Usage
 
 ### Basic
 
-Activate SQS for default project
+Activate SQS in the default Project
 
 ```terraform
 resource "scaleway_mnq_sqs" "main" {}
@@ -36,21 +36,21 @@ resource "scaleway_mnq_sqs" "for_project" {
 The following arguments are supported:
 
 
-- `region` - (Defaults to [provider](../index.md#region) `region`). The [region](../guides/regions_and_zones.md#regions)
-  in which sqs will be enabled.
+- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
+  in which SQS will be enabled.
 
-- `project_id` - (Defaults to [provider](../index.md#project_id) `project_id`) The ID of the project the sqs will be enabled for.
+- `project_id` - (Defaults to [provider](../index.mds#arguments-reference) `project_id`) The ID of the Project in which SQS will be enabled.
 
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-- `id` - The ID of the project
+- `id` - The ID of the Project
 
-~> **Important:** Messaging and Queueing sqs' IDs are [regional](../guides/regions_and_zones.md#resource-ids), which means they are of the form `{region}/{id}`, e.g. `fr-par/11111111-1111-1111-1111-111111111111`
+~> **Important:** Messaging and Queueing SQS IDs are [regional](../guides/regions_and_zones.md#resource-ids), which means they are of the form `{region}/{id}`, e.g. `fr-par/11111111-1111-1111-1111-111111111111`
 
-- `endpoint` - The endpoint of the SQS service for this project.
+- `endpoint` - The endpoint of the SQS service for this Project.
 
 ## Import
 

--- a/docs/resources/mnq_sqs.md
+++ b/docs/resources/mnq_sqs.md
@@ -36,10 +36,10 @@ resource "scaleway_mnq_sqs" "for_project" {
 The following arguments are supported:
 
 
-- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
+- `region` - (Defaults to [provider](../index.md#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions)
   in which SQS will be enabled.
 
-- `project_id` - (Defaults to [provider](../index.mds#arguments-reference) `project_id`) The ID of the Project in which SQS will be enabled.
+- `project_id` - (Defaults to [provider](../index.md#arguments-reference) `project_id`) The ID of the Project in which SQS will be enabled.
 
 
 ## Attributes Reference

--- a/docs/resources/mnq_sqs_credentials.md
+++ b/docs/resources/mnq_sqs_credentials.md
@@ -40,9 +40,9 @@ The following arguments are supported:
     - `can_manage` - (Optional). Defines whether the user can manage the associated resource(s).
 
 
-- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions) in which SQS is enabled.
+- `region` - (Defaults to [provider](../index.md#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions) in which SQS is enabled.
 
-- `project_id` - (Defaults to [provider](../index.mds#arguments-reference) `project_id`) The ID of the Project in which SQS is enabled.
+- `project_id` - (Defaults to [provider](../index.md#arguments-reference) `project_id`) The ID of the Project in which SQS is enabled.
 
 
 ## Attributes Reference

--- a/docs/resources/mnq_sqs_credentials.md
+++ b/docs/resources/mnq_sqs_credentials.md
@@ -5,9 +5,9 @@ page_title: "Scaleway: scaleway_mnq_sqs_credentials"
 
 # Resource: scaleway_mnq_sqs_credentials
 
-Creates and manages Scaleway Messaging and queuing SQS Credentials.
-For further information please check
-our [documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/sqs-overview/)
+Creates and manages Scaleway Messaging and Queuing SQS credentials.
+For further information, see
+our [main documentation](https://www.scaleway.com/en/docs/serverless/messaging/reference-content/sqs-overview/)
 
 ## Example Usage
 
@@ -32,17 +32,17 @@ resource scaleway_mnq_sqs_credentials main {
 
 The following arguments are supported:
 
-- `name` - (Optional) The unique name of the sqs credentials.
+- `name` - (Optional) The unique name of the SQS credentials.
 
-- `permissions` - (Optional). List of permissions associated to these credentials. Only one of permissions may be set.
-    - `can_publish` - (Optional). Defines if user can publish messages to the service.
-    - `can_receive` - (Optional). Defines if user can receive messages from the service.
-    - `can_manage` - (Optional). Defines if user can manage the associated resource(s).
+- `permissions` - (Optional). List of permissions associated with these credentials. Only one of the following permissions may be set:
+    - `can_publish` - (Optional). Defines whether the user can publish messages to the service.
+    - `can_receive` - (Optional). Defines whether the user can receive messages from the service.
+    - `can_manage` - (Optional). Defines whether the user can manage the associated resource(s).
 
 
-- `region` - (Defaults to [provider](../index.md#region) `region`). The [region](../guides/regions_and_zones.md#regions) in which sqs is enabled.
+- `region` - (Defaults to [provider](../index.mds#arguments-reference) `region`). The [region](../guides/regions_and_zones.md#regions) in which SQS is enabled.
 
-- `project_id` - (Defaults to [provider](../index.md#project_id) `project_id`) The ID of the project the sqs is enabled for.
+- `project_id` - (Defaults to [provider](../index.mds#arguments-reference) `project_id`) The ID of the Project in which SQS is enabled.
 
 
 ## Attributes Reference
@@ -51,14 +51,14 @@ In addition to all arguments above, the following attributes are exported:
 
 - `id` - The ID of the credentials
 
-~> **Important:** Messaging and Queueing sqs credentials' IDs are [regional](../guides/regions_and_zones.md#resource-ids), which means they are of the form `{region}/{id}`, e.g. `fr-par/11111111-1111-1111-1111-111111111111`
+~> **Important:** Messaging and Queueing SQS credential IDs are [regional](../guides/regions_and_zones.md#resource-ids), which means they are of the form `{region}/{id}`, e.g. `fr-par/11111111-1111-1111-1111-111111111111`
 
 - `access_key` - The ID of the key.
 - `secret_key` - The secret value of the key.
 
 ## Import
 
-SQS credentials can be imported using the `{region}/{id}`, e.g.
+SQS credentials can be imported using `{region}/{id}`, e.g.
 
 ```bash
 $ terraform import scaleway_mnq_sqs_credentials.main fr-par/11111111111111111111111111111111

--- a/docs/resources/mnq_sqs_queue.md
+++ b/docs/resources/mnq_sqs_queue.md
@@ -5,9 +5,9 @@ page_title: "Scaleway: scaleway_mnq_sqs_queue"
 
 # Resource: scaleway_mnq_sqs_queue
 
-Creates and manages Scaleway Messaging and queuing SQS Queues.
-For further information please check
-our [documentation](https://www.scaleway.com/en/docs/serverless/messaging/how-to/create-manage-queues/)
+Creates and manages Scaleway Messaging and Queuing SQS queues.
+For further information, see
+our [main documentation](https://www.scaleway.com/en/docs/serverless/messaging/how-to/create-manage-queues/).
 
 ## Example Usage
 
@@ -40,7 +40,7 @@ resource scaleway_mnq_sqs_queue main {
 
 The following arguments are supported:
 
-- `name` - (Optional) The unique name of the sqs queue. Either `name` or `name_prefix` is required. Conflicts with `name_prefix`.
+- `name` - (Optional) The unique name of the SQS queue. Either `name` or `name_prefix` is required. Conflicts with `name_prefix`.
 
 - `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 
@@ -62,9 +62,9 @@ The following arguments are supported:
 
 - `message_max_size` - (Optional) The maximum size of a message. Should be in bytes. Must be between 1024 and 262_144. Defaults to 262_144.
 
-- `region` - (Defaults to [provider](../index.md#region) `region`). The [region](../guides/regions_and_zones.md#regions) in which sqs is enabled.
+- `region` - (Defaults to [provider](../index.md#region) `region`). The [region](../guides/regions_and_zones.md#regions) in which SQS is enabled.
 
-- `project_id` - (Defaults to [provider](../index.md#project_id) `project_id`) The ID of the project the sqs is enabled for.
+- `project_id` - (Defaults to [provider](../index.md#project_id) `project_id`) The ID of the Project in which SQS is enabled.
 
 
 ## Attributes Reference


### PR DESCRIPTION
This PR reviews the Messaging and Queuing Terraform doc, and suggests small corrections for grammar, capitalization and outdated links.